### PR TITLE
[boost] Always provide disable_autolinking target

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1826,71 +1826,62 @@ class BoostConan(ConanFile):
         if self.options.header_only:
             self.cpp_info.components["_boost_cmake"].libdirs = []
 
+        def make_magic_autolink_target(name, define):
+            self.cpp_info.components[name].libs = []
+            self.cpp_info.components[name].set_property("cmake_target_name", f"Boost::{name}")
+            self.cpp_info.components[name].names["cmake_find_package"] = name
+            self.cpp_info.components[name].names["cmake_find_package_multi"] = name
+            self.cpp_info.components[name].names["pkg_config"] = f"boost_{name}"  # FIXME: disable on pkg_config
+            # this matches how upstream Boost's BoostConfig.cmake behaves:
+            if self.settings.os == "Windows":
+                self.cpp_info.components[name].defines = [define]
+
+        # These targets are always created by upstream Boost's CMake code.
+        make_magic_autolink_target("diagnostic_definitions", "BOOST_LIB_DIAGNOSTIC")
+        make_magic_autolink_target("disable_autolinking", "BOOST_ALL_NO_LIB")
+        make_magic_autolink_target("dynamic_linking", "BOOST_ALL_DYN_LINK")
+
+        # Auto-add the above magic targets based on options set for this recipe. We
+        # attach them to "headers" so that everything linking to Boost in a downstream
+        # build sees a consistent version of these defines.
+        #
+        # Note that upstream enables magic auto-linking by default, but this recipe
+        # *disables* it by default. diagnostic_definitions=False, magic_autolink=True
+        # and shared=False will match the default (no-defines) upstream behaviour on
+        # Windows.
+        #
+        # If we were to match upstream more closely, it would make sense to drop the
+        # diagnostic_definitions and magic_autolink options from this recipe. It will
+        # always be sensible to set dynamic_linking based on whether we built the
+        # library shared or not.
+        if self.options.diagnostic_definitions:
+            self.cpp_info.components["headers"].requires.append("diagnostic_definitions")
+
+        if self.options.magic_autolink:
+            if self._shared:
+                self.cpp_info.components["headers"].requires.append("dynamic_linking")
+            self.output.info("Enabled magic autolinking (smart and magic decisions)")
+        else:
+            self.cpp_info.components["headers"].requires.append("disable_autolinking")
+            # DISABLES AUTO LINKING! NO SMART AND MAGIC DECISIONS THANKS!
+            self.output.info("Disabled magic autolinking (smart and magic decisions)")
+
         if not self.options.header_only:
             self.cpp_info.components["_libboost"].requires = ["headers"]
 
-            self.cpp_info.components["diagnostic_definitions"].libs = []
-            self.cpp_info.components["diagnostic_definitions"].set_property("cmake_target_name", "Boost::diagnostic_definitions")
-            self.cpp_info.components["diagnostic_definitions"].names["cmake_find_package"] = "diagnostic_definitions"
-            self.cpp_info.components["diagnostic_definitions"].names["cmake_find_package_multi"] = "diagnostic_definitions"
-            self.cpp_info.components["diagnostic_definitions"].names["pkg_config"] = "boost_diagnostic_definitions"  # FIXME: disable on pkg_config
-            # I would assume headers also need the define BOOST_LIB_DIAGNOSTIC, as a header can trigger an autolink,
-            # and this definition triggers a print out of the library selected.  See notes below on autolink and headers.
-            self.cpp_info.components["headers"].requires.append("diagnostic_definitions")
-            if self.options.diagnostic_definitions:
-                self.cpp_info.components["diagnostic_definitions"].defines = ["BOOST_LIB_DIAGNOSTIC"]
-
-            self.cpp_info.components["disable_autolinking"].libs = []
-            self.cpp_info.components["disable_autolinking"].set_property("cmake_target_name", "Boost::disable_autolinking")
-            self.cpp_info.components["disable_autolinking"].names["cmake_find_package"] = "disable_autolinking"
-            self.cpp_info.components["disable_autolinking"].names["cmake_find_package_multi"] = "disable_autolinking"
-            self.cpp_info.components["disable_autolinking"].names["pkg_config"] = "boost_disable_autolinking"  # FIXME: disable on pkg_config
-
-            # Even headers needs to know the flags for disabling autolinking ...
-            # magic_autolink is an option in the recipe, so if a consumer wants this version of boost,
-            # then they should not get autolinking.
-            # Note that autolinking can sneak in just by some file #including a header with (eg) boost/atomic.hpp,
-            # even if it doesn't use any part that requires linking with libboost_atomic in order to compile.
-            # So a boost-header-only library that links to Boost::headers needs to see BOOST_ALL_NO_LIB
-            # in order to avoid autolinking to libboost_atomic
-
-            # This define is already imported into all of the _libboost libraries from this recipe anyway,
-            # so it would be better to be consistent and ensure ANYTHING using boost (headers or libs) has consistent #defines.
-
-            # Same applies for for BOOST_AUTO_LINK_{layout}:
-            # consumer libs that use headers also need to know what is the layout/filename of the libraries.
+            # Tell the auto-linking system about the layout we used - this will not *enable* auto-linking
+            # (see above for that), but will make auto-linking actually work if enabled (either via the
+            # magic_autolink option or by the downstream consumer setting or clearing the relevant
+            # defines).
             #
             # eg, if using the "tagged" naming scheme, and a header triggers an autolink,
             # then that header's autolink request had better be configured to request the "tagged" library name.
             # Otherwise, the linker will be looking for a (eg) "versioned" library name, and there will be a link error.
