### PR TITLE
gtsam: looking for metis when disabled

### DIFF
--- a/recipes/gtsam/all/conanfile.py
+++ b/recipes/gtsam/all/conanfile.py
@@ -271,7 +271,10 @@ class GtsamConan(ConanFile):
         tc.generate()
 
         deps = CMakeDeps(self)
-        deps.set_property("metis", "cmake_target_name", "metis-gtsam-if")
+
+        if self.options.support_nested_dissection:
+            deps.set_property("metis", "cmake_target_name", "metis-gtsam-if")
+
         deps.generate()
 
     def _patch_sources(self):
@@ -302,9 +305,10 @@ class GtsamConan(ConanFile):
                             'GTSAM_ADDITIONAL_LIBRARIES "tcmalloc"',
                             'GTSAM_ADDITIONAL_LIBRARIES "gperftools::gperftools"')
 
-        # Fix HandleMetis.cmake incompatibility with METIS from Conan
-        save(self, os.path.join(self.source_folder, "cmake", "HandleMetis.cmake"),
-             "find_package(metis REQUIRED CONFIG)\n")
+        if self.options.support_nested_dissection:
+            # Fix HandleMetis.cmake incompatibility with METIS from Conan
+            save(self, os.path.join(self.source_folder, "cmake", "HandleMetis.cmake"),
+                 "find_package(metis REQUIRED CONFIG)\n")
 
         # Fix TBB handling
         handle_tbb_path = os.path.join(self.source_folder, "cmake", "HandleTBB.cmake")


### PR DESCRIPTION
### Summary
Changes to recipe:  **gtsam/***

#### Motivation
With support_nested_dissection=False, the metis requirement is disabled but HandleMetis.cmake (that is responsible to early exit when the GTSAM_SUPPORT_NESTED_DISSECTION flag is disabled) is entierely replaced with a find_package of metis.

#### Details
Only override the HandleMetis.cmake file when the nested dissection is enabled and let the original source code ignore the dependency when disabled


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
