### PR TITLE
update open62541pp to 0.20.0 and restrict dependency to open62541 >= 1.4

### DIFF
--- a/recipes/open62541pp/all/conandata.yml
+++ b/recipes/open62541pp/all/conandata.yml
@@ -2,9 +2,3 @@ sources:
   "0.20.0":
     url: "https://github.com/open62541pp/open62541pp/archive/refs/tags/v0.20.0.tar.gz"
     sha256: "5f9ddc10dcc985e02d031303209b58c4fe4bfab751f227866c1f389b5bbaca99"
-  "0.19.0":
-    url: "https://github.com/open62541pp/open62541pp/archive/refs/tags/v0.19.0.tar.gz"
-    sha256: "c3b00ae083d22a470fb7df5b5426479c0fe02d5de4c4cab5813e95630147be7d"
-  "0.17.0":
-    url: "https://github.com/open62541pp/open62541pp/archive/refs/tags/v0.17.0.tar.gz"
-    sha256: "79d83fcf9673a75870f12d7f54e2d21d245931699b916e6c925df25444ce0189"

--- a/recipes/open62541pp/all/conanfile.py
+++ b/recipes/open62541pp/all/conanfile.py
@@ -5,7 +5,6 @@ from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import get, copy, rm, rmdir, replace_in_file
 from conan.tools.microsoft import is_msvc_static_runtime, is_msvc
-from conan.tools.scm import Version
 
 required_conan_version = ">=2.1"
 
@@ -36,11 +35,7 @@ class Open62541ppConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        version = Version(self.version)
-        if version <= "0.19":
-            self.requires("open62541/1.4.6", transitive_headers=True, transitive_libs=True)
-        elif version <= "0.20":
-            self.requires("open62541/1.4.14", transitive_headers=True, transitive_libs=True)
+        self.requires("open62541/[~1.4.14]", transitive_headers=True, transitive_libs=True)
 
     def validate(self):
         check_min_cppstd(self, 17)

--- a/recipes/open62541pp/config.yml
+++ b/recipes/open62541pp/config.yml
@@ -1,7 +1,3 @@
 versions:
   "0.20.0":
     folder: all
-  "0.19.0":
-    folder: all
-  "0.17.0":
-    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **open62541pp/0.20.0**

#### Motivation
adds support for the latest release and allows to build with open62541 versions >= 1.4

#### Details
adds new open62541pp upstream release and changes the required open62541 dependency to allow all 1.4 releases.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
