### PR TITLE
bison: enable build 3.8.2 for MSVC

### DIFF
--- a/recipes/bison/all/conanfile.py
+++ b/recipes/bison/all/conanfile.py
@@ -68,7 +68,7 @@ class BisonConan(ConanFile):
                 "gl_cv_func_printf_directive_n=no",
                 "gl_cv_func_snprintf_directive_n=no",
                 "gl_cv_func_snprintf_directive_n=no",
-                "gl_cv_func_free=yes",
+                "gl_cv_func_free=no",
             ])
             
             tc.extra_cflags.append("-FS")


### PR DESCRIPTION
### Summary
Changes to recipe:  **bison/3.8.2**

#### Motivation
enable build 3.8.2 for MSVC

#### Details

Dont know why failed on conan center build bot but my locally build is OK,Build logs:
<details>

```

conan create . --version=3.8.2 --build=missing

======== Exporting recipe to the cache ========
bison/3.8.2: Exporting package recipe: D:\My Documents\shun\Downloads\conan-io-recipes-bison_all\conanfile.py
bison/3.8.2: exports: File 'conandata.yml' found. Exporting it...
bison/3.8.2: Calling export_sources()
bison/3.8.2: Copied 1 '.yml' file: conandata.yml
bison/3.8.2: Copied 1 '.py' file: conanfile.py
bison/3.8.2: Copied 3 '.patch' files: 0001-3.8-create_pipe-uses-O_TEXT-not-O_BINARY-mode.patch, 0002-3.7.6-open-source-file-in-binary-mode-MS-ftell-bug-ks-68337.patch, 0005-gnulib-limit-search-range-of-_setmaxstdio.patch
bison/3.8.2: Exported to cache folder: C:\Users\shun\.conan2\p\bison5884ddfb8b8d4\e
bison/3.8.2: Exported: bison/3.8.2#d7d71b229aadbbe97d605672b6ef16d6 (2025-12-20 08:52:13 UTC)

======== Input profiles ========
Profile host:
[settings]
arch=x86_64
build_type=Release
compiler=msvc
compiler.cppstd=17
compiler.runtime=static
compiler.runtime_type=Release
compiler.version=194
os=Windows
[conf]
tools.cmake.cmaketoolchain:generator=Ninja
tools.microsoft.msbuild:vs_version=17

Profile build:
[settings]
arch=x86_64
build_type=Release
compiler=msvc
compiler.cppstd=17
compiler.runtime=static
compiler.runtime_type=Release
compiler.version=194
os=Windows
[conf]
tools.cmake.cmaketoolchain:generator=Ninja
tools.microsoft.msbuild:vs_version=17


======== Computing dependency graph ========
Graph root
    cli
Requirements
    bison/3.8.2#d7d71b229aadbbe97d605672b6ef16d6 - Cache
    m4/1.4.19#b38ced39a01e31fef5435bc634461fd2 - Cache
Build requirements
    autoconf/2.71#f9307992909d7fb3df459340f1932809 - Cache
    automake/1.16.5#058bda3e21c36c9aa8425daf3c1faf50 - Cache
    m4/1.4.19#b38ced39a01e31fef5435bc634461fd2 - Cache
    msys2/cci.latest#4927aa5502eb174e95df524f2be2685e - Cache

======== Computing necessary packages ========
Connecting to remote 'conancenter' anonymously
bison/3.8.2: Main binary package '2e88c2dcfdce83c333cc40d15b3c0b324a5ba4bd' missing
bison/3.8.2: Checking 1 compatible configurations
bison/3.8.2: Compatible configurations not found in cache, checking servers
bison/3.8.2: 'adcfa9d330c44791090b557acc425f5c5fba43b8': compiler.version=193
Requirements
    bison/3.8.2#d7d71b229aadbbe97d605672b6ef16d6:2e88c2dcfdce83c333cc40d15b3c0b324a5ba4bd - Build
    m4/1.4.19#b38ced39a01e31fef5435bc634461fd2:723257509aee8a72faf021920c2874abc738e029#f9a0d644c9e90c7024f844416dbe7384 - Cache
Build requirements
    autoconf/2.71#f9307992909d7fb3df459340f1932809:da39a3ee5e6b4b0d3255bfef95601890afd80709#5b77f70c17ad1741f5845d4e468a347e - Cache
    automake/1.16.5#058bda3e21c36c9aa8425daf3c1faf50:ebec3dc6d7f6b907b3ada0c3d3cdc83613a2b715#07094da42a0b39fd4b34760c5f1f3e7d - Cache
    m4/1.4.19#b38ced39a01e31fef5435bc634461fd2:723257509aee8a72faf021920c2874abc738e029#f9a0d644c9e90c7024f844416dbe7384 - Cache
    msys2/cci.latest#4927aa5502eb174e95df524f2be2685e:956a88975bda9dfcc485e2861d71e74bd7e2b9a5#06ca1e71ba3ed86c0b2e116f4a63da61 - Cache

======== Installing packages ========
msys2/cci.latest: Already installed! (1 of 5)
m4/1.4.19: Already installed! (2 of 5)
autoconf/2.71: Already installed! (3 of 5)
automake/1.16.5: Already installed! (4 of 5)
bison/3.8.2: Calling source() in C:\Users\shun\.conan2\p\bison5884ddfb8b8d4\s\src
bison/3.8.2: Unzipping bison-3.8.2.tar.gz to .

-------- Installing package bison/3.8.2 (5 of 5) --------
bison/3.8.2: Building from source
bison/3.8.2: Package bison/3.8.2:2e88c2dcfdce83c333cc40d15b3c0b324a5ba4bd
bison/3.8.2: Copying sources to build folder
bison/3.8.2: Building your package in C:\Users\shun\.conan2\p\b\bisonb83511f0d5b0f\b
bison/3.8.2: Calling generate()
bison/3.8.2: Generators folder: C:\Users\shun\.conan2\p\b\bisonb83511f0d5b0f\b\build-release\conan
bison/3.8.2: Generating aggregated env files
bison/3.8.2: Generated aggregated env files: ['conanbuild.sh', 'conanbuild.bat', 'conanrun.bat']
bison/3.8.2: Calling build()
bison/3.8.2: Apply patch (portability): use O_TEXT instead of O_BINARY for pipe
bison/3.8.2: Apply patch (portability): windows: open source file in binary mode
bison/3.8.2: Apply patch (portability): msvc: limit search range of _setmaxstdio
bison/3.8.2: RUN: "/c/users/shun/.conan2/p/b/bisonb83511f0d5b0f/b/src/configure" --prefix=/ --bindir=${prefix}/bin --sbindir=${prefix}/bin --libdir=${prefix}/lib --includedir=${prefix}/include --oldincludedir=${prefix}/include --enable-relocatable --disable-nls --datarootdir=${prefix}/res gl_cv_func_printf_directive_n=no gl_cv_func_snprintf_directive_n=no gl_cv_func_snprintf_directive_n=no
conanvcvars.bat: Activating environment Visual Studio 17 - amd64 - winsdk_version=None - vcvars_ver=14.4
[vcvarsall.bat] Environment initialized for: 'x64'
mkdir: cannot create directory ‘/dev/shm’: Read-only file system

Creating /dev/shm directory failed.
POSIX semaphores and POSIX shared memory will not work

mkdir: cannot create directory ‘/dev/mqueue’: Read-only file system

Creating /dev/mqueue directory failed.
POSIX message queues will not work

configure: loading site script /etc/config.site
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for a race-free mkdir -p... /c/users/shun/.conan2/p/msys26322397eb23dd/p/bin/msys64/usr/bin/mkdir -p
checking for gawk... gawk
config.status: creating po/Makefile
config.status: executing tests/atconfig commands

bison/3.8.2: RUN: make install DESTDIR=/c/users/shun/.conan2/p/b/bisonb83511f0d5b0f/p -j12
conanvcvars.bat: Activating environment Visual Studio 17 - amd64 - winsdk_version=None - vcvars_ver=14.4
[vcvarsall.bat] Environment initialized for: 'x64'
mkdir: cannot create directory ‘/dev/shm’: Read-only file system

Creating /dev/shm directory failed.
POSIX semaphores and POSIX shared memory will not work

mkdir: cannot create directory ‘/dev/mqueue’: Read-only file system

Creating /dev/mqueue directory failed.
POSIX message queues will not work

  LEX      examples/c/reccalc/scan.stamp
  GEN      lib/alloca.h
  GEN      lib/configmake.h
  GEN      lib/dirent.h
  GEN      lib/errno.h
  GEN      lib/fcntl.h
  GEN      lib/getopt.h
  GEN      lib/getopt-cdefs.h
  GEN      lib/inttypes.h
  GEN      lib/textstyle.h
  GEN      lib/uniwidth.h
  GEN      lib/wchar.h
  GEN      lib/wctype.h
make  install-recursive
make[1]: Entering directory '/c/Users/shun/.conan2/p/b/bisonb83511f0d5b0f/b/build-release'
Making install in po
make[2]: Entering directory '/c/Users/shun/.conan2/p/b/bisonb83511f0d5b0f/b/build-release/po'
if test "bison" = "gettext-tools"; then \
  /c/users/shun/.conan2/p/msys26322397eb23dd/p/bin/msys64/usr/bin/mkdir -p /c/users/shun/.conan2/p/b/bisonb83511f0d5b0f/p/res/gettext/po; \
  for file in Makefile.in.in remove-potcdate.sin quot.sed boldquot.sed en@quot.header en@boldquot.header insert-header.sin Rules-quot   Makevars.template; do \
    /usr/bin/install -c -m 644 /c/users/shun/.conan2/p/b/bisonb83511f0d5b0f/b/src/po/$file \
		    /c/users/shun/.conan2/p/b/bisonb83511f0d5b0f/p/res/gettext/po/$file; \
  done; \
  for file in Makevars; do \
    rm -f /c/users/shun/.conan2/p/b/bisonb83511f0d5b0f/p/res/gettext/po/$file; \
  done; \
else \
  : ; \
fi
make[2]: Leaving directory '/c/Users/shun/.conan2/p/b/bisonb83511f0d5b0f/b/build-release/po'
Making install in runtime-po
make[2]: Entering directory '/c/Users/shun/.conan2/p/b/bisonb83511f0d5b0f/b/build-release/runtime-po'
if test "bison" = "gettext-tools"; then \
  /c/users/shun/.conan2/p/msys26322397eb23dd/p/bin/msys64/usr/bin/mkdir -p /c/users/shun/.conan2/p/b/bisonb83511f0d5b0f/p/res/gettext/po; \
  for file in Makefile.in.in remove-potcdate.sin quot.sed boldquot.sed en@quot.header en@boldquot.header insert-header.sin Rules-quot   Makevars.template; do \
    /usr/bin/install -c -m 644 /c/users/shun/.conan2/p/b/bisonb83511f0d5b0f/b/src/runtime-po/$file \
		    /c/users/shun/.conan2/p/b/bisonb83511f0d5b0f/p/res/gettext/po/$file; \
  done; \
  for file in Makevars; do \
    rm -f /c/users/shun/.conan2/p/b/bisonb83511f0d5b0f/p/res/gettext/po/$file; \
  done; \
else \
  : ; \
fi
make[2]: Leaving directory '/c/Users/shun/.conan2/p/b/bisonb83511f0d5b0f/b/build-release/runtime-po'
Making install in gnulib-po
make[2]: Entering directory '/c/Users/shun/.conan2/p/b/bisonb83511f0d5b0f/b/build-release/gnulib-po'
if test "bison" = "gettext-tools"; then \
  /c/users/shun/.conan2/p/msys26322397eb23dd/p/bin/msys64/usr/bin/mkdir -p /c/users/shun/.conan2/p/b/bisonb83511f0d5b0f/p/res/gettext/po; \
  for file in Makefile.in.in remove-potcdate.sin quot.sed boldquot.sed en@quot.header en@boldquot.header insert-header.sin Rules-quot   Makevars.template; do \
    /usr/bin/install -c -m 644 /c/users/shun/.conan2/p/b/bisonb83511f0d5b0f/b/src/gnulib-po/$file \
		    /c/users/shun/.conan2/p/b/bisonb83511f0d5b0f/p/res/gettext/po/$file; \
  done; \
  for file in Makevars; do \
    rm -f /c/users/shun/.conan2/p/b/bisonb83511f0d5b0f/p/res/gettext/po/$file; \
  done; \
else \
  : ; \
fi
make[2]: Leaving directory '/c/Users/shun/.conan2/p/b/bisonb83511f0d5b0f/b/build-release/gnulib-po'
Making install in .
make[2]: Entering directory '/c/Users/shun/.conan2/p/b/bisonb83511f0d5b0f/b/build-release'
  CC       lib/libbison_a-malloca.obj
  CC       lib/libbison_a-gl_map.obj
u8-mbtoucr.c
u8-uctomb.c
u8-uctomb-aux.c
width.c
  AR       lib/libbison.a
  CCLD     src/bison.exe
  GEN      /c/users/shun/.conan2/p/b/bisonb83511f0d5b0f/b/src/doc/bison.help
  GEN      /c/users/shun/.conan2/p/b/bisonb83511f0d5b0f/b/src/doc/cross-options.texi
  MAKEINFO /c/users/shun/.conan2/p/b/bisonb83511f0d5b0f/b/src/doc/bison.info
  GEN      /c/users/shun/.conan2/p/b/bisonb83511f0d5b0f/b/src/doc/bison.info.bak
make[3]: Entering directory '/c/Users/shun/.conan2/p/b/bisonb83511f0d5b0f/b/build-release'
 /c/users/shun/.conan2/p/msys26322397eb23dd/p/bin/msys64/usr/bin/mkdir -p '/c/users/shun/.conan2/p/b/bisonb83511f0d5b0f/p/bin'
make[2]: Leaving directory '/c/Users/shun/.conan2/p/b/bisonb83511f0d5b0f/b/build-release/gnulib-po'
Making install in .
make[2]: Entering directory '/c/Users/shun/.conan2/p/b/bisonb83511f0d5b0f/b/build-release'
make[3]: Entering directory '/c/Users/shun/.conan2/p/b/bisonb83511f0d5b0f/b/build-release'

bison/3.8.2: package(): Packaged 1 '.exe' file: bison.exe
bison/3.8.2: package(): Packaged 23 files
bison/3.8.2: package(): Packaged 1 '.lib' file: y.lib
bison/3.8.2: package(): Packaged 14 '.m4' files
bison/3.8.2: package(): Packaged 1 '.css' file: bison-default.css
bison/3.8.2: package(): Packaged 13 '.md' files
bison/3.8.2: package(): Packaged 2 '.c' files: glr.c, yacc.c
bison/3.8.2: package(): Packaged 6 '.cc' files
bison/3.8.2: package(): Packaged 1 '.d' file: lalr1.d
bison/3.8.2: package(): Packaged 1 '.java' file: lalr1.java
bison/3.8.2: package(): Packaged 3 '.hh' files: stack.hh, variant.hh, driver.hh
bison/3.8.2: package(): Packaged 4 '.xsl' files: bison.xsl, xml2dot.xsl, xml2text.xsl, xml2xhtml.xsl
bison/3.8.2: package(): Packaged 12 '.y' files
bison/3.8.2: package(): Packaged 2 '.l' files: scan.l, scan.l
bison/3.8.2: package(): Packaged 1 '.h' file: calc.h
bison/3.8.2: package(): Packaged 4 '.yy' files: simple.yy, variant-11.yy, variant.yy, parser.yy
bison/3.8.2: package(): Packaged 1 '.ll' file: scanner.ll
bison/3.8.2: package(): Packaged 1 '.info' file: bison.info
bison/3.8.2: package(): Packaged 1 '.1' file: yacc.1
bison/3.8.2: Created package revision 40f825e3f79e384733db5a349e710d1e
bison/3.8.2: Package '2e88c2dcfdce83c333cc40d15b3c0b324a5ba4bd' created
bison/3.8.2: Full package reference: bison/3.8.2#d7d71b229aadbbe97d605672b6ef16d6:2e88c2dcfdce83c333cc40d15b3c0b324a5ba4bd#40f825e3f79e384733db5a349e710d1e
bison/3.8.2: Package folder C:\Users\shun\.conan2\p\b\bisonb83511f0d5b0f\p

======== Launching test_package ========

======== Computing dependency graph ========
Graph root
    bison/3.8.2 (test package): D:\My Documents\shun\Downloads\conan-io-recipes-bison_all\test_package\conanfile.py
Build requirements
    autoconf/2.71#f9307992909d7fb3df459340f1932809 - Cache
    automake/1.16.5#058bda3e21c36c9aa8425daf3c1faf50 - Cache
    bison/3.8.2#d7d71b229aadbbe97d605672b6ef16d6 - Cache
    m4/1.4.19#b38ced39a01e31fef5435bc634461fd2 - Cache
    msys2/cci.latest#4927aa5502eb174e95df524f2be2685e - Cache

======== Computing necessary packages ========
Build requirements
    bison/3.8.2#d7d71b229aadbbe97d605672b6ef16d6:2e88c2dcfdce83c333cc40d15b3c0b324a5ba4bd#40f825e3f79e384733db5a349e710d1e - Cache
    m4/1.4.19#b38ced39a01e31fef5435bc634461fd2:723257509aee8a72faf021920c2874abc738e029#f9a0d644c9e90c7024f844416dbe7384 - Cache
    msys2/cci.latest#4927aa5502eb174e95df524f2be2685e:956a88975bda9dfcc485e2861d71e74bd7e2b9a5#06ca1e71ba3ed86c0b2e116f4a63da61 - Cache
Skipped binaries
    autoconf/2.71, automake/1.16.5

======== Installing packages ========
msys2/cci.latest: Already installed! (1 of 3)
m4/1.4.19: Already installed! (2 of 3)
bison/3.8.2: Already installed! (3 of 3)
WARN: deprecated: Usage of deprecated Conan 1.X features that will be removed in Conan 2.X:
WARN: deprecated:     'env_info' used in: m4/1.4.19, msys2/cci.latest

======== Testing the package ========
Removing previously existing 'test_package' build folder: D:\My Documents\shun\Downloads\conan-io-recipes-bison_all\test_package\build\msvc-194-x86_64-17-release
bison/3.8.2 (test package): Test package build: build\msvc-194-x86_64-17-release
bison/3.8.2 (test package): Test package build folder: D:\My Documents\shun\Downloads\conan-io-recipes-bison_all\test_package\build\msvc-194-x86_64-17-release
bison/3.8.2 (test package): Writing generators to D:\My Documents\shun\Downloads\conan-io-recipes-bison_all\test_package\build\msvc-194-x86_64-17-release\generators
bison/3.8.2 (test package): Generator 'CMakeToolchain' calling 'generate()'
bison/3.8.2 (test package): CMakeToolchain generated: conan_toolchain.cmake
bison/3.8.2 (test package): CMakeToolchain generated: D:\My Documents\shun\Downloads\conan-io-recipes-bison_all\test_package\build\msvc-194-x86_64-17-release\generators\CMakePresets.json
bison/3.8.2 (test package): CMakeToolchain generated: D:\My Documents\shun\Downloads\conan-io-recipes-bison_all\test_package\CMakeUserPresets.json
bison/3.8.2 (test package): Generator 'VirtualBuildEnv' calling 'generate()'
bison/3.8.2 (test package): Generator 'VirtualRunEnv' calling 'generate()'
bison/3.8.2 (test package): Generating aggregated env files
bison/3.8.2 (test package): Generated aggregated env files: ['conanbuild.sh', 'conanbuild.bat', 'conanrun.bat']

======== Testing the package: Building ========
bison/3.8.2 (test package): Calling build()
bison/3.8.2 (test package): Running CMake.configure()
bison/3.8.2 (test package): RUN: cmake -G "Ninja" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="D:/My Documents/shun/Downloads/conan-io-recipes-bison_all/test_package" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "D:/My Documents/shun/Downloads/conan-io-recipes-bison_all/test_package"
conanvcvars.bat: Activating environment Visual Studio 17 - amd64 - winsdk_version=None - vcvars_ver=14.4
[vcvarsall.bat] Environment initialized for: 'x64'
mkdir: cannot create directory ‘/dev/shm’: Read-only file system

Creating /dev/shm directory failed.
POSIX semaphores and POSIX shared memory will not work

mkdir: cannot create directory ‘/dev/mqueue’: Read-only file system

Creating /dev/mqueue directory failed.
POSIX message queues will not work

-- Using Conan toolchain: D:/My Documents/shun/Downloads/conan-io-recipes-bison_all/test_package/build/msvc-194-x86_64-17-release/generators/conan_toolchain.cmake
-- Conan toolchain: Setting CMAKE_MSVC_RUNTIME_LIBRARY=$<$<CONFIG:Release>:MultiThreaded>
-- Conan toolchain: C++ Standard 17 with extensions OFF
-- The CXX compiler identification is MSVC 19.40.33812.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.40.33807/bin/Hostx64/x64/cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found BISON: C:/Users/shun/.conan2/p/b/bisonb83511f0d5b0f/p/bin/bison.exe (found version "3.8.2")
BISON_FOUND: TRUE
BISON_EXECUTABLE: C:/Users/shun/.conan2/p/b/bisonb83511f0d5b0f/p/bin/bison.exe
BISON_VERSION: 3.8.2
-- Configuring done (2.8s)
-- Generating done (0.0s)
-- Build files have been written to: D:/My Documents/shun/Downloads/conan-io-recipes-bison_all/test_package/build/msvc-194-x86_64-17-release

```

</details>

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
