### PR TITLE
drogon: Package missing CMake module files

### DIFF
--- a/recipes/drogon/all/conanfile.py
+++ b/recipes/drogon/all/conanfile.py
@@ -3,7 +3,7 @@ import os
 from conan import ConanFile
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import cmake_layout, CMakeToolchain, CMakeDeps, CMake
-from conan.tools.files import copy, get, rmdir, rm
+from conan.tools.files import copy, get, rm
 from conan.tools.scm import Version
 from conan.tools.microsoft import is_msvc
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **drogon/[*]**

#### Motivation

fix #24189

#### Maintainer Notes

Originally, this PR brought more changes, including related to #11037. However, the #11037 is fixed now by #29538. Still, this PR preserves the CMake module files as originally intended. 

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan
