### PR TITLE
proj: Libtiff as version range to avoid conflicts in dependants

### DIFF
--- a/recipes/proj/all/conanfile.py
+++ b/recipes/proj/all/conanfile.py
@@ -54,7 +54,7 @@ class ProjConan(ConanFile):
         self.requires("nlohmann_json/3.11.3")
         self.requires("sqlite3/[>=3.44 <4]")
         if self.options.with_tiff:
-            self.requires("libtiff/4.6.0")
+            self.requires("libtiff/[>=4.6.0 <5]")
         if self.options.with_curl:
             self.requires("libcurl/[>=7.78.0 <9]")
 


### PR DESCRIPTION
When building osgeart, we detected some verison conflicts with libtiff:
openscenegraph needs libtiff, and has a version range
gdal requires libgeotiff (https://github.com/conan-io/conan-center-index/pull/29038) which also has this same version range

Reording gdal to come first is not quite optimal as that would generate missing binaries, so this is a better fit to consolidate all dependencies


---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
