### PR TITLE
abseil: add version 20250814.1

### DIFF
--- a/recipes/abseil/all/conandata.yml
+++ b/recipes/abseil/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "20250814.1":
+    url: "https://github.com/abseil/abseil-cpp/archive/20250814.1.tar.gz"
+    sha256: "1692f77d1739bacf3f94337188b78583cf09bab7e420d2dc6c5605a4f86785a1"
   "20250814.0":
     url: "https://github.com/abseil/abseil-cpp/archive/20250814.0.tar.gz"
     sha256: "9b2b72d4e8367c0b843fa2bcfa2b08debbe3cee34f7aaa27de55a6cbb3e843db"

--- a/recipes/abseil/config.yml
+++ b/recipes/abseil/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "20250814.1":
+    folder: all
   "20250814.0":
     folder: all
   "20250512.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **abseil/20250814.1**

#### Motivation
I'm in the process of updating our tool chain to clang20 and gcc15. This is one part of getting gRPC to compile with Clang20.

#### Details
Next MRs will be protobuf and gRPC with compatible versions.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
