### PR TITLE
libraw: Bump version to 0.21.5b

### DIFF
--- a/recipes/libraw/all/conandata.yml
+++ b/recipes/libraw/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "0.21.4":
-    url: "https://github.com/LibRaw/LibRaw/archive/0.21.4.tar.gz"
-    sha256: "8baeb5253c746441fadad62e9c5c43ff4e414e41b0c45d6dcabccb542b2dff4b"
+  "0.21.5b":
+    url: "https://github.com/LibRaw/LibRaw/archive/0.21.5b.tar.gz"
+    sha256: "f60e8377dec42e50f59ed2860ba00bcb59773e04afbf7bd6bd9367ac3529e0e8"
   "0.21.2":
     url: "https://github.com/LibRaw/LibRaw/archive/0.21.2.tar.gz"
     sha256: "7ac056e0d9e814d808f6973a950bbf45e71b53283eed07a7ea87117a6c0ced96"

--- a/recipes/libraw/config.yml
+++ b/recipes/libraw/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "0.21.4":
+  "0.21.5b":
     folder: all
   "0.21.2":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **libraw/0.21.5b**

#### Motivation
A few small fixes since the 0.21.4 version (bugfixes/checks when reading files so might be security-risks mitigated).

#### Details
* https://github.com/LibRaw/LibRaw/compare/0.21.4...0.21.5b
* https://github.com/LibRaw/LibRaw/releases/tag/0.21.5b

(0.21.5 was released just a day before so only small change in the autotools configure script we ignore, so no relevant change between 0.21.5 and 0.21.5b.)


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
