### PR TITLE
[msys2] Restrict recipe triplet when the target is Windows only

### DIFF
--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -205,8 +205,7 @@ class MSYS2Conan(ConanFile):
 
         if self.settings_target is not None and \
             self.settings_target.os == "Windows" and \
-            self.settings_target.arch == "armv8" and \
-            self.settings_build.os == "Windows":
+            self.settings_target.arch == "armv8":
             # Expose /opt/bin to PATH, so that aarch64-w64-mingw32- prefixed tools can be found
             # Define autotools host/build triplet so that the right tools are used
             self.cpp_info.bindirs.insert(0, os.path.join(msys_root, "opt", "bin"))


### PR DESCRIPTION
### Summary
Changes to recipe:  **msys2/cci.latest**

#### Motivation

The initial motivation for this PR is allowing cross-building projects from Windows to Android, using autotools, which requires this msys2 package too. 

This suggestion also came from https://github.com/conan-io/conan-center-index/pull/28999#issuecomment-3589851106

/cc @vbieleny

#### Details

The current msys2 recipe is projected for Windows, not considering other targets like Android. Its `package_info` is using a specific triplet that does not match when the `self.settings_target.os` is not Windows (e.g. Android), as a consequence, the misconfiguration results in errors like [reported on PR 28999](https://github.com/user-attachments/files/23788203/autotools_android_error.txt)

This PR adds a restriction to msys2 package_info to only configure that triplet when the expected OS and Arch matches to what is listed in the triplet.

On the other hand, when that triplet is not configured by msys and is cross-building to Android, Conan client is capable to deduce a valid triplet:

```
System type:
checking build system type... x86_64-unknown-windows
checking host system type... aarch64-unknown-linux-android
```

I used xz_utils/5.8.1 as an example, you can check its build log using this PR changes: [xz_utils-5.8.1-windows-cross-android-conan.log](https://github.com/user-attachments/files/23860011/xz_utils-5.8.1-windows-cross-android-conan.log)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
