### PR TITLE
libpq: add 17.7

### DIFF
--- a/recipes/libpq/config.yml
+++ b/recipes/libpq/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "17.7":
+    folder: meson
   "17.5":
     folder: meson
   "16.8":

--- a/recipes/libpq/meson/conandata.yml
+++ b/recipes/libpq/meson/conandata.yml
@@ -1,7 +1,12 @@
 sources:
+  "17.7":
+    url: "https://ftp.postgresql.org/pub/source/v17.7/postgresql-17.7.tar.bz2"
+    sha256: "ef9e343302eccd33112f1b2f0247be493cb5768313adeb558b02de8797a2e9b5"
   "17.5":
     url: "https://ftp.postgresql.org/pub/source/v17.5/postgresql-17.5.tar.bz2"
     sha256: "fcb7ab38e23b264d1902cb25e6adafb4525a6ebcbd015434aeef9eda80f528d8"
 patches:
+  "17.7":
+    - patch_file: "patches/17.5-pgflex-preserve-environment-variables.patch"
   "17.5":
-    - patch_file : "patches/17.5-pgflex-preserve-environment-variables.patch"
+    - patch_file: "patches/17.5-pgflex-preserve-environment-variables.patch"


### PR DESCRIPTION
### Summary
Changes to recipe:  **libpq/17.7**

#### Motivation
A new version.

#### Details
First part for GCC15 (Cstd23) support. Not all dependencies support it completely but `libpq` itself does it now.
Others will follow.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan: `2.23.0`

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
