### PR TITLE
qt6: qhelpgenerator not built when widgets option is False.

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -892,7 +892,9 @@ class QtConan(ConanFile):
         if self.settings.os == "Windows":
             targets.extend(["windeployqt"])
         if self.options.qttools:
-            targets.extend(["qhelpgenerator", "qtattributionsscanner"])
+            if self.options.widgets:
+                targets.extend(["qhelpgenerator"])
+            targets.extend(["qtattributionsscanner"])
             targets.extend(["lconvert", "lprodump", "lrelease", "lrelease-pro", "lupdate", "lupdate-pro"])
         if self.options.qtshadertools:
             targets.append("qsb")


### PR DESCRIPTION
### Summary
Changes to recipe:  **qt/6.x**

#### Motivation
When you build qt/6.x with option 'widgets' set to False the Qt package build will fail with an error in the package step:
```
ERROR: qt/6.7.3: Error in package() method, line 1004
        raise ConanException(f"Could not find executable {target}{extension} in {self.package_folder}")
        ConanException: Could not find executable qhelpgenerator in /home/wdobbe/.conan2/p/b/qt671fbfb1fcc2b/p
```

#### Details
Add qhelpgenerator only to the list of to-be-packaged targets if options widgets is True.


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
