### PR TITLE
xz_utils: fix Android build from Windows

### DIFF
--- a/recipes/xz_utils/all/conanfile.py
+++ b/recipes/xz_utils/all/conanfile.py
@@ -58,14 +58,10 @@ class XZUtilsConan(ConanFile):
                            and self.settings.compiler == "clang"
                            and self.settings.get_safe("compiler.runtime") is not None)
         return (is_msvc(self) or assume_clang_cl) and Version(self.version) < "5.8.1"
-    
-    @property
-    def _building_android_from_windows(self):
-        return self.settings.os == "Android" and self._settings_build.os == "Windows"
 
     @property
     def _use_cmake(self):
-        return (self.settings.os == "Windows" or self._building_android_from_windows) and Version(self.version) >= "5.8.1"
+        return self.settings.os == "Windows" and Version(self.version) >= "5.8.1"
 
     def export_sources(self):
         export_conandata_patches(self)
@@ -84,7 +80,7 @@ class XZUtilsConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def build_requirements(self):
-        if self._settings_build.os == "Windows" and not self._use_msbuild and not self._use_cmake:
+        if self._settings_build.os == "Windows" and not self._use_msbuild and (Version(self.version) < "5.8.1" or self.settings.os == "Android"):
             self.win_bash = True
             if not self.conf.get("tools.microsoft.bash:path", check_type=str):
                 self.tool_requires("msys2/cci.latest")


### PR DESCRIPTION
### Summary
Changes to recipe:  **xz_utils/5.8.1**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
This is a fix for cross building from Windows to Android. At the moment, I encountered two issues. One issue was that `msys2` was not used when building for Android with Autotools with `xz_utils` version 5.8.1. But even after fixing that, the Autotools failed while building. I fixed it by using CMake when building for Android on Windows since I don't have much experience with Autotools.

This PR fixes cross-compilation from Windows to Android. I encountered two issues during the process. The first was that MSYS2 wasn’t being used when building for Android with Autotools (xz_utils 5.8.1). After resolving that, the Autotools build still failed. Since I don’t have much experience with Autotools, I switched to using CMake for the Windows-to-Android build, which resolved the remaining issues.

#### Details
Initially, I had to update the following condition:

```python
if self._settings_build.os == "Windows" and not self._use_msbuild and Version(self.version) < "5.8.1":
```

to:

```python
if self._settings_build.os == "Windows" and not self._use_msbuild and not self._use_cmake:
```

Without this change, the build wouldn’t use `msys2` at all and failed with the following error:

[configure_error.txt](https://github.com/user-attachments/files/23788197/configure_error.txt)

However, even after resolving that, the Autotools build still failed because it attempted to include `windows.h` while targeting Android. Relevant logs:

[autotools_android_error.txt](https://github.com/user-attachments/files/23788203/autotools_android_error.txt)

Switching to CMake for Windows-to-Android builds resolves the issue, and the build completes successfully:

[cmake_android_build.txt](https://github.com/user-attachments/files/23788205/cmake_android_build.txt)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
