### PR TITLE
libinput test from meson to cmake

### DIFF
--- a/recipes/libinput/all/test_package/CMakeLists.txt
+++ b/recipes/libinput/all/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES C)
+
+find_package(libinput REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE libinput::libinput)
+
+

--- a/recipes/libinput/all/test_package/conanfile.py
+++ b/recipes/libinput/all/test_package/conanfile.py
@@ -1,30 +1,24 @@
 from conan import ConanFile
 from conan.tools.build import can_run
-from conan.tools.layout import basic_layout
-from conan.tools.meson import Meson
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "PkgConfigDeps", "MesonToolchain", "VirtualRunEnv", "VirtualBuildEnv"
+    generators = "CMakeDeps", "CMakeToolchain"
     test_type = "explicit"
 
     def layout(self):
-        basic_layout(self)
+        cmake_layout(self)
 
     def requirements(self):
         self.requires(self.tested_reference_str)
 
-    def build_requirements(self):
-        self.tool_requires("meson/1.3.2")
-        if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
-            self.tool_requires("pkgconf/2.1.0")
-
     def build(self):
-        meson = Meson(self)
-        meson.configure()
-        meson.build()
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
 
     def test(self):
         if can_run(self):

--- a/recipes/libinput/all/test_package/meson.build
+++ b/recipes/libinput/all/test_package/meson.build
@@ -1,5 +1,0 @@
-project('test_package', 'c')
-package_dep = dependency('libinput')
-executable('test_package',
-            sources : ['test_package.c'],
-            dependencies : [package_dep])


### PR DESCRIPTION
### Summary
Changes to recipe:  **libinput/[*]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Migrate the test package from cmake to meson

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
Just the minimal changes

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
