### PR TITLE
[verilog-slang] Expose more compiler definitions

### DIFF
--- a/recipes/verilog-slang/all/conanfile.py
+++ b/recipes/verilog-slang/all/conanfile.py
@@ -87,8 +87,14 @@ class VerilogSlangConan(ConanFile):
 
         self.cpp_info.components["core"].set_property("cmake_target_name", "slang::slang")
         self.cpp_info.components["core"].requires = ["fmt::fmt", "boost_unordered"]
+        self.cpp_info.components["core"].defines = ["SLANG_USE_THREADS"]
+        if self.settings.build_type == "Debug":
+            self.cpp_info.components["core"].defines.append("SLANG_DEBUG")
+        if not self.options.shared:
+            self.cpp_info.components["core"].defines.append("SLANG_STATIC_DEFINE")
         if not self.options.shared or not self.settings.os == "Windows":
             self.cpp_info.components["core"].requires.append("mimalloc::mimalloc")
+            self.cpp_info.components["core"].defines.append("SLANG_USE_MIMALLOC")
         self.cpp_info.components["core"].libs = ["svlang"]
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["core"].system_libs = ["m", "pthread", "dl"]


### PR DESCRIPTION
### Summary
Changes to recipe:  **verilog-slang/9.1**

#### Motivation

As a follow-up to PR #28886, this new PR exposes more compiler definitions that should be listed as public in the generated CMake files. It reflects the same behavior as when consuming the upstream's slangConfig.cmake and similar.

/cc @mattyoung101


#### Details

* The Thread support is enabled by default, resulting in `SLANG_STATIC_DEFINE` as a public definition:
  - https://github.com/MikePopoloski/slang/blob/v9.1/CMakeLists.txt#L75
  - https://github.com/MikePopoloski/slang/blob/v9.1/source/CMakeLists.txt#L149

* When building on Debug, the project exports `SLANG_DEBUG`:
  - https://github.com/MikePopoloski/slang/blob/v9.1/source/CMakeLists.txt#L131
  
* When building static library, the definition `SLANG_STATIC_DEFINE` is exported:
  - https://github.com/MikePopoloski/slang/blob/v9.1/source/CMakeLists.txt#L178
  
* When using mimalloc, the project exports `SLANG_USE_MIMALLOC` as well:
  - https://github.com/MikePopoloski/slang/blob/v9.1/source/CMakeLists.txt#L154
  
----

When building locally using `build_type=Debug` on Linux, I obtained the following `slangTargets.cmake` from the project (not generated by Conan CMakeDeps):

```cmake
...
# Create imported target slang::boost_unordered
add_library(slang::boost_unordered INTERFACE IMPORTED)

set_target_properties(slang::boost_unordered PROPERTIES
  INTERFACE_COMPILE_DEFINITIONS "SLANG_BOOST_SINGLE_HEADER"
)

# Create imported target slang::slang
add_library(slang::slang STATIC IMPORTED)

set_target_properties(slang::slang PROPERTIES
  INTERFACE_COMPILE_DEFINITIONS "\$<\$<CONFIG:Debug>:SLANG_DEBUG>;SLANG_USE_THREADS;SLANG_USE_MIMALLOC;SLANG_STATIC_DEFINE"
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include;${_IMPORT_PREFIX}/include"
  INTERFACE_LINK_LIBRARIES "fmt::fmt;slang::boost_unordered;mimalloc-static"
)
...
```

My local build log (Linux + amd64 + GCC11 + C++20 + Debug + Static): [verilog-slang-9.1-linux-amd64-gcc11-debug-static.log](https://github.com/user-attachments/files/23955837/verilog-slang-9.1-linux-amd64-gcc11-debug-static.log)

Regards.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
