### PR TITLE
onnx/1.1.80: Add missing patch

### DIFF
--- a/recipes/onnx/all/test_v1_package/CMakeLists.txt
+++ b/recipes/onnx/all/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package)

--- a/recipes/onnx/all/test_v1_package/conanfile.py
+++ b/recipes/onnx/all/test_v1_package/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)


### PR DESCRIPTION
In https://github.com/conan-io/conan-center-index/pull/27666 a new version was added but the corresponding patch was not ported from old versions.

Without this, compiling locally I get: (With a replace_requires to protobuf for 5.x)

<img width="835" height="410" alt="image" src="https://github.com/user-attachments/assets/d2cab36e-4366-4201-acfb-4616f6af0279" />

This PR was done as part of our effort to bring libtorch to CCI
---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
