### PR TITLE
Fix compatibility with CMake 4.0

### DIFF
--- a/recipes/marisa/all/patches/0001-add-cmake.patch
+++ b/recipes/marisa/all/patches/0001-add-cmake.patch
@@ -4,7 +4,7 @@ index 0000000..c7e4c0e
 --- /dev/null
 +++ b/CMakeLists.txt
 @@ -0,0 +1,114 @@
-+cmake_minimum_required(VERSION 3.1)
++cmake_minimum_required(VERSION 3.5)
 +project(marisa CXX)
 +
 +include(GNUInstallDirs)


### PR DESCRIPTION
Enable CMake 4.0 to build this recipe


### Summary
Changes to recipe:  **marisa/0.2.6**

#### Motivation
CMake 4.0 dropped compatibility with versions <3.5. `cmake_minimum_required` needs to be updated to >= 3.5 to build with CMake 4.0.

#### Details
Updates `cmake_minimum_required` to 3.5.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
