### PR TITLE
winflexbison: Fix clang-cl compatibility with __extension__ keyword

### DIFF
--- a/recipes/winflexbison/all/conandata.yml
+++ b/recipes/winflexbison/all/conandata.yml
@@ -11,6 +11,9 @@ sources:
 patches:
   "2.5.25":
     - patch_file: "patches/0001-2.5.25-mingw-support.patch"
+    - patch_file: "patches/0002-fix-clang-cl-compatibility.patch"
+      patch_description: "Fix clang-cl compatibility with __extension__ keyword"
+      patch_type: "portability"
   "2.5.24":
     - patch_file: "patches/0001-2.5.24-mingw-support.patch"
   "2.5.22":

--- a/recipes/winflexbison/all/patches/0002-fix-clang-cl-compatibility.patch
+++ b/recipes/winflexbison/all/patches/0002-fix-clang-cl-compatibility.patch
@@ -1,0 +1,27 @@
+From d43fca14d3dc69e3b6cf19dc359389786b6b15f6 Mon Sep 17 00:00:00 2001
+From: johan-bytecat <johan@bytecat.co.za>
+Date: Wed, 26 Nov 2025 10:05:04 +0200
+Subject: [PATCH] Fix clang-cl compatibility
+
+---
+ CMakeLists.txt | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index cf657a6..1fca4da 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -37,7 +37,9 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+     #   applies to WIN32/MSVC.
+     #------------------------------------------------------------------------
+     if (MSVC)
+-        add_compile_definitions("__extension__")
++	if (NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
++        	add_compile_definitions("__extension__")
++	endif ()
+         add_compile_options("/source-charset:utf-8")
+         option( USE_STATIC_RUNTIME "Set ON to change /MD(DLL) to /MT(static)" OFF )
+         if (USE_STATIC_RUNTIME)
+-- 
+2.30.0.windows.1
+


### PR DESCRIPTION
### Summary
Changes to recipe:  **winflexbison/2.5.25**

#### Motivation
The CMakeLists.txt unconditionally defines `__extension__` as empty when `MSVC` is true, but clang-cl needs the `__extension__` keyword to enable GNU extensions in system headers like `<mmintrin.h>`. clang-cl defines MSVC to true for compatibility reasons.

Bug Issue #28989 

#### Details
Change the CMakeLists.txt to NOT define __extension__ when the compiler is clang.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
