### PR TITLE
matio: require hdf5 in range [>=1.14.3 <2] instead of fixed 1.14.3 version

### DIFF
--- a/recipes/matio/all/conanfile.py
+++ b/recipes/matio/all/conanfile.py
@@ -54,7 +54,7 @@ class MatioConan(ConanFile):
 
     def requirements(self):
         if self.options.with_hdf5:
-            self.requires("hdf5/1.14.3")
+            self.requires("hdf5/[>=1.14.3 <2]")
         if self.options.with_zlib:
             self.requires("zlib/[>=1.2.11 <2]")
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **matio**

#### Motivation
Using a backwards-compatible hdf5 range allows for more elastic usage and potentially using improved hdf5 versions with bugfixes, etc.

#### Details
hdf5 version used is now a backwards compatible range.

fixes #28988
---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
