### PR TITLE
libx264: Add latest commit as new version

### DIFF
--- a/recipes/libx264/all/conandata.yml
+++ b/recipes/libx264/all/conandata.yml
@@ -1,13 +1,10 @@
 sources:
+  "cci.20250910":
+    url: "https://code.videolan.org/videolan/x264/-/archive/0480cb05fa188d37ae87e8f4fd8f1aea3711f7ee/x264-0480cb05fa188d37ae87e8f4fd8f1aea3711f7ee.tar.bz2"
+    sha256: "f05c59f2e83d494c36307025dca2d3afc6b4d185f3a3453d06cc4fecd7094057"
   "cci.20240224":
     url: "https://code.videolan.org/videolan/x264/-/archive/7241d020118bb09cc0ad119d7bc9f630a1caad10/x264-7241d020118bb09cc0ad119d7bc9f630a1caad10.tar.bz2"
     sha256: "5417c167a69cc19db044c227163f9b9b1dface9fca361a3e83d5417f8e304dd6"
   "cci.20220602":
     url: "https://code.videolan.org/videolan/x264/-/archive/baee400fa9ced6f5481a728138fed6e867b0ff7f/x264-baee400fa9ced6f5481a728138fed6e867b0ff7f.tar.bz2"
     sha256: "ce6623b8b289765daee04a297c2fd1a293cb2565a1749c76d66c8d72c7ddc1ab"
-  "20191217":
-    url: "https://download.videolan.org/pub/videolan/x264/snapshots/x264-snapshot-20191217-2245.tar.bz2"
-    sha256: "0bb67d095513391e637b3b47e8efc3ba4603c3844f1b4c2690f4d36da7763055"
-  "20190605":
-    url: "http://download.videolan.org/pub/videolan/x264/snapshots/x264-snapshot-20190605-2245.tar.bz2"
-    sha256: "c75203ef4759e4d7bc38e686b156c54c43b78edc73123c0b25db5224758bd1fc"

--- a/recipes/libx264/config.yml
+++ b/recipes/libx264/config.yml
@@ -1,9 +1,7 @@
 versions:
+  "cci.20250910":
+    folder: all
   "cci.20240224":
     folder: all
   "cci.20220602":
-    folder: all
-  "20191217":
-    folder: all
-  "20190605":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **libx264/cci.20250910**

#### Motivation
A number of improvements have happened since the last release we have. General optimizations and work on architecture support/improvements - especially arm64 based systems have been improved according to the commit history.

#### Details
The videolan-project doesn't tag any versions, so I just used the latest commit.

https://code.videolan.org/videolan/x264/-/compare/7241d020118bb09cc0ad119d7bc9f630a1caad10...0480cb05fa188d37ae87e8f4fd8f1aea3711f7ee?from_project_id=536

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
