### PR TITLE
opencv: fix compilation problems with MSVC+Cuda 12.9

### DIFF
--- a/recipes/opencv/4.x/conandata.yml
+++ b/recipes/opencv/4.x/conandata.yml
@@ -34,3 +34,7 @@ patches:
       patch_description: "Fix Eigen legacy version variable uses"
       patch_type: "backport"
       patch_source: "https://github.com/opencv/opencv/pull/27536"
+    - patch_file: "patches/4.12.0-0003-fix-cuda-12-9.patch"
+      patch_description: "Fix compilation problems with MSVC+Cuda 12.9"
+      patch_type: "backport"
+      patch_source: "https://github.com/opencv/opencv/commit/e2d87defd10d415c29120c3b1c07ac7364ba12f2"

--- a/recipes/opencv/4.x/patches/4.12.0-0003-fix-cuda-12-9.patch
+++ b/recipes/opencv/4.x/patches/4.12.0-0003-fix-cuda-12-9.patch
@@ -1,0 +1,20 @@
+diff --git a/cmake/OpenCVDetectCUDAUtils.cmake b/cmake/OpenCVDetectCUDAUtils.cmake
+index 040273d6c5..7f0f923380 100644
+--- a/cmake/OpenCVDetectCUDAUtils.cmake
++++ b/cmake/OpenCVDetectCUDAUtils.cmake
+@@ -388,8 +388,13 @@ macro(ocv_nvcc_flags)
+     set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -Xcompiler=-fno-finite-math-only)
+   endif()
+
+-  if(WIN32 AND NOT (CUDA_VERSION VERSION_LESS "11.2"))
+-    set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -Xcudafe --display_error_number --diag-suppress 1394,1388)
++  if(WIN32)
++    if (NOT (CUDA_VERSION VERSION_LESS "11.2"))
++        set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -Xcudafe --display_error_number --diag-suppress 1394,1388)
++    endif()
++    if(CUDA_VERSION GREATER "12.8")
++        set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -Xcompiler=/Zc:preprocessor)
++    endif()
+   endif()
+
+   if(CMAKE_CROSSCOMPILING AND (ARM OR AARCH64))


### PR DESCRIPTION
### Summary
Changes to recipe:  **opencv/4.12.0**

#### Motivation
This pull request is a backport of an OpenCV fix for compilation problems with Cuda 12.9 on Windows.
https://github.com/opencv/opencv/commit/e2d87defd10d415c29120c3b1c07ac7364ba12f2

#### Details
Compiling OpenCV 4.12 fails if the Cuda version is 12.9 or newer. 
There is already an upstream fix that will be released in the next OpenCV version.
This is a backport of the fix with commit id e2d87defd10d415c29120c3b1c07ac7364ba12f2


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
