### PR TITLE
ccache: add version 4.12.2

### DIFF
--- a/recipes/ccache/all/conandata.yml
+++ b/recipes/ccache/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.12.2":
+    url: "https://github.com/ccache/ccache/releases/download/v4.12.2/ccache-4.12.2.tar.gz"
+    sha256: "2a087efb66b62d4c66d4eb276748bbfa797ff3bde20adf44c53e5a8b9f3679af"
   "4.12.1":
     url: "https://github.com/ccache/ccache/releases/download/v4.12.1/ccache-4.12.1.tar.gz"
     sha256: "a3da50ab0fb0d42f60c17d1450312e6ace9b681f6221cb77c8a09a845f9d760c"

--- a/recipes/ccache/config.yml
+++ b/recipes/ccache/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.12.2":
+    folder: all
   "4.12.1":
     folder: all
   "4.11":


### PR DESCRIPTION
### Summary
Changes to recipe:  **ccache/4.12.2**

#### Motivation
Bump version of ccache. Bug fixes and improvements. See https://ccache.dev/releasenotes.html#_ccache_4_12_2 for full set of changes.

#### Details
n/a


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
