### PR TITLE
[Arrow] Fix rapidjson integration in arrow recipe

### DIFF
--- a/recipes/arrow/all/conandata.yml
+++ b/recipes/arrow/all/conandata.yml
@@ -15,6 +15,7 @@ patches:
   "22.0.0":
     - patch_file: "patches/22.0.0-0001-fix-downloaded-mimalloc.patch"
     - patch_file: "patches/22.0.0-0002-fix-msvc-arm64.patch"
+    - patch_file: "patches/22.0.0-0003-fix-rapidjson-use.patch"
   "21.0.0":
     - patch_file: "patches/21.0.0-0001-fix-downloaded-mimalloc.patch"
     - patch_file: "patches/21.0.0-0002-fix-msvc-arm64.patch"

--- a/recipes/arrow/all/patches/22.0.0-0003-fix-rapidjson-use.patch
+++ b/recipes/arrow/all/patches/22.0.0-0003-fix-rapidjson-use.patch
@@ -1,0 +1,15 @@
+--- cpp/cmake_modules/ThirdpartyToolchain.cmake
++++ cpp/cmake_modules/ThirdpartyToolchain.cmake
+@@ -2550,12 +2550,9 @@
+ endmacro()
+ 
+ if(ARROW_WITH_RAPIDJSON)
+-  set(ARROW_RAPIDJSON_REQUIRED_VERSION "1.1.0")
+   resolve_dependency(RapidJSON
+                      HAVE_ALT
+                      TRUE
+-                     REQUIRED_VERSION
+-                     ${ARROW_RAPIDJSON_REQUIRED_VERSION}
+                      IS_RUNTIME_DEPENDENCY
+                      FALSE)
+ endif()


### PR DESCRIPTION
### Summary
Changes to recipe:  **arrow/22.0.0**

#### Motivation
While building arrow I noticed the following error message:
```
CMake Warning at cmake_modules/FindRapidJSONAlt.cmake:29 (find_package):
  Could not find a configuration file for package "RapidJSON" that is
  compatible with requested version "1.1.0".

  The following configuration files were considered but not accepted:

    /home/oz/.conan2/p/b/arrow5bc1de719e47f/b/build/Release/generators/RapidJSONConfig.cmake, version: cci.20230929

Call Stack (most recent call first):
  cmake_modules/ThirdpartyToolchain.cmake:310 (find_package)
  cmake_modules/ThirdpartyToolchain.cmake:2554 (resolve_dependency)
  CMakeLists.txt:523 (include)

```
#### Details
Arrow internally uses hard-coded versions of its dependencies and the version of the rapidjson package is not compatible with this. This PR removes the hard-coded version for rapidjson.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
