### PR TITLE
Update libpng to support version 1.6.52 

### DIFF
--- a/recipes/libpng/all/conandata.yml
+++ b/recipes/libpng/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.6.52":
+    url: "https://download.sourceforge.net/libpng/libpng-1.6.52.tar.xz"
+    sha256: "36bd726228ec93a3b6c22fdb49e94a67b16f2fe9b39b78b7cb65772966661ccc"
   "1.6.51":
     url: "https://sourceforge.net/projects/libpng/files/libpng16/1.6.51/libpng-1.6.51.tar.xz"
     sha256: "a050a892d3b4a7bb010c3a95c7301e49656d72a64f1fc709a90b8aded192bed2"

--- a/recipes/libpng/config.yml
+++ b/recipes/libpng/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.6.52":
+    folder: all
   "1.6.51":
     folder: all
   "1.6.50":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libpng/1.6.52**

#### Motivation

libpng versions 1.6.0 through 1.6.51 have a recently discovered security vulnerability:
[CVE-2025-66293](https://www.cve.org/CVERecord?id=CVE-2025-66293) (high severity): out-of-bounds read in png_image_read_composite() when processing palette PNG images with partial transparency and gamma correction
This vulnerability is fixed in version 1.6.52, released on 3 December 2025. Note that it affects valid, conformant PNG images: specifically, those with a tRNS chunk containing partial alpha values (1-254) and a gAMA chunk when processed via the simplified API with an output format without alpha and no explicit background color. (To our knowledge, no web browsers use the simplified API, so they should not be affected.)

#### Details

Add new version 1.6.52

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
