### PR TITLE
entt: Add version 3.16.0

### DIFF
--- a/recipes/entt/3.x.x/conandata.yml
+++ b/recipes/entt/3.x.x/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.16.0":
+    url: "https://github.com/skypjack/entt/archive/refs/tags/v3.16.0.tar.gz"
+    sha256: "7d7b4037b737992342049ffab14f22fa10243e01664f8c3a0657aa247ac52f71"
   "3.15.0":
     url: "https://github.com/skypjack/entt/archive/refs/tags/v3.15.0.tar.gz"
     sha256: "01466fcbf77618a79b62891510c0bbf25ac2804af5751c84982b413852234d66"

--- a/recipes/entt/config.yml
+++ b/recipes/entt/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.16.0":
+    folder: 3.x.x
   "3.15.0":
     folder: 3.x.x
   "3.14.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **entt/3.16.0**

#### Motivation
New version published
https://github.com/skypjack/entt/compare/v3.15.0...v3.16.0

#### Details
- config.yml and conandata.yml point to the newly created entt/3.16.0


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
