### PR TITLE
Glaze: add version 6.2.0

### DIFF
--- a/recipes/glaze/all/conandata.yml
+++ b/recipes/glaze/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "6.2.0":
+    url: "https://github.com/stephenberry/glaze/archive/refs/tags/v6.2.0.tar.gz"
+    sha256: "0826D9E50F22A1D8B8E28A29AAD8AF2781F81BF85EFA14D34B5709792E50B2BF"
   "6.1.0":
     url: "https://github.com/stephenberry/glaze/archive/refs/tags/v6.1.0.tar.gz"
     sha256: "4ec01e893363701735d1ef3842fa77a74c4a664edaf08d6a1da0e744900d4125"

--- a/recipes/glaze/config.yml
+++ b/recipes/glaze/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "6.2.0":
+    folder: all
   "6.1.0":
     folder: all
   "6.0.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **glaze/6.2.0**

#### Motivation
6.2.0 brings many improvements and fixes, especially to the networking parts of glaze, including a compile error that would prevent the websocket code from compiling on msvc.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
