### PR TITLE
Disable Werror on perf builds

### DIFF
--- a/recipes/perf/all/conanfile.py
+++ b/recipes/perf/all/conanfile.py
@@ -43,6 +43,7 @@ class Perf(ConanFile):
     def generate(self):
         tc = AutotoolsToolchain(self)
         tc.make_args += ["NO_LIBPYTHON=1"]
+        tc.make_args += ["WERROR=0"]
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **perf/***

#### Motivation
Perf has `Werror` enabled by default and that breaks conan builds under some configurations (e.g. gcc 11 @ Ubuntu 22.04).
https://github.com/torvalds/linux/blob/master/tools/perf/Makefile.config#L261
```
src/tools/include/linux/kernel.h:43:24: warning: comparison of distinct pointer types lacks a cast
   43 |         (void) (&_max1 == &_max2);              \
      |                        ^~
builtin-sched.c:673:34: note: in expansion of macro ‘max’
  673 |                         (size_t) max(16 * 1024, PTHREAD_STACK_MIN));
      |                                  ^~~
```

And
```
error: argument 2 null where non-null expected [-Werror=nonnull]
   35 |                 epoll_pwait(-(i + 1), NULL, 0, 0, NULL);
      |                 ^~~~~~~~~~~
```

#### Details
Having Werror enabled makes the build unpredictable. Different compiler and compiler versions will produce different warnings. Conan or package consumers should not have to patch them in order to build the package.

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
