### PR TITLE
faiss: depend on maintained version of openblas

### DIFF
--- a/recipes/faiss/all/conanfile.py
+++ b/recipes/faiss/all/conanfile.py
@@ -33,7 +33,7 @@ class FaissConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("openblas/0.3.27")
+        self.requires("openblas/[^0.3.27]")
         self.requires("gflags/2.2.2")
 
     def build_requirements(self):


### PR DESCRIPTION
### Summary
openblas/0.3.27 is in the remote repository but not in the git one  - a small step closer to self consistency

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
