### PR TITLE
[package] safe-dist/0.1.0Add safe-dist/0.1.0 - C++ directory integrity checker for CI/CD

### DIFF
--- a/recipes/safe-dist/all/conandata.yml
+++ b/recipes/safe-dist/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.1.0":
+    url: "https://github.com/emorilebo/safe-dist/archive/refs/tags/v0.1.0.tar.gz"
+    sha256: "10cc8b71f2f0bbf8d0df45f266787315ecbf9ee618c3fc93a3ddc3fc264bfa33e"

--- a/recipes/safe-dist/all/conanfile.py
+++ b/recipes/safe-dist/all/conanfile.py
@@ -1,0 +1,49 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import get, copy, rmdir
+import os
+
+
+class SafeDistConan(ConanFile):
+    name = "safe-dist"
+    description = "A C++ directory integrity checker for CI/CD pipelines"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/emorilebo/safe-dist"
+    topics = ("security", "cli", "integrity", "deployment", "ci-cd")
+    package_type = "application"
+    settings = "os", "arch", "compiler", "build_type"
+
+    def export_sources(self):
+        copy(self, "CMakeLists.txt", src=self.recipe_folder, dst=self.export_sources_folder)
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        # Remove any cmake files installed
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+
+    def package_info(self):
+        self.cpp_info.frameworkdirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.resdirs = []
+        self.cpp_info.includedirs = []
+        # This is a CLI tool, so we add the bin folder to the PATH
+        bindir = os.path.join(self.package_folder, "bin")
+        self.buildenv_info.prepend_path("PATH", bindir)

--- a/recipes/safe-dist/all/test_package/conanfile.py
+++ b/recipes/safe-dist/all/test_package/conanfile.py
@@ -1,0 +1,14 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    test_type = "explicit"
+
+    def build_requirements(self):
+        self.tool_requires(self.tested_reference_str)
+
+    def test(self):
+        if can_run(self):
+            self.run("safe-dist --help", env="conanbuild")

--- a/recipes/safe-dist/config.yml
+++ b/recipes/safe-dist/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.1.0":
+    folder: all


### PR DESCRIPTION
## New Package Request
   
   - Package name: safe-dist
   - Version: 0.1.0
   - Homepage: https://github.com/emorilebo/safe-dist
   - Description: A C++ directory integrity checker for CI/CD pipelines
   - License: MIT
   - Topics: security, cli, integrity, deployment, ci-cd
   
   ### What the package does:
   safe-dist is a command-line tool that scans directories for debris files (.DS_Store, *.bak, *.tmp) and insecure permissions before deployment. It's designed for use as a quality gate in CI/CD pipelines.### Summary
Changes to recipe:  **lib/[version]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
