### PR TITLE
[opentelemetry-cpp] Remove OpenSSL as a direct dependency

### DIFF
--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -95,7 +95,6 @@ class OpenTelemetryCppConan(ConanFile):
            self.options.get_safe("with_otlp_file")
         ):
             self.requires("nlohmann_json/3.11.3")
-            self.requires("openssl/[>=1.1 <4]")
 
         if (self.options.with_zipkin or
            self.options.with_elasticsearch or
@@ -359,7 +358,6 @@ class OpenTelemetryCppConan(ConanFile):
             self.options.with_elasticsearch
         ):
             self.cpp_info.components[self._http_client_name].requires.append("libcurl::libcurl")
-            self.cpp_info.components[self._http_client_name].requires.append("openssl::openssl")
 
         if self.options.with_otlp_http:
             self.cpp_info.components["opentelemetry_exporter_otlp_http_client"].requires.extend([


### PR DESCRIPTION
### Summary
Changes to recipe:  **opentelemetry-cpp/1.22.0**

#### Motivation

closes #28953

/cc @MatevzFa

#### Details

As reported on the issue #26878, OpenTelemetry-CPP does not list OpenSSL as a direct dependency:

- https://github.com/open-telemetry/opentelemetry-cpp/blob/v1.22.0/docs/dependencies.md
- https://github.com/open-telemetry/opentelemetry-cpp/blob/v1.22.0/MODULE.bazel
- https://github.com/open-telemetry/opentelemetry-cpp/blob/v1.22.0/third_party_release
- https://github.com/open-telemetry/opentelemetry-cpp/blob/v1.22.0/tools/setup-buildtools.cmd
- https://github.com/open-telemetry/opentelemetry-cpp/blob/v1.22.0/docs/building-with-vs2019.md?plain=1#L61
- https://github.com/open-telemetry/opentelemetry-cpp/blob/v1.22.0/install/conan/conanfile_latest.txt

The OpenSSL is listed as a dependency since its first commit on CCI: #7799

It's true OpenTelemetry-CPP can be used with SSL, but then it's a requirement for Curl: https://github.com/open-telemetry/opentelemetry-cpp/blob/v1.22.0/docs/testing-with-ssl.md?plain=1

I'm able to build on Windows without OpenSSL as a dependency, and using `curl:with_ssl=schannel`: 
[opentelemetry-1.22.0-windows-no-openssl.log](https://github.com/user-attachments/files/23819062/opentelemetry-1.22.0-windows-no-openssl.log)


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
