### PR TITLE
msys2: Fix pollution of package folder

### DIFF
--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -201,15 +201,9 @@ class MSYS2Conan(ConanFile):
         self.buildenv_info.define_path("MSYS_ROOT", msys_root)
         self.buildenv_info.define_path("MSYS_BIN", msys_bin)
 
-        msys_tmp = tempfile.mkdtemp(prefix="msys_tmp_")
-        msys_home = tempfile.mkdtemp(prefix="msys_home_")
-        # Redirect HOME so MSYS2 does not pollute package folder
-        self.buildenv_info.define_path("HOME", msys_home)
-        self.buildenv_info.define_path("USERPROFILE", msys_home)
         # Redirect /tmp so MSYS2 does not pollute the package folder
-        self.buildenv_info.define_path("MSYS2_TMPDIR", msys_tmp)
+        msys_tmp = tempfile.mkdtemp(prefix="msys_tmp_")
         self.buildenv_info.define_path("TMP", msys_tmp)
-        self.buildenv_info.define_path("TEMP", msys_tmp)
 
         self.conf_info.define("tools.microsoft.bash:subsystem", "msys2")
         self.conf_info.define("tools.microsoft.bash:path", os.path.join(msys_bin, "bash.exe"))


### PR DESCRIPTION
### Summary
Changes to recipe:  **msys2/cci.latest**

#### Motivation
closes https://github.com/conan-io/conan-center-index/issues/28993#event-21215158355

#### Details
It sets the home anf temp folder to the temp system directory creating respective subfolders.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
