### PR TITLE
json-schema-validator: add version 2.4.0

### DIFF
--- a/recipes/json-schema-validator/all/conandata.yml
+++ b/recipes/json-schema-validator/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.4.0":
+    url: "https://github.com/pboettch/json-schema-validator/archive/refs/tags/2.4.0.tar.gz"
+    sha256: "24cbb114609cc9b43d4018b8d03e082ff5d2f26f5dce8bd36538097267b63af9"
   "2.3.0":
     url: "https://github.com/pboettch/json-schema-validator/archive/refs/tags/2.3.0.tar.gz"
     sha256: "2c00b50023c7d557cdaa71c0777f5bcff996c4efd7a539e58beaa4219fa2a5e1"

--- a/recipes/json-schema-validator/config.yml
+++ b/recipes/json-schema-validator/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.4.0":
+    folder: all
   "2.3.0":
     folder: all
   "2.2.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **json-schema-validator/2.4.0**

#### Motivation
The 2.4.0 release was tagged back in November, but the GitHub release was only just created yesterday. This PR makes that official release available via conan.

#### Details
Just adding a new version with URL and sha256 hash. No functional changes to recipes or anything else.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
