### PR TITLE
replace rapidhash 3.0 sha256

### DIFF
--- a/recipes/rapidhash/all/conandata.yml
+++ b/recipes/rapidhash/all/conandata.yml
@@ -1,7 +1,10 @@
 sources:
+  "3.0.cci20251211":
+    url: "https://github.com/Nicoshev/rapidhash/archive/d60698faa10916879f85b2799bfdc6996b94c2b7.tar.gz"
+    sha256: "f403f34f892a78d58aef08bcb2a3ed1152a05ff07b70a698e02ba30865800b36"
   "3.0":
-    url: "https://github.com/Nicoshev/rapidhash/archive/refs/tags/rapidhash_v3.tar.gz"
-    sha256: "2e708bb2be76fd76f1e5d75bb3145d058e2dad0c5b0022646f84ec83aeff400d"
+    url: "https://github.com/Nicoshev/rapidhash/archive/bbaf1a70775b785f11dab29dc7d9bd717b4eb6a6.tar.gz"
+    sha256: "48c3cf8464deeeb1eb1023fd132c3e19d00c37d7931816fb1bd09eec8f4db00e"
   "1.0":
     url: "https://github.com/Nicoshev/rapidhash/archive/refs/tags/rapidhash_v1.0.tar.gz"
     sha256: "d295e66eec6745cc0e0c8c65fb8b5edf08ab3af83b0a503c54c6705144b53848"

--- a/recipes/rapidhash/all/conandata.yml
+++ b/recipes/rapidhash/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "3.0":
     url: "https://github.com/Nicoshev/rapidhash/archive/refs/tags/rapidhash_v3.tar.gz"
-    sha256: "645084e192a28fedfb2be80066a7849c4e3dd2443f686fb266d1a284b7a01eb9"
+    sha256: "2e708bb2be76fd76f1e5d75bb3145d058e2dad0c5b0022646f84ec83aeff400d"
   "1.0":
     url: "https://github.com/Nicoshev/rapidhash/archive/refs/tags/rapidhash_v1.0.tar.gz"
     sha256: "d295e66eec6745cc0e0c8c65fb8b5edf08ab3af83b0a503c54c6705144b53848"

--- a/recipes/rapidhash/all/conandata.yml
+++ b/recipes/rapidhash/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "3.0.cci20251211":
-    url: "https://github.com/Nicoshev/rapidhash/archive/d60698faa10916879f85b2799bfdc6996b94c2b7.tar.gz"
-    sha256: "f403f34f892a78d58aef08bcb2a3ed1152a05ff07b70a698e02ba30865800b36"
+  "3.0.cci20250816":
+    url: "https://github.com/Nicoshev/rapidhash/archive/bc4b4baa48a15ff52ff4725e1ccdcda62815221c.tar.gz"
+    sha256: "b5cfa9d75466acae11704504852b752da2789732cdcfb0666999b2d1a53e97ff"
   "3.0":
     url: "https://github.com/Nicoshev/rapidhash/archive/bbaf1a70775b785f11dab29dc7d9bd717b4eb6a6.tar.gz"
     sha256: "48c3cf8464deeeb1eb1023fd132c3e19d00c37d7931816fb1bd09eec8f4db00e"

--- a/recipes/rapidhash/all/conandata.yml
+++ b/recipes/rapidhash/all/conandata.yml
@@ -1,10 +1,16 @@
 sources:
-  "3.0.cci20250816":
-    url: "https://github.com/Nicoshev/rapidhash/archive/bc4b4baa48a15ff52ff4725e1ccdcda62815221c.tar.gz"
-    sha256: "b5cfa9d75466acae11704504852b752da2789732cdcfb0666999b2d1a53e97ff"
+  "3.0.cci20260819":
+    url: "https://github.com/Nicoshev/rapidhash/archive/1ae7842f59f25929a338e5a76e3fa350673e48e1.tar.gz"
+    sha256: "af11d54a8dd9c0a85d132efad91f15281d0a0f6d72876a5aa2c4b1d0a76af246"
   "3.0":
     url: "https://github.com/Nicoshev/rapidhash/archive/bbaf1a70775b785f11dab29dc7d9bd717b4eb6a6.tar.gz"
     sha256: "48c3cf8464deeeb1eb1023fd132c3e19d00c37d7931816fb1bd09eec8f4db00e"
   "1.0":
     url: "https://github.com/Nicoshev/rapidhash/archive/refs/tags/rapidhash_v1.0.tar.gz"
     sha256: "d295e66eec6745cc0e0c8c65fb8b5edf08ab3af83b0a503c54c6705144b53848"
+patches:
+  "3.0":
+    - patch_file: "patches/0001-fix-3-0-msvc-build.patch"
+      patch_description: "Fix broken msvc build & C++11 build"
+      patch_type: "portability"
+      patch_source: "https://github.com/Nicoshev/rapidhash/commit/3f525283155155a590936d0d0497255164fdf73e"

--- a/recipes/rapidhash/all/conanfile.py
+++ b/recipes/rapidhash/all/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
 
 from conan.tools.build import check_min_cppstd
-from conan.tools.files import copy, get
+from conan.tools.files import copy, get, apply_conandata_patches, export_conandata_patches
 from conan.tools.layout import basic_layout
 import os
 
@@ -27,8 +27,12 @@ class RapidHashConan(ConanFile):
     def validate(self):
         check_min_cppstd(self, 11)
 
+    def export_sources(self):
+        export_conandata_patches(self)
+
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
 
     def package(self):
         copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))

--- a/recipes/rapidhash/all/patches/0001-fix-3-0-msvc-build.patch
+++ b/recipes/rapidhash/all/patches/0001-fix-3-0-msvc-build.patch
@@ -1,0 +1,17 @@
+diff --git a/rapidhash.h b/rapidhash.h
+index cc18a20..c5ca0f3 100755
+--- a/rapidhash.h
++++ b/rapidhash.h
+@@ -63,7 +63,11 @@
+  # ifndef RAPIDHASH_INLINE
+  #   define RAPIDHASH_INLINE RAPIDHASH_ALWAYS_INLINE
+  # endif
+- # define RAPIDHASH_INLINE_CONSTEXPR RAPIDHASH_ALWAYS_INLINE constexpr
++ # if __cplusplus >= 201402L && !defined(_MSC_VER)
++ #   define RAPIDHASH_INLINE_CONSTEXPR RAPIDHASH_ALWAYS_INLINE constexpr
++ # else
++ #   define RAPIDHASH_INLINE_CONSTEXPR RAPIDHASH_ALWAYS_INLINE
++ # endif
+  #else
+  # define RAPIDHASH_NOEXCEPT
+  # define RAPIDHASH_CONSTEXPR static const


### PR DESCRIPTION
### Summary
Changes to recipe:  **rapidhash/3.0**

#### Motivation
This recipe currently is not buildable anymore, because:
1. rapidhash seems to replace the v3 version when changes are made, instead of adding a new version. This means that the sha256 in the current recipe is not correct. (When consuming the package normally it seems to fetch a cached version from cci and thus work?)
2. The version of rapidhash from the original recipe does not compile on msvc due to a constexpr issue, which is fixed in newer versions of rapidhash. Interestingly I think I had compiled it successfully in the past (with the same compiler), but now it does definetly not work anymore (tested with the three latest versions of msvc).

So maybe a new versioning system for cci is needed (e.g. `3.0.cci20251211`)? But I guess we can't just remove the `3.0` version. Maybe the url for getting the source should be changed to point to a specific commit to guarantee it wont change in the future?

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
