### PR TITLE
d3d12-memory-allocator: fix postfix library depending on build type

### DIFF
--- a/recipes/d3d12-memory-allocator/all/conanfile.py
+++ b/recipes/d3d12-memory-allocator/all/conanfile.py
@@ -34,7 +34,7 @@ class D3D12MemoryAllocatorConan(ConanFile):
     def source(self):
         get(self, **self.conan_data["sources"][self.version],
             destination=self.source_folder, strip_root=True)
-    
+
     def build_requirements(self):
         self.tool_requires("cmake/[>=3.25]")
 
@@ -58,4 +58,5 @@ class D3D12MemoryAllocatorConan(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "D3D12MemoryAllocator")
         self.cpp_info.set_property("cmake_target_name", "GPUOpen::D3D12MemoryAllocator")
-        self.cpp_info.libs = ["D3D12MA"]
+        postfix = {"Release": "", "Debug": "d", "RelWithDebInfo": "rd", "MinSizeRel": "s"}[str(self.settings.build_type)]
+        self.cpp_info.libs = [f"D3D12MA{postfix}"]


### PR DESCRIPTION
### Summary
Changes to recipe:  **d3d12-memory-allocator/3.0.1**

#### Motivation
Fix https://github.com/conan-io/conan-center-index/issues/29071

#### Details

Library name depends on build type as specified in the [upstream CMakeLists](https://github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator/blob/c06cd9a6ec4578016aadf650af104c4055ec609a/src/CMakeLists.txt#L24-L26).


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
