### PR TITLE
Replace obsolete URL with canonical sourceforge URL for libpfm4.

### DIFF
--- a/recipes/libpfm4/all/conandata.yml
+++ b/recipes/libpfm4/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "4.13.0":
-    url: "https://versaweb.dl.sourceforge.net/project/perfmon2/libpfm4/libpfm-4.13.0.tar.gz"
+    url: "https://downloads.sourceforge.net/project/perfmon2/libpfm4/libpfm-4.13.0.tar.gz"
     sha256: "d18b97764c755528c1051d376e33545d0eb60c6ebf85680436813fa5b04cc3d1"
   "4.12.0":
-    url: "https://versaweb.dl.sourceforge.net/project/perfmon2/libpfm4/libpfm-4.12.0.tar.gz"
+    url: "https://downloads.sourceforge.net/project/perfmon2/libpfm4/libpfm-4.12.0.tar.gz"
     sha256: "4b0c1f53f39a61525b69bebf532c68040c1b984d7544a8ae0844b13cd91e1ee4"


### PR DESCRIPTION
### Summary
Changes to recipe:  **libpfm4/4.13.0** fixes #29238 

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
The recipe for libpfm4 had stopped working for my project and I noticed the broken link. 

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
Replaced the the fixed URL with the canonical Sourceforge, which would redirect as needed. I used curl to check redirects and then managed to build the library from the recipe correctly (before I had the unresolved host problem).

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
