### PR TITLE
[osqp] add options to disable ctrlc interrupt

### DIFF
--- a/recipes/osqp/all/conanfile.py
+++ b/recipes/osqp/all/conanfile.py
@@ -18,10 +18,12 @@ class OsqpConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "with_ctrlc": [True, False]
     }
     default_options = {
         "shared": False,
         "fPIC": True,
+        "with_ctrlc": True
     }
 
     def config_options(self):
@@ -46,7 +48,7 @@ class OsqpConan(ConanFile):
         tc.variables['UNITTESTS'] = not self.conf.get("tools.build:skip_test", default=True, check_type=bool)
         tc.variables["PRINTING"] = True
         tc.variables["PROFILING"] = True
-        tc.variables["CTRLC"] = True
+        tc.variables["CTRLC"] = self.options.with_ctrlc
         tc.variables["DFLOAT"] = False
         tc.variables["DLONG"] = True
         tc.variables["COVERAGE"] = False


### PR DESCRIPTION
### Summary
Changes to recipe:  **osqp/0.6.3**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Adds option to disable ctrlc

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
OSQP provides CMakeList variable `CTRLC` to disable the capture of SIGINT. This change exposes the update to be changed via options at the downstream package

---
- [ ✓] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ✓] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ✓] If this is a bug fix, please link related issue or provide bug details
- [✓ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
