### PR TITLE
Fix pcl/1.14.1 CMake patch

### DIFF
--- a/recipes/pcl/all/patches/1.14.1-0001-cmake_use_conan_targets.patch
+++ b/recipes/pcl/all/patches/1.14.1-0001-cmake_use_conan_targets.patch
@@ -9,7 +9,7 @@
  endif()
  if(OpenMP_FOUND)
    string(APPEND CMAKE_C_FLAGS " ${OpenMP_C_FLAGS}")
-@@ -319,11 +319,14 @@
+@@ -319,13 +319,16 @@
  find_package(Threads REQUIRED)
 
  # Eigen3 (required)
@@ -46,7 +46,7 @@
    if(NOT (${QHULL_LIBRARY_TYPE} MATCHES ${PCL_QHULL_REQUIRED_TYPE}) AND NOT (${PCL_QHULL_REQUIRED_TYPE} MATCHES "DONTCARE"))
      message(FATAL_ERROR "Qhull was selected with ${PCL_QHULL_REQUIRED_TYPE} but found as ${QHULL_LIBRARY_TYPE}")
    endif()
-@@ -409,7 +409,7 @@
+@@ -409,7 +412,7 @@
  #Find PCAP
  option(WITH_PCAP "pcap file capabilities in Velodyne HDL driver" TRUE)
  if(WITH_PCAP)


### PR DESCRIPTION
Make sure that all line counts and offsets are correct to ensure that all patch hunks can be applied successfully

### Summary
Changes to recipe:  **pcl/1.14.1**

#### Motivation
The CMakeLists.txt of pcl must be patched for Conan usage, so that Qhull can be found and used for convex hull computations.

#### Details
After updating from pcl/1.13.1 to 1.14.1, we were missing the Qhull related headers, because the find_package() call in the CMakeLists.txt was no longer patched.

Trying to apply the patch manually showed the following error:
```
git apply 1.14.1-0001-cmake_use_conan_targets.patch
error: patch fragment without header at line 31: @@ -365,7 +368,7 @@
```

The patch file has been reviewed and corrected, so that it can be applied successfully now.

Tested with Conan version 2.23.0.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
