### PR TITLE
Add FreeGLUT 3.8.0, no recipe modification

### DIFF
--- a/recipes/freeglut/all/conandata.yml
+++ b/recipes/freeglut/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.8.0":
+    url: "https://github.com/FreeGLUTProject/freeglut/archive/v3.8.0.tar.gz"
+    sha256: "bc3d5ab1439769f53ce648657227d6f2f6de84d429cb1dbe0e98e0a2e61c4c49"
   "3.4.0":
     url: "https://github.com/FreeGLUTProject/freeglut/archive/v3.4.0.tar.gz"
     sha256: "3c0bcb915d9b180a97edaebd011b7a1de54583a838644dcd42bb0ea0c6f3eaec"

--- a/recipes/freeglut/config.yml
+++ b/recipes/freeglut/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.8.0":
+    folder: all
   "3.4.0":
     folder: all
   "3.2.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  **freeglut/3.8.0**

#### Motivation
the latest available conan package for freeglut was 3.4.0 while 3.8.0 is the latest available from git.

#### Details
I only added the GitHub links, all patches have been merged upstream, so there is no need to rebase them.

I only tested on Windows 11 using msvc.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
