### PR TITLE
Update to SQLite3 Multiple Ciphers 2.2.7

### DIFF
--- a/recipes/sqlite3mc/all/conandata.yml
+++ b/recipes/sqlite3mc/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "2.2.6":
-    url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v2.2.6.1.tar.gz"
-    sha256: "151ffefb80f7198ddd7fee7d506255130337025ac18bd68b6fc06b1b5da470ad"
+  "2.2.7":
+    url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v2.2.7.tar.gz"
+    sha256: "b863ace2d6aab6a9d287c024fb9ad27b699e2876e6e95495c491a2d4db2126df"
   "2.2.3":
     url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v2.2.3.tar.gz"
     sha256: "eba448e84aaf78ba5153223adb2072b483f1c28824860a71334e28f133306807"

--- a/recipes/sqlite3mc/config.yml
+++ b/recipes/sqlite3mc/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "2.2.6":
+  "2.2.7":
     folder: all
   "2.2.3":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **sqlite3mc**

#### Motivation
**sqlite3mc version 2.2.7** supports the latest SQLite version 3.51.2, and includes important bug fixes regarding raw keys.

#### Details

Version 2.2.7 includes important bug fixes:

- Raw keys in SQLCipher notation were not handled correctly
- Allow initializing library without default VFS

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan