### PR TITLE
Add in a deprecation notice for foxglove-websocket.

### DIFF
--- a/recipes/foxglove-websocket/all/conanfile.py
+++ b/recipes/foxglove-websocket/all/conanfile.py
@@ -11,6 +11,7 @@ required_conan_version = ">=1.53.0"
 
 class FoxgloveWebSocketConan(ConanFile):
     name = "foxglove-websocket"
+    deprecated = "Please switch to using https://github.com/foxglove/foxglove-sdk instead"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/foxglove/ws-protocol"
     description = "A C++ server implementation of the Foxglove WebSocket Protocol"


### PR DESCRIPTION
It still works, but it is no longer maintained and has been replaced with a different project.

### Summary
Add in a deprecation notice for foxglove-websocket.

#### Motivation
The upstream repository for foxglove-websocket, https://github.com/foxglove/ws-protocol has been archived and is no longer being maintained.  All of the functionality that used to be in there has now moved to a different repository, https://github.com/foxglove/foxglove-sdk .

#### Details
Add in a deprecation warning to foxglove-websocket that it has been deprecated, and new users should move to foxglove-sdk.  We don't want to remove the package at this time because it might still have users, and it still works for those users.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [N/A] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
