### PR TITLE
libjuice: added 1.7.0 version

### DIFF
--- a/recipes/libjuice/all/conandata.yml
+++ b/recipes/libjuice/all/conandata.yml
@@ -5,3 +5,6 @@ sources:
   "1.6.2":
     url: "https://github.com/paullouisageneau/libjuice/archive/refs/tags/v1.6.2.tar.gz"
     sha256: "5078176d55042f3ccf3999c2556d84903f7edf80177ce4a7bf59507541e93938"
+  "1.7.0":
+    url: "https://github.com/paullouisageneau/libjuice/archive/refs/tags/v1.7.0.tar.gz"
+    sha256: "a510c7df90d82731d1d5e32e32205d3370ec2e62d6230ffe7b19b0f3c1acabf2"

--- a/recipes/libjuice/config.yml
+++ b/recipes/libjuice/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: all
   "1.6.2":
     folder: all
+  "1.7.0":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **libjuice/1.7.0**

#### Motivation
Update the libjuice package to the latest version

#### Details
To avoid duplicating this version in both our local Conan repository and Conan Center, we prefer to update it here so it’s available to everyone. Also, this new release includes several bug fixes that may resolve some of the issues we’ve been experiencing when using this library with [libdatachannel](https://github.com/paullouisageneau/libdatachannel).


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

