### PR TITLE
[libpng] Add support for libpng version 1.6.51.

### DIFF
--- a/recipes/libpng/all/conandata.yml
+++ b/recipes/libpng/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.6.51":
+    url: "https://sourceforge.net/projects/libpng/files/libpng16/1.6.51/libpng-1.6.51.tar.xz"
+    sha256: "a050a892d3b4a7bb010c3a95c7301e49656d72a64f1fc709a90b8aded192bed2"
   "1.6.50":
     url: "https://sourceforge.net/projects/libpng/files/libpng16/1.6.50/libpng-1.6.50.tar.xz"
     sha256: "4df396518620a7aa3651443e87d1b2862e4e88cad135a8b93423e01706232307"

--- a/recipes/libpng/config.yml
+++ b/recipes/libpng/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.6.51":
+    folder: all
   "1.6.50":
     folder: all
   "1.6.48":


### PR DESCRIPTION
libpng has a new version, 1.6.51 and according to the project's website
 fixes the following vulnerabilities:
 - CVE-2025-64505 (moderate severity): Heap buffer overflow in png_do_quantize() via malformed palette index
 - CVE-2025-64506 (moderate severity): Heap buffer over-read in png_write_image_8bit() with 8-bit input and convert_to_8bit enabled
 - CVE-2025-64720 (high severity): Buffer overflow in png_image_read_composite() via incorrect palette premultiplication 
 - CVE-2025-65018 (high severity): Heap buffer overflow in png_combine_row() triggered via png_image_finish_read() 
 
 see https://libpng.org/pub/png/ligpng.html for details.


### Summary
Changes to recipe:  **libpng/1.6.51**

#### Motivation
 - CVE-2025-64505 (moderate severity): Heap buffer overflow in png_do_quantize() via malformed palette index
 - CVE-2025-64506 (moderate severity): Heap buffer over-read in png_write_image_8bit() with 8-bit input and convert_to_8bit enabled
 - CVE-2025-64720 (high severity): Buffer overflow in png_image_read_composite() via incorrect palette premultiplication 
 - CVE-2025-65018 (high severity): Heap buffer overflow in png_combine_row() triggered via png_image_finish_read() 
  
#### Details

Add the new version to yaml files - tested on MacOS ARM Sequoia / Xcode 16.4 w/ Conan version 2.22.2

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
