### PR TITLE
qt: Build qmltc, the qml type compiler

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -907,7 +907,7 @@ class QtConan(ConanFile):
             targets.append("qsb")
         if self.options.qtdeclarative:
             targets.extend(["qmltyperegistrar", "qmlcachegen", "qmllint", "qmlimportscanner"])
-            targets.extend(["qmlformat", "qml", "qmlprofiler", "qmlpreview"])
+            targets.extend(["qmlformat", "qml", "qmlprofiler", "qmlpreview", "qmltc"])
             if Version(self.version) >= "6.8.3":
                 targets.extend(["qmlaotstats"])
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **qt/***

#### Motivation

Using the type compiler in a project, but it's missing from the conan package. Its an officially documented qt tool from what I can find.

If preferred I could also add it behind a flag? But seems like other tools like this are simply "always on" atm in the rest of the recipe.

#### Details

qmltc has been available since qt 6.3: [release notes](https://www.qt.io/blog/qt-6.3-released), [github](https://github.com/qt/qtdeclarative/tree/6.3/tools/qmltc)

Official documentation: https://doc.qt.io/qt-6/qtqml-qml-type-compiler.html

Built this locally on macOS (apple silicon) and ubuntu linux/arm64 docker image to test.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
