### PR TITLE
Added recipe options to override defaults for C and C++ standard library inclusion

### DIFF
--- a/recipes/cpputest/all/conanfile.py
+++ b/recipes/cpputest/all/conanfile.py
@@ -25,11 +25,15 @@ class CppUTestConan(ConanFile):
         "fPIC": [True, False],
         "with_extensions": [True, False],
         "with_leak_detection": [True, False],
+        "with_std_c": [True, False],
+        "with_std_cpp": [True, False]
     }
     default_options = {
         "fPIC": True,
         "with_extensions": True,
         "with_leak_detection": True,
+        "with_std_c": True,
+        "with_std_cpp": True,
     }
 
     def export_sources(self):
@@ -48,8 +52,8 @@ class CppUTestConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["STD_C"] = True
-        tc.variables["STD_CPP"] = True
+        tc.variables["STD_C"] = self.options.with_std_c
+        tc.variables["STD_CPP"] = self.options.with_std_cpp
         tc.variables["C++11"] = True
         tc.variables["MEMORY_LEAK_DETECTION"] = self.options.with_leak_detection
         tc.variables["EXTENSIONS"] = self.options.with_extensions


### PR DESCRIPTION
### Summary
Added options to expose cpputest's existing STD_C and STD_CPP buid config options, which are currently hard-coded to `True` in the conancenter recipe.

#### Motivation
The existing recipe is unable to build for bare metal platforms due to the inability to configure standard library options. Users can still download cpputest directly and build from source, but it would be ideal to be able to use the conan recipe to build for all available configuration.

Issue link:
https://github.com/conan-io/conan-center-index/issues/29069

#### Details
The PR is extremely small, and simply changes two cmake toolchain variables from their current `True` hard-coding, to an option that can be set on the conan invocation.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!

