### PR TITLE
imgui: Add 1.92.5, stop publishing 1.89.9

### DIFF
--- a/recipes/imgui/all/conandata.yml
+++ b/recipes/imgui/all/conandata.yml
@@ -1,20 +1,20 @@
 # this package's recipe relies on version suffixes to handle imgui's docking branch.
 # Suffix: -docking for docking branch sources
 sources:
-  "1.92.4":
+  "1.92.5":
     core:
-      url: "https://github.com/ocornut/imgui/archive/v1.92.4.tar.gz"
-      sha256: "0e175d4d941112532549b418ced0bd546abe9024ecb9b5f431f8a67a2197b0ba"
+      url: "https://github.com/ocornut/imgui/archive/v1.92.5.tar.gz"
+      sha256: "0eb50fe9aeba1a51f96b5843c7f630a32ed2e9362d693c61b87e4fa870cf826d"
     testengine:
-      url: "https://github.com/ocornut/imgui_test_engine/archive/v1.92.4.tar.gz"
-      sha256: "3102103924596cb5950b18aa6e18609110a85414543989483f564174718a3b03"
-  "1.92.4-docking":
+      url: "https://github.com/ocornut/imgui_test_engine/archive/v1.92.5.tar.gz"
+      sha256: "c8da0872c663b9a39939d32d3d4a87e45bb947dd4a8e31fa58d8c0989ef1af99"
+  "1.92.5-docking":
     core:
-      url: "https://github.com/ocornut/imgui/archive/v1.92.4-docking.tar.gz"
-      sha256: "c5e2053afc707c70385431ed85c500b108b521784a3f6a7a31ea17583aab89a2"
+      url: "https://github.com/ocornut/imgui/archive/v1.92.5-docking.tar.gz"
+      sha256: "c816c20e8c75f3e15ae867350e79925502d1a6a85938bb1a73b8927e5f31f9cb"
     testengine:
-      url: "https://github.com/ocornut/imgui_test_engine/archive/v1.92.4.tar.gz"
-      sha256: "3102103924596cb5950b18aa6e18609110a85414543989483f564174718a3b03"
+      url: "https://github.com/ocornut/imgui_test_engine/archive/v1.92.5.tar.gz"
+      sha256: "c8da0872c663b9a39939d32d3d4a87e45bb947dd4a8e31fa58d8c0989ef1af99"
   "1.92.2b":
     core:
       url: "https://github.com/ocornut/imgui/archive/v1.92.2b.tar.gz"
@@ -65,20 +65,6 @@ sources:
     testengine:
       url: "https://github.com/ocornut/imgui_test_engine/archive/v1.90.5.tar.gz"
       sha256: "79339246d8c919c5926df0a7bee99be585ebaf67cdaba89a0ac314b1f7846f92"
-  "1.89.9":
-    core:
-      url: "https://github.com/ocornut/imgui/archive/v1.89.9.tar.gz"
-      sha256: "1acc27a778b71d859878121a3f7b287cd81c29d720893d2b2bf74455bf9d52d6"
-    testengine:
-      url: "https://github.com/ocornut/imgui_test_engine/archive/v1.89.9.tar.gz"
-      sha256: "951f2a45d7e637983265dead44a6e78a0b0dc79d4e9cf44f3f7a48d0aa2053b5"
-  "1.89.9-docking":
-    core:
-      url: "https://github.com/ocornut/imgui/archive/v1.89.9-docking.tar.gz"
-      sha256: "2481489ce9091239b3cab8a330d0409ffdd9ee607ad1f3fe3a0b0b751c27a8eb"
-    testengine:
-      url: "https://github.com/ocornut/imgui_test_engine/archive/v1.89.9.tar.gz"
-      sha256: "951f2a45d7e637983265dead44a6e78a0b0dc79d4e9cf44f3f7a48d0aa2053b5"
   "1.88":
     core:
       url: "https://github.com/ocornut/imgui/archive/v1.88.tar.gz"

--- a/recipes/imgui/config.yml
+++ b/recipes/imgui/config.yml
@@ -1,7 +1,7 @@
 versions:
-  "1.92.4":
+  "1.92.5":
     folder: all
-  "1.92.4-docking":
+  "1.92.5-docking":
     folder: all
   "1.92.2b":
     folder: all
@@ -18,10 +18,6 @@ versions:
   "1.90.5":
     folder: all
   "1.90.5-docking":
-    folder: all
-  "1.89.9":
-    folder: all
-  "1.89.9-docking":
     folder: all
   "1.88":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **imgui/1.92.5**

#### Motivation
Usual upstream iteration.

Stop publishing an old version. (Only removed the one not used by other recipes, all others are used in some other recipe or for 1.90.9, I thought it is best to leave the newest from the 1.90 track in as 1.90.5 is used and leaving that but the latest from 1.90 would feel bad.)

#### Details
* https://github.com/ocornut/imgui/releases/tag/v1.92.5
* https://github.com/ocornut/imgui/compare/v1.92.4...v1.92.5
  Large diff but mainly changes to the examples & introduction of wgpu examples & improvements. Build wise I didn't see anything for the library and bindings.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
