### PR TITLE
libpng: update url for version 1.6.37

### DIFF
--- a/recipes/libpng/all/conandata.yml
+++ b/recipes/libpng/all/conandata.yml
@@ -6,5 +6,5 @@ sources:
     url: "https://sourceforge.net/projects/libpng/files/libpng16/1.6.40/libpng-1.6.40.tar.xz"
     sha256: "535b479b2467ff231a3ec6d92a525906fb8ef27978be4f66dbe05d3f3a01b3a1"
   "1.6.37":
-    url: "https://sourceforge.net/projects/libpng/files/libpng16/1.6.37/libpng-1.6.37.tar.xz"
+    url: "https://sourceforge.net/projects/libpng/files/libpng16/older-releases/1.6.37/libpng-1.6.37.tar.xz"
     sha256: "505e70834d35383537b6491e7ae8641f1a4bed1876dbfe361201fc80868d88ca"


### PR DESCRIPTION
### Summary
Updated source url in  **libpng/1.6.37** conandata.yml

#### Motivation
gtk/4.7.0 requires libpng/1.6.37, which has an outdated source url

#### Details
https://sourceforge.net/projects/libpng/files/libpng16/ contains libpng version's directories


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
