### PR TITLE
cpp-httplib: add version 0.28.0

### DIFF
--- a/recipes/cpp-httplib/all/conandata.yml
+++ b/recipes/cpp-httplib/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.28.0":
+    url: "https://github.com/yhirose/cpp-httplib/archive/v0.28.0.tar.gz"
+    sha256: "ccb32f9832c906d571f61794f453223dbb724ba738265551e3cd28ca325b529d"
   "0.27.0":
     url: "https://github.com/yhirose/cpp-httplib/archive/v0.27.0.tar.gz"
     sha256: "cc57615af359efda816122dcfca37bcbb9f1591396f50a1fd1ad70bbe6050581"

--- a/recipes/cpp-httplib/config.yml
+++ b/recipes/cpp-httplib/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.28.0":
+    folder: all
   "0.27.0":
     folder: all
   "0.20.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **cpp-httplib/0.28.0**

#### Motivation
Bump version of cpp-httplib. Bug fixes and improvements, including a vulnerability fix.

#### Details

**[Bug fixes and improvements](https://github.com/yhirose/cpp-httplib/releases/tag/v0.28.0)**
- **Vulnerability fix: [Untrusted HTTP Header Handling: Internal Header Shadowing (REMOTE*/LOCAL*)](https://github.com/yhirose/cpp-httplib/security/advisories/GHSA-xm2j-vfr9-mg9m)**
- Fix HTTP 414 errors hanging until timeout by @chansikpark in https://github.com/yhirose/cpp-httplib/pull/2260
- CMake: Add HTTPLIB_SHARED option, don't define BUILD_SHARED_LIBS by @vadz in https://github.com/yhirose/cpp-httplib/pull/2266
- Add Client methods with both content provider and receiver by @clarkok in https://github.com/yhirose/cpp-httplib/pull/2268
- Fix struct member initialization issue in getaddrinfo_with_timeout by @clarkok in https://github.com/yhirose/cpp-httplib/pull/2273
- Add #undef _res after including resolv.h to prevent macro conflicts by @Copilot in https://github.com/yhirose/cpp-httplib/pull/2280

**Full changelog:**
- https://github.com/yhirose/cpp-httplib/compare/v0.27.0...v0.28.0


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
