### PR TITLE
ktx: Backport fix for newer compilers

### DIFF
--- a/recipes/ktx/all/conandata.yml
+++ b/recipes/ktx/all/conandata.yml
@@ -9,6 +9,7 @@ patches:
   "4.3.2":
     - patch_file: "patches/4.3.2/0001-objutil-cxx-std.patch"
     - patch_file: "patches/4.3.2/0004-unvendor-dependencies.patch"
+    - patch_file: "patches/4.3.2/0005-missing-include.patch"
   "4.0.0":
     - patch_file: "patches/4.0.0/0001-objutil-cxx-std.patch"
     - patch_file: "patches/4.0.0/0002-lodepng-no-export-symbols.patch"

--- a/recipes/ktx/all/patches/4.3.2/0005-missing-include.patch
+++ b/recipes/ktx/all/patches/4.3.2/0005-missing-include.patch
@@ -1,0 +1,18 @@
+https://github.com/KhronosGroup/KTX-Software/pull/936
+
+---
+ tools/imageio/imageio.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/tools/imageio/imageio.h b/tools/imageio/imageio.h
+index 02e6ab5e38..83c1331b32 100644
+--- a/tools/imageio/imageio.h
++++ b/tools/imageio/imageio.h
+@@ -37,6 +37,7 @@
+ #include <string>
+ #include <sstream>
+ #include <vector>
++#include <memory>
+ 
+ #include <fmt/format.h>
+ #include <math.h>


### PR DESCRIPTION
A missing header was generating build failures in newer compilers.

Note that this commit is already part of a released version, but as the work to get the new version seems not to be balanced by a user need (we would need to re-unvendorize dependencies and patches), backporitng this as a way to unblock the user seems like a faster solution for now

Closes https://github.com/conan-io/conan-center-index/issues/29222, where the proposed patch comes directly from the linked PR

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
