### PR TITLE
fix cmake recipe: zlib set_property error

### DIFF
--- a/recipes/cmake/3.x.x/conanfile.py
+++ b/recipes/cmake/3.x.x/conanfile.py
@@ -39,6 +39,7 @@ class CMakeConan(ConanFile):
     def requirements(self):
         if self.options.get_safe("with_openssl", default=False):
             self.requires("openssl/[>=1.1 <4]")
+        self.requires("zlib/[>=1.2.11 <2]")
 
     def validate_build(self):
         if self.settings.os == "Windows" and self.options.bootstrap:
@@ -121,6 +122,7 @@ class CMakeConan(ConanFile):
             # the windows SDK available in the system
             if is_msvc(self) and not self.conf.get("tools.cmake.cmaketoolchain:system_version"):
                 tc.variables["CMAKE_SYSTEM_VERSION"] = "10.0"
+            tc.cache_variables["CMAKE_USE_SYSTEM_ZLIB"] = True
             tc.generate()
             tc = CMakeDeps(self)
             # CMake try_compile failure: https://github.com/conan-io/conan-center-index/pull/16073#discussion_r1110037534


### PR DESCRIPTION
### Summary
Changes to recipe:  **cmake/[version]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Close: https://github.com/conan-io/conan-center-index/issues/27314

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
The CMAKE_USE_SYSTEM_ZLIB variable wasn’t being set, which was causing an issue during the build.
https://github.com/Kitware/CMake/blob/v3.26.4/Source/Modules/CMakeBuildUtilities.cmake#L114

[build-3_26_4.log](https://github.com/user-attachments/files/24127594/build-3_26_4.log)


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
