### PR TITLE
Removed unneded glibmm dependency from libxmlpp

### DIFF
--- a/recipes/libxmlpp/all/conanfile.py
+++ b/recipes/libxmlpp/all/conanfile.py
@@ -3,7 +3,6 @@ from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.meson import Meson, MesonToolchain
 from conan.tools.gnu import PkgConfigDeps
-from conan.tools.scm import Version
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.microsoft import is_msvc
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, rmdir, rename, get, rm, replace_in_file


### PR DESCRIPTION
### Summary
Changes to recipe:  **libxmlpp**

#### Motivation

Fix https://github.com/conan-io/conan-center-index/issues/29209 

#### Details

As described in [upstream documentation](https://libxmlplusplus.github.io/libxmlplusplus/), `libxmlpp > 5` does no longer depends on `glibmm`.

> libxml++-5.0: Does not depend on glibmm, is not as good at handling UTF-8 strings, has fewer dependencies.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
