### PR TITLE
opentelemetry-cpp: Enable shared configuration where supported (And make Windows static only)

### DIFF
--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -68,11 +68,7 @@ class OpenTelemetryCppConan(ConanFile):
             self.options.rm_safe("fPIC")
             del self.options.with_etw
             # Opentelemetry-cpp on Windows only supports static libraries,
-            # due to ppor support from upstream (and build failures)
-            # As Upstream does not expect shared builds to work properly on Windows,
-            # instead of validating shared out (which would remove shared builds from CCI of dependants),
-            # we just force static builds on Windows.
-            # See https://github.com/open-telemetry/opentelemetry-cpp/issues/2477
+            # upstream does not support shared builds on Windows
             self.package_type = "static-library"
             del self.options.shared
 


### PR DESCRIPTION
The abseil variant usage is used as a header-only component, with a custom namespace which avoids naming colisions. This allows dependencies of opentelemetry-cpp to use it as a shared library too.

This is a backwards compatible change.

This additionally disabled functional testing which was left enabled in older revisions

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
