### PR TITLE
rmlui: add optional SVG plugin support

### DIFF
--- a/recipes/rmlui/4.x/conandata.yml
+++ b/recipes/rmlui/4.x/conandata.yml
@@ -35,3 +35,6 @@ patches:
     - patch_file: "patches/4.4-fix-cmake-targets-and-config.patch"
       patch_description: "Make external libraries work when provided by conan and remove the generation of a config file"
       patch_type: "conan"
+    - patch_file: "patches/4.4-use-conan-lunasvg.patch"
+      patch_description: "Use Conan CMakeDeps lunasvg target"
+      patch_type: "conan"

--- a/recipes/rmlui/4.x/patches/4.4-use-conan-lunasvg.patch
+++ b/recipes/rmlui/4.x/patches/4.4-use-conan-lunasvg.patch
@@ -1,0 +1,20 @@
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -377,14 +377,12 @@
+ 	
+ 	message("-- Can SVG plugin be enabled - looking for lunasvg library")
+ 
+-	find_package(lunasvg REQUIRED)
+-	
+-	list(APPEND CORE_LINK_LIBS ${LUNASVG_LIBRARIES})
+-	list(APPEND CORE_INCLUDE_DIRS ${LUNASVG_INCLUDE_DIR})
++	find_package(lunasvg REQUIRED CONFIG)
++	list(APPEND CORE_LINK_LIBS lunasvg::lunasvg)
+ 	list(APPEND CORE_PRIVATE_DEFS RMLUI_ENABLE_SVG_PLUGIN)
+ 	
+ 	list(APPEND Core_HDR_FILES ${SVG_HDR_FILES})
+ 	list(APPEND Core_PUB_HDR_FILES ${SVG_PUB_HDR_FILES})
+ 	list(APPEND Core_SRC_FILES ${SVG_SRC_FILES})
+ 
+ 	message("-- Can SVG plugin be enabled - yes - lunasvg library found")
+ endif()


### PR DESCRIPTION
## Summary
- Add `with_svg` option for `rmlui/4.4` to enable the SVG plugin (lunasvg).
- Wire CMake `ENABLE_SVG_PLUGIN` and link against `lunasvg::lunasvg` via CMakeDeps.