### PR TITLE
embree: Fix embree overlinking onetbb

### DIFF
--- a/recipes/embree/all/conanfile.py
+++ b/recipes/embree/all/conanfile.py
@@ -124,3 +124,4 @@ class EmbreeConan(ConanFile):
 
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.extend(["dl", "m", "pthread"])
+        self.cpp_info.requires = ["onetbb::libtbb"]


### PR DESCRIPTION
### Summary
Changes to recipe:  **embree/[>=4.3.3]**

#### Motivation
embree only links libtbb, not tbbmalloc or tbbmalloc_proxy. The package info causes overlinking of onetbb downstream because it uses the onetbb::onetbb target, which causes all three libs to be linked. This results in fatal crashes.  

#### Details
This PR specifies strict linking of the libtbb target in the package requires.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
