### PR TITLE
[rtmidi] Update rtmidi source URLs to new domain

### DIFF
--- a/recipes/rtmidi/all/conandata.yml
+++ b/recipes/rtmidi/all/conandata.yml
@@ -1,18 +1,18 @@
 sources:
   "6.0.0":
     url:
-      - "https://www.music.mcgill.ca/~gary/rtmidi/release/rtmidi-6.0.0.tar.gz"
-      - "http://www.music.mcgill.ca/~gary/rtmidi/release/rtmidi-6.0.0.tar.gz"
+      - "https://caml.music.mcgill.ca/~gary/rtmidi/release/rtmidi-6.0.0.tar.gz"
+      - "http://caml.music.mcgill.ca/~gary/rtmidi/release/rtmidi-6.0.0.tar.gz"
     sha256: "5960ccf64b42c23400720ccc880e2f205677ce9457f747ef758b598acd64db5b"
   "5.0.0":
     url:
-      - "https://www.music.mcgill.ca/~gary/rtmidi/release/rtmidi-5.0.0.tar.gz"
-      - "http://www.music.mcgill.ca/~gary/rtmidi/release/rtmidi-5.0.0.tar.gz"
+      - "https://caml.music.mcgill.ca/~gary/rtmidi/release/rtmidi-5.0.0.tar.gz"
+      - "http://caml.music.mcgill.ca/~gary/rtmidi/release/rtmidi-5.0.0.tar.gz"
     sha256: "48db0ed58c8c0e207b5d7327a0210b5bcaeb50e26387935d02829239b0f3c2b9"
   "4.0.0":
     url:
-      - "https://www.music.mcgill.ca/~gary/rtmidi/release/rtmidi-4.0.0.tar.gz"
-      - "http://www.music.mcgill.ca/~gary/rtmidi/release/rtmidi-4.0.0.tar.gz"
+      - "https://caml.music.mcgill.ca/~gary/rtmidi/release/rtmidi-4.0.0.tar.gz"
+      - "http://caml.music.mcgill.ca/~gary/rtmidi/release/rtmidi-4.0.0.tar.gz"
     sha256: "370cfe710f43fbeba8d2b8c8bc310f314338c519c2cf2865e2d2737b251526cd"
 patches:
   "4.0.0":


### PR DESCRIPTION
### Summary

Changes to recipe: **lib/[version]**

The link to the rtmidi source code has changed to a new location:
https://github.com/thestk/rtmidi/releases/tag/6.0.0

#### Motivation

The current link are broken.

#### Details

<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->

---

- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---

Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
