### PR TITLE
roaring: add version 4.5.0

### DIFF
--- a/recipes/roaring/all/conandata.yml
+++ b/recipes/roaring/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.5.0":
+    url: "https://github.com/RoaringBitmap/CRoaring/archive/refs/tags/v4.5.0.tar.gz"
+    sha256: "8f945ad82ce1be195c899c57e0734a5c0ea2685c3127bf9033d4391d054f94ab"
   "4.2.1":
     url: "https://github.com/RoaringBitmap/CRoaring/archive/refs/tags/v4.2.1.tar.gz"
     sha256: "3514728e9eb8c90dbc00a9e337302eb458c65be2f9501a3e882d051599c4a74c"

--- a/recipes/roaring/config.yml
+++ b/recipes/roaring/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.5.0":
+    folder: all
   "4.2.1":
     folder: all
   "4.2.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **roaring/4.5.0**

#### Motivation
4.2.1 was released in 2024.

#### Details
https://github.com/RoaringBitmap/CRoaring/releases/tag/v4.5.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
