### PR TITLE
[icu] Resolve issue #28972 by making the filename suffix 'b' on big-endan targets.

### DIFF
--- a/recipes/icu/all/conanfile.py
+++ b/recipes/icu/all/conanfile.py
@@ -228,7 +228,10 @@ class ICUConan(ConanFile):
     def _data_filename(self):
         vtag = Version(self.version).major
         arch = self.settings.get_safe("arch")
-        suffix = "b" if arch in {"ppc", "ppc64", "sparc", "sparc64", "mips"} else "l"
+        suffix = "b" if arch in {"ppc32", "ppc64",
+                                 "sparc", "sparcv9",
+                                 "s390", "s390x",
+                                 "mips", "mips64"} else "l"
         return f"icudt{vtag}{suffix}.dat"
 
     @property


### PR DESCRIPTION

### Summary
Changes to recipe:  **icu/[>=75.1]**

The ICU Autotools build generates a datafile that has a different filename on big-endian systems, but the icu recipe had this hard-coded to the little-endian name, which caused failures during packaging on all big-endian targets.
Resolve by checking the target arch for some of the common big endian architectures, and using "b" for big "l" for little to match ICU's filename.

#### Motivation
Resolve issue #28972 by making the icu datafile dependent on the system architecture

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
