### PR TITLE
ffmpeg: Add 8.0.1 and 7.1.3

### DIFF
--- a/recipes/ffmpeg/all/conandata.yml
+++ b/recipes/ffmpeg/all/conandata.yml
@@ -1,10 +1,10 @@
 sources:
-  "8.0":
-    url: "https://ffmpeg.org/releases/ffmpeg-8.0.tar.xz"
-    sha256: "b2751fccb6cc4c77708113cd78b561059b6fa904b24162fa0be2d60273d27b8e"
-  "7.1.2":
-    url: "https://ffmpeg.org//releases/ffmpeg-7.1.2.tar.bz2"
-    sha256: "5eb62f529114778333b7eb0381cb16e2b8725ce2ae081d07b1082effe22b12e9"
+  "8.0.1":
+    url: "https://ffmpeg.org/releases/ffmpeg-8.0.1.tar.xz"
+    sha256: "05ee0b03119b45c0bdb4df654b96802e909e0a752f72e4fe3794f487229e5a41"
+  "7.1.3":
+    url: "https://ffmpeg.org//releases/ffmpeg-7.1.3.tar.bz2"
+    sha256: "e7df715136a1231598dadb70fe6abd5cd66abc1ac2f470a02c567b2600c5292b"
   "4.4.6":
     url: "https://ffmpeg.org/releases/ffmpeg-4.4.6.tar.bz2"
     sha256: "822c980717470a2a576e5adba4e8a40977d15c3312b89dcd121547262b730d11"

--- a/recipes/ffmpeg/config.yml
+++ b/recipes/ffmpeg/config.yml
@@ -1,7 +1,7 @@
 versions:
-  "8.0":
+  "8.0.1":
     folder: "all"
-  "7.1.2":
+  "7.1.3":
     folder: "all"
   "4.4.6":
     folder: "all"


### PR DESCRIPTION
### Summary
Changes to recipe:  **ffmpeg/8.0.1** & **ffmpeg/7.1.3**

#### Motivation
Many small bugfixes in both versions.

#### Details
* Changelog for 8.0.1: https://git.ffmpeg.org/gitweb/ffmpeg.git/blob_plain/894da5ca7d742e4429ffb2af534fcda0103ef593:/Changelog
  Diff of the configure script only contains a small changes that I don't see needing to change the recipe:
```
diff --git configure configure
index 732de59292..a0eed36abf 100755
--- configure
+++ configure
@@ -7049,12 +7049,16 @@ enabled libfontconfig     && require_pkg_config libfontconfig fontconfig "fontco
 enabled libfreetype       && require_pkg_config libfreetype freetype2 "ft2build.h FT_FREETYPE_H" FT_Init_FreeType
 enabled libfribidi        && require_pkg_config libfribidi fribidi fribidi.h fribidi_version_info
 enabled libharfbuzz       && require_pkg_config libharfbuzz harfbuzz hb.h hb_buffer_create
-enabled libglslang && { check_lib spirv_compiler glslang/Include/glslang_c_interface.h glslang_initialize_process \
+if enabled libglslang; then
+    spvremap="-lSPVRemapper"
+    require_headers "glslang/build_info.h" && { test_cpp_condition glslang/build_info.h "GLSLANG_VERSION_MAJOR >= 16" && spvremap="" ; }
+    check_lib spirv_compiler glslang/Include/glslang_c_interface.h glslang_initialize_process \
                             -lglslang -lMachineIndependent -lGenericCodeGen \
-                            -lSPVRemapper -lSPIRV -lSPIRV-Tools-opt -lSPIRV-Tools -lpthread -lstdc++ -lm ||
+                            ${spvremap} -lSPIRV -lSPIRV-Tools-opt -lSPIRV-Tools -lpthread -lstdc++ -lm ||
                         require spirv_compiler glslang/Include/glslang_c_interface.h glslang_initialize_process \
                             -lglslang -lMachineIndependent -lOSDependent -lHLSL -lOGLCompiler -lGenericCodeGen \
-                            -lSPVRemapper -lSPIRV -lSPIRV-Tools-opt -lSPIRV-Tools -lpthread -lstdc++ -lm ; }
+                            ${spvremap} -lSPIRV -lSPIRV-Tools-opt -lSPIRV-Tools -lpthread -lstdc++ -lm ;
+fi
 enabled libgme            && { check_pkg_config libgme libgme gme/gme.h gme_new_emu ||
                                require libgme gme/gme.h gme_new_emu -lgme -lstdc++; }
 enabled libgsm            && { for gsm_hdr in "gsm.h" "gsm/gsm.h"; do
@@ -7754,7 +7758,7 @@ if enabled icc; then
     fi
 elif enabled gcc; then
     gcc_version=$($cc -dumpversion)
-    major_version=${gcc_version%%.*}
+    major_version=${gcc_version%%[!0-9]*}
     if [ $major_version -lt 13 ]; then
         # Disable tree-vectorize for GCC <13 - it has historically been buggy.
         check_optflags -fno-tree-vectorize
```

* Changelog for 7.1.3: https://git.ffmpeg.org/gitweb/ffmpeg.git/blob_plain/f46e514491172d15bd74b4abb1814cd2f05a763e:/Changelog
  No line of the configure script is changed. 

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!