### PR TITLE
xkeyboard-config: fix test package self.conf.get

### DIFF
--- a/recipes/xkeyboard-config/all/test_package/conanfile.py
+++ b/recipes/xkeyboard-config/all/test_package/conanfile.py
@@ -19,5 +19,5 @@ class TestPackageConan(ConanFile):
         pkg_config_deps.generate()
 
     def test(self):
-        pkg_config = self.conf_info.get("tools.gnu:pkg_config", default="pkg-config")
+        pkg_config = self.conf.get("tools.gnu:pkg_config", default="pkg-config")
         self.run(f"{pkg_config} --validate xkeyboard-config")


### PR DESCRIPTION
There was a bug and the value of `tools.gnu:pkg_config` was not being correctly retrieved.


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
