### PR TITLE
grpc: Set grpc_MSVC_STATIC_RUNTIME when needed

### DIFF
--- a/recipes/grpc/all/conanfile.py
+++ b/recipes/grpc/all/conanfile.py
@@ -60,6 +60,10 @@ class GrpcConan(ConanFile):
     _target_info = None
 
     @property
+    def _is_clang_cl(self):
+        return self.settings.compiler == "clang" and self.settings.os == "Windows"
+
+    @property
     def _grpc_plugin_template(self):
         return "grpc_plugin_template.cmake.in"
 
@@ -213,6 +217,11 @@ class GrpcConan(ConanFile):
         if is_apple_os(self):
             # workaround for: install TARGETS given no BUNDLE DESTINATION for MACOSX_BUNDLE executable
             tc.cache_variables["CMAKE_MACOSX_BUNDLE"] = False
+
+        if is_msvc(self) or self._is_clang_cl:
+            runtime = self.settings.get_safe("compiler.runtime")
+            if runtime:
+                tc.cache_variables["grpc_MSVC_STATIC_RUNTIME"] = runtime == "static"
 
         if self._supports_libsystemd:
             tc.cache_variables["gRPC_USE_SYSTEMD"] = self.options.with_libsystemd


### PR DESCRIPTION
### Summary
Changes to recipe:  **lib/[version]**

The options exists in grps and needs to be set properly: https://github.com/grpc/grpc/blob/master/cmake/msvc_static_runtime.cmake

In protobuf we do the similar thing: https://github.com/conan-io/conan-center-index/blob/master/recipes/protobuf/all/conanfile.py#L158

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
