### PR TITLE
net-snmp: Fix transitive headers for openssl

### DIFF
--- a/recipes/net-snmp/all/conanfile.py
+++ b/recipes/net-snmp/all/conanfile.py
@@ -56,7 +56,7 @@ class NetSnmpConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("openssl/[>=1.1 <4]")
+        self.requires("openssl/[>=1.1 <4]", transitive_headers=True)
         self.requires("pcre/8.45")
         self.requires("zlib/[>=1.2.11 <2]")
 
@@ -75,7 +75,7 @@ class NetSnmpConan(ConanFile):
             self.tool_requires("automake/1.16.5")
             self.tool_requires("libtool/2.4.7")
         if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
-            self.tool_requires("pkgconf/2.2.0")
+            self.tool_requires("pkgconf/[>=2.2.0 <3]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/net-snmp/all/test_package/test_package.c
+++ b/recipes/net-snmp/all/test_package/test_package.c
@@ -1,5 +1,7 @@
 #include <net-snmp/net-snmp-config.h>
 #include <net-snmp/library/snmp_api.h>
+#include <net-snmp/net-snmp-includes.h>
+#include <net-snmp/transform_oids.h>
 #include <stddef.h>
 
 int main()

--- a/recipes/net-snmp/all/test_package/test_package.c
+++ b/recipes/net-snmp/all/test_package/test_package.c
@@ -1,7 +1,6 @@
 #include <net-snmp/net-snmp-config.h>
 #include <net-snmp/library/snmp_api.h>
 #include <net-snmp/net-snmp-includes.h>
-#include <net-snmp/transform_oids.h>
 #include <stddef.h>
 
 int main()


### PR DESCRIPTION
Fixes transitive header issues. Before this fixes, you'd get

```
[1/2] Building C object CMakeFiles/test_package.dir/test_package.c.o
FAILED: [code=1] CMakeFiles/test_package.dir/test_package.c.o 
/Users/ruben/.conan2/p/b/ccach31b575140aeb2/p/bin/ccache /usr/bin/cc -DPCRE_STATIC=1 -isystem /Users/ruben/.conan2/p/b/net-s59081d1b16d2f/p/include -isystem /Users/ruben/.conan2/p/opensca6fa8a584c20/p/include -isystem /Users/ruben/.conan2/p/zlibf7af9c3d20ae6/p/include -O3 -DNDEBUG -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -MD -MT CMakeFiles/test_package.dir/test_package.c.o -MF CMakeFiles/test_package.dir/test_package.c.o.d -o CMakeFiles/test_package.dir/test_package.c.o -c /Users/ruben/coding/conan-center-index/recipes/net-snmp/all/test_package/test_package.c
/Users/ruben/coding/conan-center-index/recipes/net-snmp/all/test_package/test_package.c:4:10: fatal error: 'net-snmp/transform_oids.h' file not found
    4 | #include <net-snmp/transform_oids.h>
```

with the updated test_package. After, the same test runs correctly


Closes https://github.com/conan-io/conan-center-index/issues/29236

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
