### PR TITLE
[raylib] Fix shared library build for Android

### DIFF
--- a/recipes/raylib/all/conandata.yml
+++ b/recipes/raylib/all/conandata.yml
@@ -12,6 +12,8 @@ sources:
     url: "https://github.com/raysan5/raylib/archive/refs/tags/3.5.0.tar.gz"
     sha256: "761985876092fa98a99cbf1fef7ca80c3ee0365fb6a107ab901a272178ba69f5"
 patches:
+  "5.5":
+    - patch_file: "patches/5.5-0001-fix-android-shared.patch"
   "4.0.0":
     - patch_file: "patches/4.0.0-0001-enable-cmake-build-android.patch"
     - patch_file: "patches/4.0.0-0002-win32-glfw3native.patch"

--- a/recipes/raylib/all/patches/5.5-0001-fix-android-shared.patch
+++ b/recipes/raylib/all/patches/5.5-0001-fix-android-shared.patch
@@ -1,0 +1,21 @@
+https://github.com/raysan5/raylib/pull/4671
+
+diff --git a/cmake/LibraryConfigurations.cmake b/cmake/LibraryConfigurations.cmake
+index fb789830683a..00dda033a86a 100644
+--- a/cmake/LibraryConfigurations.cmake
++++ b/cmake/LibraryConfigurations.cmake
+@@ -69,6 +69,14 @@ elseif (${PLATFORM} MATCHES "Android")
+     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+     list(APPEND raylib_sources ${ANDROID_NDK}/sources/android/native_app_glue/android_native_app_glue.c)
+     include_directories(${ANDROID_NDK}/sources/android/native_app_glue)
++
++    # NOTE: We remove '-Wl,--no-undefined' (set by default) as it conflicts with '-Wl,-undefined,dynamic_lookup' needed
++    #       for compiling with the missing 'void main(void)' declaration in `android_main()`.
++    #       We also remove other unnecessary or problematic flags.
++
++    string(REPLACE "-Wl,--no-undefined -Qunused-arguments" "" CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}")
++    string(REPLACE "-static-libstdc++" "" CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}")
++
+     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--exclude-libs,libatomic.a -Wl,--build-id -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -Wl,--warn-shared-textrel -Wl,--fatal-warnings -u ANativeActivity_onCreate -Wl,-undefined,dynamic_lookup")
+
+     find_library(OPENGL_LIBRARY OpenGL)


### PR DESCRIPTION
### Summary
Changes to recipe:  **raylib/5.5**

#### Motivation

After talking about a new blog post involving Android and Raylib, and doing some cross-building from Linux to Android, the Raylib 5.5 fails during the linkage stage:

```
FAILED: [code=1] raylib/libraylib.so
: && /home/uilian/.conan2/p/andro2b0bf7da06ed1/p/bin/toolchains/llvm/prebuilt/linux-x86_64/bin/clang --target=aarch64-none-linux-android27 --sysroot=/home/uilian/.conan2/p/andro2b0bf7da06ed1/p/bin/toolchains/llvm/prebuilt/linux-x86_64/sysroot -fPIC -no-canonical-prefixes -Wa,--noexecstack -fstack-protector-strong -funwind-tables -ffunction-sections -fno-strict-aliasing -Werror=implicit-function-declaration -Werror=pointer-arith -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security  -O3 -DNDEBUG  -static-libstdc++ -Wl,--build-id=sha1 -Wl,--no-rosegment -Wl,--no-undefined-version -Wl,--fatal-warnings -Wl,--no-undefined -Qunused-arguments  -Wl,--exclude-libs,libatomic.a -Wl,--build-id -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -Wl,--warn-shared-textrel -Wl,--fatal-warnings -u ANativeActivity_onCreate -Wl,-undefined,dynamic_lookup -Wl,--gc-sections   -Xlinker --dependency-file=raylib/CMakeFiles/raylib.dir/link.d -shared -Wl,-soname,libraylib.so -o raylib/libraylib.so raylib/CMakeFiles/raylib.dir/raudio.c.o raylib/CMakeFiles/raylib.dir/rcore.c.o raylib/CMakeFiles/raylib.dir/rmodels.c.o raylib/CMakeFiles/raylib.dir/rshapes.c.o raylib/CMakeFiles/raylib.dir/rtext.c.o raylib/CMakeFiles/raylib.dir/rtextures.c.o raylib/CMakeFiles/raylib.dir/utils.c.o raylib/CMakeFiles/raylib.dir/home/uilian/.conan2/p/andro2b0bf7da06ed1/p/bin/sources/android/native_app_glue/android_native_app_glue.c.o  -lm  -llog  -landroid  -lEGL  -lGLESv2  -lOpenSLES  -latomic  -lc  -latomic -lm && :
ld.lld: error: undefined symbol: main
>>> referenced by rcore_android.c:279 (/home/uilian/.conan2/p/b/raylib7bf4b4d8560c/b/src/src/platforms/rcore_android.c:279)
>>>               raylib/CMakeFiles/raylib.dir/rcore.c.o:(android_main)
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Fortunately, this error was reported on the upstream by https://github.com/raysan5/raylib/issues/4484 and later fixed on https://github.com/raysan5/raylib/pull/4671.

But the latest Raylib version (5.5) is from 2024 and does not contain that fix. So this PR brings the merged PR as a backported fix patch. 

#### Details

The recipe from the master branch failed to build, and can be checked here: [raylib-5.5-android-amd64-clang-release-shared-original.log](https://github.com/user-attachments/files/23653442/raylib-5.5-android-amd64-clang-release-shared-original.log)

Then, once this new patch is applied, the error is gone: [raylib-5.5-android-amd64-clang-release-shared-patched.log](https://github.com/user-attachments/files/23653480/raylib-5.5-android-amd64-clang-release-shared-patched.log)

Building Raylib as a static library does not break using this new patch: [raylib-5.5-android-amd64-clang-release-static-patched.log](https://github.com/user-attachments/files/23653491/raylib-5.5-android-amd64-clang-release-static-patched.log)

I'm using the Conan package for Android NDK, not a system one. 

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