-
-            # Note that "_libboost" requires "headers" so these defines will be applied to all the libraries too.
-            self.cpp_info.components["headers"].requires.append("disable_autolinking")
             if is_msvc(self) or self._is_clang_cl:
-                if self.options.magic_autolink:
-                    if self.options.layout == "system":
-                        self.cpp_info.components["headers"].defines.append("BOOST_AUTO_LINK_SYSTEM")
-                    elif self.options.layout == "tagged":
-                        self.cpp_info.components["headers"].defines.append("BOOST_AUTO_LINK_TAGGED")
-                    self.output.info("Enabled magic autolinking (smart and magic decisions)")
-                else:
-                    # DISABLES AUTO LINKING! NO SMART AND MAGIC DECISIONS THANKS!
-                    self.cpp_info.components["disable_autolinking"].defines = ["BOOST_ALL_NO_LIB"]
-                    self.output.info("Disabled magic autolinking (smart and magic decisions)")
-
-            self.cpp_info.components["dynamic_linking"].libs = []
-            self.cpp_info.components["dynamic_linking"].set_property("cmake_target_name", "Boost::dynamic_linking")
-            self.cpp_info.components["dynamic_linking"].names["cmake_find_package"] = "dynamic_linking"
-            self.cpp_info.components["dynamic_linking"].names["cmake_find_package_multi"] = "dynamic_linking"
-            self.cpp_info.components["dynamic_linking"].names["pkg_config"] = "boost_dynamic_linking"  # FIXME: disable on pkg_config
-            # A library that only links to Boost::headers can be linked into another library that links a Boost::library,
-            # so for this reasons, the header-only library should know the BOOST_ALL_DYN_LINK definition as it will likely
-            # change some important part of the boost code and cause linking errors downstream.
-            # This is in the same theme as the notes above, re autolinking.
-            self.cpp_info.components["headers"].requires.append("dynamic_linking")
-            if self._shared:
-                # A Boost::dynamic_linking cmake target does only make sense for a shared boost package
-                self.cpp_info.components["dynamic_linking"].defines = ["BOOST_ALL_DYN_LINK"]
+                if self.options.layout == "system":
+                    self.cpp_info.components["headers"].defines.append("BOOST_AUTO_LINK_SYSTEM")
+                elif self.options.layout == "tagged":
+                    self.cpp_info.components["headers"].defines.append("BOOST_AUTO_LINK_TAGGED")
 
             # https://www.boost.org/doc/libs/1_73_0/more/getting_started/windows.html#library-naming
             # libsuffix for MSVC:


### PR DESCRIPTION
### Summary
Changes to recipe:  **boost**

#### Motivation

fixes #8787 and #29286

The Arrow build system (in 20.0.0 and earlier), at least, assumes the `Boost::disable_autolinking` target is always available, even when it only needs Boost headers (see #29286).

Auto-linking generally makes no sense for header-only packages (as there are no libraries to link), so it makes sense to prevent accidental auto-linking. Note that some Boost libraries (such as Boost.JSON) can be used in either header-only or library mode - header-only mode only requires including `<boost/json/src.hpp>` somewhere in a project.

Confirmed locally that a `header_only=True` build of Boost can be used to build Arrow (with thrift and parquet disabled) on Windows. Without this change, the Arrow build fails due to a missing `Boost::disable_autolinking` target.

#### Details

When `header_only=True`:

- provide the `Boost::disable_autolinking` target
- make that target set `BOOST_ALL_NO_LIB`
- make that target a dependency of `Boost::headers`

Only the first change is required to fix the Arrow build with a header_only Boost. All three changes are necessary to fix all the issues reported on #8787 without requiring build system changes to projects consuming Boost.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
