### PR TITLE
drogon: fix building with brotli

### DIFF
--- a/recipes/drogon/all/conanfile.py
+++ b/recipes/drogon/all/conanfile.py
@@ -131,6 +131,9 @@ class DrogonConan(ConanFile):
         if self.options.get_safe("with_mysql"):
             deps.set_property("mariadb-connector-c", "cmake_file_name", "MySQL")
             deps.set_property("mariadb-connector-c", "cmake_target_name", "MySQL_lib")
+        if self.options.get_safe("with_brotli"):
+            deps.set_property("brotli", "cmake_file_name", "Brotli")
+            deps.set_property("brotli", "cmake_target_name", "Brotli_lib")
         deps.generate()
 
     def build(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **drogon/***

#### Motivation
This PR is fixing the `with_brotli` option, which has previously not used the conan target.

```
FAILED: CMakeFiles/drogon.dir/lib/src/HttpRequestImpl.cc.o.ddi 
/usr/bin/g++ -DCARES_STATICLIB -DUSE_BROTLI -DUSE_OSSP_UUID=0 -I/root/.conan2/p/b/drogode5ee988acaab/b/src/lib/inc -I/root/.conan2/p/b/drogode5ee988acaab/b/build/RelWithDebInfo/lib/inc -I/root/.conan2/p/b/drogode5ee988acaab/b/src/orm_lib/inc -I/root/.conan2/p/b/drogode5ee988acaab/b/src/nosql_lib/redis/inc -I/root/.conan2/p/b/drogode5ee988acaab/b/build/RelWithDebInfo -I/root/.conan2/p/b/drogode5ee988acaab/b/build/RelWithDebInfo/exports -isystem /root/.conan2/p/b/trantac56c34864e0d/p/include -isystem /root/.conan2/p/b/opens5f5e10f3f7ec1/p/include -isystem /root/.conan2/p/b/zlib94819a1992926/p/include -isystem /root/.conan2/p/b/jsoncad961d899f2f2/p/include -isystem /root/.conan2/p/b/util-60dc284d553e4/p/include/uuid -isystem /root/.conan2/p/b/libpq67bb58644c558/p/include -m64 -O2 -g -DNDEBUG -std=c++23 -fPIC -E -x c++ /root/.conan2/p/b/drogode5ee988acaab/b/src/lib/src/HttpRequestImpl.cc -MT CMakeFiles/drogon.dir/lib/src/HttpRequestImpl.cc.o.ddi -MD -MF CMakeFiles/drogon.dir/lib/src/HttpRequestImpl.cc.o.ddi.d -fmodules-ts -fdeps-file=CMakeFiles/drogon.dir/lib/src/HttpRequestImpl.cc.o.ddi -fdeps-target=CMakeFiles/drogon.dir/lib/src/HttpRequestImpl.cc.o -fdeps-format=p1689r5 -o CMakeFiles/drogon.dir/lib/src/HttpRequestImpl.cc.o.ddi.i
/root/.conan2/p/b/drogode5ee988acaab/b/src/lib/src/HttpRequestImpl.cc:28:10: fatal error: brotli/decode.h: No such file or directory
   28 | #include <brotli/decode.h>
      |          ^~~~~~~~~~~~~~~~~
compilation terminated.
[23/154] Scanning /root/.conan2/p/b/drogode5ee988acaab/b/src/lib/src/HttpRequestParser.cc for CXX dependencies
ninja: build stopped: subcommand failed.
drogon/1.9.11: ERROR: 
Package '220834240896925ef5af1054aefdc4be597124f1' build failed
drogon/1.9.11: WARN: Build folder /root/.conan2/p/b/drogode5ee988acaab/b/build/RelWithDebInfo
ERROR: drogon/1.9.11: Error in build() method, line 140
	cmake.build()
	ConanException: Error 1 while executing
CMake Error at cmake/conan/conan_provider.cmake:489 (message):
  Conan install failed='1'
Call Stack (most recent call first):
```

#### Details
Patch drogon's CMakeLists.txt in accordance to previous patches to use conan package and target.

[drogon_with_patch.log](https://github.com/user-attachments/files/23756645/drogon_with_patch.log)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
