### PR TITLE
Fix drogon CMake variables

### DIFF
--- a/recipes/drogon/all/conanfile.py
+++ b/recipes/drogon/all/conanfile.py
@@ -113,17 +113,16 @@ class DrogonConan(ConanFile):
         tc.variables["BUILD_EXAMPLES"] = False
         tc.variables["BUILD_ORM"] = self.options.with_orm
         tc.variables["COZ_PROFILING"] = self.options.with_profile
-        tc.variables["BUILD_DROGON_SHARED"] = self.options.shared
+        tc.variables["BUILD_SHARED_LIBS"] = self.options.shared
         tc.variables["BUILD_DOC"] = False
         tc.variables["BUILD_BROTLI"] = self.options.with_brotli
         tc.variables["BUILD_YAML_CONFIG"] = self.options.get_safe("with_yaml_cpp", False)
         tc.variables["BUILD_POSTGRESQL"] = self.options.get_safe("with_postgres", False)
-        tc.variables["BUILD_POSTGRESQL_BATCH"] = self.options.get_safe("with_postgres_batch", False)
+        tc.variables["LIBPQ_BATCH_MODE"] = self.options.get_safe("with_postgres_batch", False)
         tc.variables["BUILD_MYSQL"] = self.options.get_safe("with_mysql", False)
         tc.variables["BUILD_SQLITE"] = self.options.get_safe("with_sqlite", False)
         tc.variables["BUILD_REDIS"] = self.options.get_safe("with_redis", False)
         tc.cache_variables["CMAKE_TRY_COMPILE_CONFIGURATION"] = str(self.settings.build_type)
-        tc.cache_variables["BUILD_SHARED_LIBS"] = self.options.shared
         if is_msvc(self):
             tc.variables["CMAKE_CXX_FLAGS"] = "/Zc:__cplusplus /EHsc"
         tc.variables["USE_SUBMODULE"] = False


### PR DESCRIPTION
### Summary
Changes to recipe:  **drogon/***

#### Motivation
This is a bugfix for drogon build options, specifically postgres batch mode and a small rename for building as a shared library.

#### Details
This is a small fix to enable drogon to build without postgres batch support by fixing the cmake variable name the recipe sets and remove unused variable for drogon shared lib to instead use the one already set as `tc.cache_variables`


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan
