### PR TITLE
ompl: add recipe for version 1.7.0

### DIFF
--- a/recipes/ompl/all/conandata.yml
+++ b/recipes/ompl/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.7.0":
+    url: "https://github.com/ompl/ompl/archive/1.7.0.tar.gz"
+    sha256: "e2e2700dfb0b4c2d86e216736754dd1b316bd6a46cc8818e1ffcbce4a388aca9"

--- a/recipes/ompl/all/conandata.yml
+++ b/recipes/ompl/all/conandata.yml
@@ -2,3 +2,7 @@ sources:
   "2.0.0":
     url: "https://github.com/ompl/ompl/releases/download/2.0.0/ompl-2.0.0-Source.tar.gz"
     sha256: "7b6032ca69d0c69280ce3872737c1c6ff6105cfa38769befb57dd15610c90f75"
+  "1.7.0":
+    # The 1.7.0 release does not have library sources, only app
+    url: "https://github.com/ompl/ompl/archive/1.7.0.tar.gz"
+    sha256: "e2e2700dfb0b4c2d86e216736754dd1b316bd6a46cc8818e1ffcbce4a388aca9"

--- a/recipes/ompl/all/conandata.yml
+++ b/recipes/ompl/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "2.0.0":
-    url: "https://github.com/ompl/ompl/archive/2.0.0.tar.gz"
-    sha256: "643d3218aca72ea9007daea0b5871d534b9cd3239d2e4cc140b152be86c8eb2c"
+    url: "https://github.com/ompl/ompl/releases/download/2.0.0/ompl-2.0.0-Source.tar.gz"
+    sha256: "7b6032ca69d0c69280ce3872737c1c6ff6105cfa38769befb57dd15610c90f75"

--- a/recipes/ompl/all/conandata.yml
+++ b/recipes/ompl/all/conandata.yml
@@ -1,7 +1,4 @@
 sources:
-  "2.0.0":
-    url: "https://github.com/ompl/ompl/releases/download/2.0.0/ompl-2.0.0-Source.tar.gz"
-    sha256: "7b6032ca69d0c69280ce3872737c1c6ff6105cfa38769befb57dd15610c90f75"
   "1.7.0":
     # The 1.7.0 release does not have library sources, only app
     url: "https://github.com/ompl/ompl/archive/1.7.0.tar.gz"

--- a/recipes/ompl/all/conandata.yml
+++ b/recipes/ompl/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "1.7.0":
-    url: "https://github.com/ompl/ompl/archive/1.7.0.tar.gz"
-    sha256: "e2e2700dfb0b4c2d86e216736754dd1b316bd6a46cc8818e1ffcbce4a388aca9"
+  "2.0.0":
+    url: "https://github.com/ompl/ompl/archive/2.0.0.tar.gz"
+    sha256: "643d3218aca72ea9007daea0b5871d534b9cd3239d2e4cc140b152be86c8eb2c"

--- a/recipes/ompl/all/conanfile.py
+++ b/recipes/ompl/all/conanfile.py
@@ -1,0 +1,144 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
+from conan.tools.files import get, copy, rmdir
+from conan.tools.build import check_min_cppstd
+import os
+
+required_conan_version = ">=1.53.0"
+
+
+class OmplConan(ConanFile):
+    name = "ompl"
+    description = "The Open Motion Planning Library (OMPL)"
+    license = "BSD-3-Clause"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://ompl.kavrakilab.org/"
+    topics = ("motion-planning", "robotics", "path-planning")
+
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+
+    # Add options for optional dependencies
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "with_flann": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "with_flann": True,  # Enabled by default, can be disabled by user
+    }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("eigen/3.4.0", transitive_headers=True)
+
+        # Configure Boost: Disable Python and other unused components to prevent build errors
+        self.requires(
+            "boost/1.83.0",
+            transitive_headers=True,
+            options={
+                # Explicitly disabled components (Not needed by OMPL)
+                "without_python": True,
+                "without_mpi": True,
+                "without_test": True,
+                "without_contract": True,
+                "without_stacktrace": True,
+                "without_fiber": True,
+                "without_log": True,
+                "without_wave": True,
+                "without_nowide": True,
+                "without_json": True,
+                "without_url": True,
+                "without_locale": True,
+                "without_context": True,
+                "without_coroutine": True,
+                "without_timer": True,
+                "without_type_erasure": True,
+                # NOTE: We KEEP these implicitly enabled by NOT listing them above:
+                # - filesystem
+                # - graph
+                # - math
+                # - program_options
+                # - serialization
+                # - system
+                # - iostreams (often a transitive dependency for serialization/fs)
+                # - chrono (required by thread)
+                # - container (required by thread)
+                # - thread (needed by system/graph)
+            },
+        )
+
+        if self.options.with_flann:
+            self.requires("flann/1.9.2")
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, 17)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.cache_variables["OMPL_BUILD_DEMOS"] = False
+        tc.cache_variables["OMPL_BUILD_TESTS"] = False
+        tc.cache_variables["OMPL_BUILD_PYBINDINGS"] = False
+        tc.cache_variables["OMPL_BUILD_PYTESTS"] = False
+        tc.cache_variables["OMPL_REGISTRATION"] = False
+        tc.cache_variables["OMPL_VERSIONED_INSTALL"] = False
+
+        # Handle Optional Dependencies in CMake
+        # If with_flann is False, explicitly disable finding the package
+        if not self.options.with_flann:
+            tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_flann"] = True
+
+        # Disable others not currently supported in this recipe
+        tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_castxml"] = True
+        tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_Doxygen"] = True
+        tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_spot"] = True
+        tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_Triangle"] = True
+
+        tc.generate()
+
+        cd = CMakeDeps(self)
+        cd.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(
+            self,
+            "LICENSE",
+            src=self.source_folder,
+            dst=os.path.join(self.package_folder, "licenses"),
+        )
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "ompl")
+        self.cpp_info.set_property("cmake_target_name", "ompl::ompl")
+        self.cpp_info.set_property("pkg_config_name", "ompl")
+
+        self.cpp_info.libs = ["ompl"]
+
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs = ["m", "pthread"]

--- a/recipes/ompl/all/conanfile.py
+++ b/recipes/ompl/all/conanfile.py
@@ -92,9 +92,17 @@ class OmplConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
+
+        # Enforce CMake Policy CMP0077 to NEW.
+        # This prevents internal 'option()' command overwrite back to default."
+        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
+
+        # Respect the shared option defined in this recipe.
+        tc.cache_variables["BUILD_SHARED_LIBS"] = self.options.shared
+
+        tc.cache_variables["OMPL_BUILD_PYBINDINGS"] = False
         tc.cache_variables["OMPL_BUILD_DEMOS"] = False
         tc.cache_variables["OMPL_BUILD_TESTS"] = False
-        tc.cache_variables["OMPL_BUILD_PYBINDINGS"] = False
         tc.cache_variables["OMPL_BUILD_PYTESTS"] = False
         tc.cache_variables["OMPL_REGISTRATION"] = False
         tc.cache_variables["OMPL_VERSIONED_INSTALL"] = False

--- a/recipes/ompl/all/conanfile.py
+++ b/recipes/ompl/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
-from conan.tools.files import get, copy, rmdir
+from conan.tools.files import get, copy, rmdir, replace_in_file
 from conan.tools.build import check_min_cppstd
 import os
 
@@ -124,6 +124,18 @@ class OmplConan(ConanFile):
         cd.generate()
 
     def build(self):
+        # PATCH: The OMPL CMakeLists.txt hardcodes "SHARED" for non-MSVC builds
+        # Remove this keyword so CMake respects Conan's "shared=False" setting
+        ompl_cmake_path = os.path.join(
+            self.source_folder, "src", "ompl", "CMakeLists.txt"
+        )
+        replace_in_file(
+            self,
+            ompl_cmake_path,
+            "add_library(ompl SHARED ${OMPL_SOURCE_CODE})",
+            "add_library(ompl ${OMPL_SOURCE_CODE})",
+        )
+
         cmake = CMake(self)
         cmake.configure()
         cmake.build()

--- a/recipes/ompl/all/conanfile.py
+++ b/recipes/ompl/all/conanfile.py
@@ -1,10 +1,12 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
-from conan.tools.files import get, copy, rmdir, replace_in_file
+from conan.tools.files import get, copy, rmdir
 from conan.tools.build import check_min_cppstd
+from conan.tools.microsoft import is_msvc
+from conan.errors import ConanInvalidConfiguration
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.1"
 
 
 class OmplConan(ConanFile):
@@ -14,151 +16,61 @@ class OmplConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://ompl.kavrakilab.org/"
     topics = ("motion-planning", "robotics", "path-planning")
-
     package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
-
-    # Add options for optional dependencies
-    options = {
-        "shared": [True, False],
-        "fPIC": [True, False],
-        "with_flann": [True, False],
-    }
-    default_options = {
-        "shared": False,
-        "fPIC": True,
-        "with_flann": True,  # Enabled by default, can be disabled by user
-    }
-
-    def config_options(self):
-        if self.settings.os == "Windows":
-            del self.options.fPIC
-
-    def configure(self):
-        if self.options.shared:
-            self.options.rm_safe("fPIC")
+    options = {"shared": [True, False], "fPIC": [True, False]}
+    default_options = {"shared": False, "fPIC": True}
+    implements = ["auto_shared_fpic"]
 
     def layout(self):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("eigen/3.4.0", transitive_headers=True)
-
-        # Configure Boost: Disable Python and other unused components to prevent build errors
-        self.requires(
-            "boost/1.83.0",
-            transitive_headers=True,
-            options={
-                # Explicitly disabled components (Not needed by OMPL)
-                "without_python": True,
-                "without_mpi": True,
-                "without_test": True,
-                "without_contract": True,
-                "without_stacktrace": True,
-                "without_fiber": True,
-                "without_log": True,
-                "without_wave": True,
-                "without_nowide": True,
-                "without_json": True,
-                "without_url": True,
-                "without_locale": True,
-                "without_context": True,
-                "without_coroutine": True,
-                "without_timer": True,
-                "without_type_erasure": True,
-                # NOTE: We KEEP these implicitly enabled by NOT listing them above:
-                # - filesystem
-                # - graph
-                # - math
-                # - program_options
-                # - serialization
-                # - system
-                # - iostreams (often a transitive dependency for serialization/fs)
-                # - chrono (required by thread)
-                # - container (required by thread)
-                # - thread (needed by system/graph)
-            },
-        )
-
-        if self.options.with_flann:
-            self.requires("flann/1.9.2")
+        self.requires("eigen/[>=3.4.0 <4]", transitive_headers=True)
+        self.requires("boost/1.88.0", transitive_headers=True)
 
     def validate(self):
-        if self.settings.compiler.get_safe("cppstd"):
-            check_min_cppstd(self, 17)
+        check_min_cppstd(self, 17)
+        if is_msvc(self) and self.options.shared:
+            # INFO https://github.com/ompl/ompl/blob/1.7.0/src/ompl/CMakeLists.txt#L36
+            raise ConanInvalidConfiguration('Only static library is provided for MSVC compiler. Use -o "ompl/*:shared=False"')
+        elif not is_msvc(self) and not self.options.shared:
+            raise ConanInvalidConfiguration('Only shared library is provided for non-MSVC compilers. Use -o "ompl/*:shared=True"')
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)
-
-        # Enforce CMake Policy CMP0077 to NEW.
-        # This prevents internal 'option()' command overwrite back to default."
-        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
-
-        # Respect the shared option defined in this recipe.
-        tc.cache_variables["BUILD_SHARED_LIBS"] = self.options.shared
-
         tc.cache_variables["OMPL_BUILD_PYBINDINGS"] = False
         tc.cache_variables["OMPL_BUILD_DEMOS"] = False
         tc.cache_variables["OMPL_BUILD_TESTS"] = False
         tc.cache_variables["OMPL_BUILD_PYTESTS"] = False
         tc.cache_variables["OMPL_REGISTRATION"] = False
         tc.cache_variables["OMPL_VERSIONED_INSTALL"] = False
-
-        # Handle Optional Dependencies in CMake
-        # If with_flann is False, explicitly disable finding the package
-        if not self.options.with_flann:
-            tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_flann"] = True
-
-        # Disable others not currently supported in this recipe
         tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_castxml"] = True
         tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_Doxygen"] = True
         tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_spot"] = True
         tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_Triangle"] = True
-
+        tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_flann"] = True
         tc.generate()
 
         cd = CMakeDeps(self)
         cd.generate()
 
     def build(self):
-        # PATCH: The OMPL CMakeLists.txt hardcodes "SHARED" for non-MSVC builds
-        # Remove this keyword so CMake respects Conan's "shared=False" setting
-        ompl_cmake_path = os.path.join(
-            self.source_folder, "src", "ompl", "CMakeLists.txt"
-        )
-        replace_in_file(
-            self,
-            ompl_cmake_path,
-            "add_library(ompl SHARED ${OMPL_SOURCE_CODE})",
-            "add_library(ompl ${OMPL_SOURCE_CODE})",
-        )
-
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
 
     def package(self):
-        copy(
-            self,
-            "LICENSE",
-            src=self.source_folder,
-            dst=os.path.join(self.package_folder, "licenses"),
-        )
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
         cmake = CMake(self)
         cmake.install()
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         rmdir(self, os.path.join(self.package_folder, "share"))
-        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
-        self.cpp_info.set_property("cmake_file_name", "ompl")
-        self.cpp_info.set_property("cmake_target_name", "ompl::ompl")
-        self.cpp_info.set_property("pkg_config_name", "ompl")
-
         self.cpp_info.libs = ["ompl"]
-
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs = ["m", "pthread"]

--- a/recipes/ompl/all/conanfile.py
+++ b/recipes/ompl/all/conanfile.py
@@ -36,47 +36,32 @@ class OmplConan(ConanFile):
 
     def validate(self):
         check_min_cppstd(self, 17)
-        if Version(self.version) < "2.0.0":
-            if is_msvc(self) and self.options.shared:
-                # INFO https://github.com/ompl/ompl/blob/1.7.0/src/ompl/CMakeLists.txt#L36
-                raise ConanInvalidConfiguration('Only static library is provided for MSVC compiler. Use -o "ompl/*:shared=False"')
-            elif not is_msvc(self) and not self.options.shared:
-                raise ConanInvalidConfiguration('Only shared library is provided for non-MSVC compilers. Use -o "ompl/*:shared=True"')
-        else:
-            if is_msvc(self):
-                # FIXME: https://github.com/ompl/ompl/issues/1423
-                raise ConanInvalidConfiguration('Does not support MSVC compiler due M_PI missing definition. See https://github.com/ompl/ompl/issues/1423')
+        if is_msvc(self) and self.options.shared:
+            # INFO https://github.com/ompl/ompl/blob/1.7.0/src/ompl/CMakeLists.txt#L36
+            raise ConanInvalidConfiguration('Only static library is provided for MSVC compiler. Use -o "ompl/*:shared=False"')
+        elif not is_msvc(self) and not self.options.shared:
+            raise ConanInvalidConfiguration('Only shared library is provided for non-MSVC compilers. Use -o "ompl/*:shared=True"')
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
         # https://github.com/ompl/ompl/blob/2.0.0/CMakeModules/OMPLCompilerSettings.cmake#L1
-        cmakefile = "CompilerSettings.cmake" if Version(self.version) < "2.0.0" else "OMPLCompilerSettings.cmake"
-        replace_in_file(self, os.path.join(self.source_folder, "CMakeModules", cmakefile), "set(CMAKE_CXX_STANDARD 17)", "")
+        replace_in_file(self, os.path.join(self.source_folder, "CMakeModules", "CompilerSettings.cmake"), "set(CMAKE_CXX_STANDARD 17)", "")
         # https://github.com/ompl/ompl/blob/2.0.0/CMakeModules/OMPLCompilerSettings.cmake#L37
-        replace_in_file(self, os.path.join(self.source_folder, "CMakeModules", cmakefile), "add_definitions(-fPIC)", "")
-        if Version(self.version) < "2.0.0":
-            # INFO: Boost::system moved to header-only
-            replace_in_file(self, os.path.join(self.source_folder, "src", "ompl", "CMakeLists.txt"), "Boost::system", "Boost::headers")
+        replace_in_file(self, os.path.join(self.source_folder, "CMakeModules", "CompilerSettings.cmake"), "add_definitions(-fPIC)", "")
+        # INFO: Boost::system moved to header-only
+        replace_in_file(self, os.path.join(self.source_folder, "src", "ompl", "CMakeLists.txt"), "Boost::system", "Boost::headers")
 
     def generate(self):
         tc = CMakeToolchain(self)
-        if Version(self.version) < "2.0.0":
-            tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_castxml"] = True
-            tc.cache_variables["OMPL_REGISTRATION"] = False
-            tc.cache_variables["OMPL_BUILD_PYTESTS"] = False
-            tc.cache_variables["OMPL_BUILD_PYBINDINGS"] = False
-        else:
-            tc.cache_variables["OMPL_BUILD_SHARED"] = self.options.shared
-            tc.cache_variables["OMPL_BUILD_VAMP"] = False
-            tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_Python"] = True
-            tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_yaml-cpp"] = True
-            tc.cache_variables["OMPL_BUILD_PYTHON_BINDINGS"] = False
-
+        tc.cache_variables["OMPL_REGISTRATION"] = False
+        tc.cache_variables["OMPL_BUILD_PYTESTS"] = False
+        tc.cache_variables["OMPL_BUILD_PYBINDINGS"] = False
         tc.cache_variables["OMPL_BUILD_DEMOS"] = False
         tc.cache_variables["OMPL_BUILD_TESTS"] = False
         tc.cache_variables["OMPL_VERSIONED_INSTALL"] = False
         # INFO: Disable dependencies that are not needed for ompl library
         # github.com/ompl/ompl/blob/2.0.0/CMakeModules/OMPLDependencies.cmake
+        tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_castxml"] = True
         tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_Doxygen"] = True
         tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_spot"] = True
         tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_Triangle"] = True

--- a/recipes/ompl/all/conanfile.py
+++ b/recipes/ompl/all/conanfile.py
@@ -4,7 +4,6 @@ from conan.tools.files import get, copy, rmdir, replace_in_file
 from conan.tools.build import check_min_cppstd
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.microsoft import is_msvc
-from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=2.1"

--- a/recipes/ompl/all/conanfile.py
+++ b/recipes/ompl/all/conanfile.py
@@ -2,6 +2,9 @@ from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
 from conan.tools.files import get, copy, rmdir, replace_in_file
 from conan.tools.build import check_min_cppstd
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.microsoft import is_msvc
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=2.1"
@@ -33,26 +36,47 @@ class OmplConan(ConanFile):
 
     def validate(self):
         check_min_cppstd(self, 17)
+        if Version(self.version) < "2.0.0":
+            if is_msvc(self) and self.options.shared:
+                # INFO https://github.com/ompl/ompl/blob/1.7.0/src/ompl/CMakeLists.txt#L36
+                raise ConanInvalidConfiguration('Only static library is provided for MSVC compiler. Use -o "ompl/*:shared=False"')
+            elif not is_msvc(self) and not self.options.shared:
+                raise ConanInvalidConfiguration('Only shared library is provided for non-MSVC compilers. Use -o "ompl/*:shared=True"')
+        else:
+            if is_msvc(self):
+                # FIXME: https://github.com/ompl/ompl/issues/1423
+                raise ConanInvalidConfiguration('Does not support MSVC compiler due M_PI missing definition. See https://github.com/ompl/ompl/issues/1423')
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
         # https://github.com/ompl/ompl/blob/2.0.0/CMakeModules/OMPLCompilerSettings.cmake#L1
-        replace_in_file(self, os.path.join(self.source_folder, "CMakeModules", "OMPLCompilerSettings.cmake"), "set(CMAKE_CXX_STANDARD 17)", "")
+        cmakefile = "CompilerSettings.cmake" if Version(self.version) < "2.0.0" else "OMPLCompilerSettings.cmake"
+        replace_in_file(self, os.path.join(self.source_folder, "CMakeModules", cmakefile), "set(CMAKE_CXX_STANDARD 17)", "")
         # https://github.com/ompl/ompl/blob/2.0.0/CMakeModules/OMPLCompilerSettings.cmake#L37
-        replace_in_file(self, os.path.join(self.source_folder, "CMakeModules", "OMPLCompilerSettings.cmake"), "add_definitions(-fPIC)", "")
+        replace_in_file(self, os.path.join(self.source_folder, "CMakeModules", cmakefile), "add_definitions(-fPIC)", "")
+        if Version(self.version) < "2.0.0":
+            # INFO: Boost::system moved to header-only
+            replace_in_file(self, os.path.join(self.source_folder, "src", "ompl", "CMakeLists.txt"), "Boost::system", "Boost::headers")
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.cache_variables["OMPL_BUILD_SHARED"] = self.options.shared
-        tc.cache_variables["OMPL_BUILD_PYTHON_BINDINGS"] = False
+        if Version(self.version) < "2.0.0":
+            tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_castxml"] = True
+            tc.cache_variables["OMPL_REGISTRATION"] = False
+            tc.cache_variables["OMPL_BUILD_PYTESTS"] = False
+            tc.cache_variables["OMPL_BUILD_PYBINDINGS"] = False
+        else:
+            tc.cache_variables["OMPL_BUILD_SHARED"] = self.options.shared
+            tc.cache_variables["OMPL_BUILD_VAMP"] = False
+            tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_Python"] = True
+            tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_yaml-cpp"] = True
+            tc.cache_variables["OMPL_BUILD_PYTHON_BINDINGS"] = False
+
         tc.cache_variables["OMPL_BUILD_DEMOS"] = False
         tc.cache_variables["OMPL_BUILD_TESTS"] = False
-        tc.cache_variables["OMPL_BUILD_VAMP"] = False
         tc.cache_variables["OMPL_VERSIONED_INSTALL"] = False
         # INFO: Disable dependencies that are not needed for ompl library
         # github.com/ompl/ompl/blob/2.0.0/CMakeModules/OMPLDependencies.cmake
-        tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_Python"] = True
-        tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_yaml-cpp"] = True
         tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_Doxygen"] = True
         tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_spot"] = True
         tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_Triangle"] = True

--- a/recipes/ompl/all/conanfile.py
+++ b/recipes/ompl/all/conanfile.py
@@ -76,7 +76,8 @@ class OmplConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["ompl"]
-        self.cpp_info.requires = ["eigen::eigen", "boost::headers", "boost::serialization"]
+        self.cpp_info.requires = ["eigen::eigen", "boost::headers", "boost::serialization",
+                                  "boost::math", "boost::graph", "boost::random", "boost::iostreams"]
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs = ["m", "pthread"]
         elif self.settings.os == "Windows":

--- a/recipes/ompl/all/conanfile.py
+++ b/recipes/ompl/all/conanfile.py
@@ -1,9 +1,7 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
-from conan.tools.files import get, copy, rmdir
+from conan.tools.files import get, copy, rmdir, replace_in_file
 from conan.tools.build import check_min_cppstd
-from conan.tools.microsoft import is_msvc
-from conan.errors import ConanInvalidConfiguration
 import os
 
 required_conan_version = ">=2.1"
@@ -26,29 +24,35 @@ class OmplConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("eigen/[>=3.4.0 <4]", transitive_headers=True)
-        self.requires("boost/1.88.0", transitive_headers=True)
+        # ompl/base/spaces/special/SphereStateSpace.h:45 #include <Eigen/Core>
+        # ompl/datastructures/Grid.h:40 #include <Eigen/Core>
+        self.requires("eigen/[>=3.4.0 <5]", transitive_headers=True)
+        # ompl/base/PlannerData.h:48 #include <boost/serialization/access.hpp>
+        # ompl/base/spaces/constraint/AtlasStateSpace.h:48 #include <boost/math/constants/constants.hpp>
+        self.requires("boost/[>=1.85.0 <1.92.0]", transitive_headers=True)
 
     def validate(self):
         check_min_cppstd(self, 17)
-        if is_msvc(self) and self.options.shared:
-            # INFO https://github.com/ompl/ompl/blob/1.7.0/src/ompl/CMakeLists.txt#L36
-            raise ConanInvalidConfiguration('Only static library is provided for MSVC compiler. Use -o "ompl/*:shared=False"')
-        elif not is_msvc(self) and not self.options.shared:
-            raise ConanInvalidConfiguration('Only shared library is provided for non-MSVC compilers. Use -o "ompl/*:shared=True"')
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        # https://github.com/ompl/ompl/blob/2.0.0/CMakeModules/OMPLCompilerSettings.cmake#L1
+        replace_in_file(self, os.path.join(self.source_folder, "CMakeModules", "OMPLCompilerSettings.cmake"), "set(CMAKE_CXX_STANDARD 17)", "")
+        # https://github.com/ompl/ompl/blob/2.0.0/CMakeModules/OMPLCompilerSettings.cmake#L37
+        replace_in_file(self, os.path.join(self.source_folder, "CMakeModules", "OMPLCompilerSettings.cmake"), "add_definitions(-fPIC)", "")
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.cache_variables["OMPL_BUILD_PYBINDINGS"] = False
+        tc.cache_variables["OMPL_BUILD_SHARED"] = self.options.shared
+        tc.cache_variables["OMPL_BUILD_PYTHON_BINDINGS"] = False
         tc.cache_variables["OMPL_BUILD_DEMOS"] = False
         tc.cache_variables["OMPL_BUILD_TESTS"] = False
-        tc.cache_variables["OMPL_BUILD_PYTESTS"] = False
-        tc.cache_variables["OMPL_REGISTRATION"] = False
+        tc.cache_variables["OMPL_BUILD_VAMP"] = False
         tc.cache_variables["OMPL_VERSIONED_INSTALL"] = False
-        tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_castxml"] = True
+        # INFO: Disable dependencies that are not needed for ompl library
+        # github.com/ompl/ompl/blob/2.0.0/CMakeModules/OMPLDependencies.cmake
+        tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_Python"] = True
+        tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_yaml-cpp"] = True
         tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_Doxygen"] = True
         tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_spot"] = True
         tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_Triangle"] = True
@@ -72,5 +76,8 @@ class OmplConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["ompl"]
+        self.cpp_info.requires = ["eigen::eigen", "boost::headers", "boost::serialization"]
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs = ["m", "pthread"]
+        elif self.settings.os == "Windows":
+            self.cpp_info.system_libs = ["psapi", "ws2_32"]

--- a/recipes/ompl/all/test_package/CMakeLists.txt
+++ b/recipes/ompl/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(TestPackage CXX)
+
+find_package(ompl REQUIRED CONFIG)
+
+add_executable(test_package test_package.cpp)
+target_link_libraries(test_package PRIVATE ompl::ompl)

--- a/recipes/ompl/all/test_package/conanfile.py
+++ b/recipes/ompl/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/ompl/all/test_package/conanfile.py
+++ b/recipes/ompl/all/test_package/conanfile.py
@@ -6,7 +6,6 @@ import os
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
 
     def layout(self):
         cmake_layout(self)

--- a/recipes/ompl/all/test_package/test_package.cpp
+++ b/recipes/ompl/all/test_package/test_package.cpp
@@ -1,0 +1,16 @@
+#include <ompl/base/SpaceInformation.h>
+#include <ompl/base/spaces/RealVectorStateSpace.h>
+#include <iostream>
+
+int main() {
+    // Construct a simple 3D state space
+    auto space = std::make_shared<ompl::base::RealVectorStateSpace>(3);
+
+    // Construct a space information instance for this state space
+    ompl::base::SpaceInformation si(space);
+
+    // Simple check to ensure library loaded and objects can be created
+    std::cout << "OMPL Test: State space dimension is " << space->getDimension() << std::endl;
+
+    return 0;
+}

--- a/recipes/ompl/all/test_package/test_package.cpp
+++ b/recipes/ompl/all/test_package/test_package.cpp
@@ -1,16 +1,16 @@
-#include <ompl/base/SpaceInformation.h>
-#include <ompl/base/spaces/RealVectorStateSpace.h>
 #include <iostream>
+#include <memory>
+
+#include <ompl/base/SpaceInformation.h>
+#include <ompl/base/spaces/special/SphereStateSpace.h>
 
 int main() {
-    // Construct a simple 3D state space
-    auto space = std::make_shared<ompl::base::RealVectorStateSpace>(3);
-
-    // Construct a space information instance for this state space
+    auto space = std::make_shared<ompl::base::SphereStateSpace>(1.0);
     ompl::base::SpaceInformation si(space);
+    si.setStateValidityChecker([](const ompl::base::State *) { return true; });
+    si.setup();
 
-    // Simple check to ensure library loaded and objects can be created
-    std::cout << "OMPL Test: State space dimension is " << space->getDimension() << std::endl;
-
+    std::cout << "ompl test_package: space dim=" << space->getDimension()
+              << " state dim=" << si.getStateDimension() << std::endl;
     return 0;
 }

--- a/recipes/ompl/config.yml
+++ b/recipes/ompl/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.7.0":
+    folder: all

--- a/recipes/ompl/config.yml
+++ b/recipes/ompl/config.yml
@@ -1,3 +1,5 @@
 versions:
   "2.0.0":
     folder: all
+  "1.7.0":
+    folder: all

--- a/recipes/ompl/config.yml
+++ b/recipes/ompl/config.yml
@@ -1,5 +1,3 @@
 versions:
-  "2.0.0":
-    folder: all
   "1.7.0":
     folder: all

--- a/recipes/ompl/config.yml
+++ b/recipes/ompl/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.7.0":
+  "2.0.0":
     folder: all


### PR DESCRIPTION
### Summary

Changes to recipe: **ompl/1.7.0** (New Recipe)

#### Motivation

This PR introduces the [Open Motion Planning Library (OMPL)](https://ompl.kavrakilab.org/) to Conan Center.

**What is OMPL?**
OMPL is a standard, widely-used library in robotics and autonomous systems. It consists of state-of-the-art sampling-based motion planning algorithms (such as RRT*, EST, PRM, etc.). It is designed to be the core "solver" for planning paths for rigid bodies and robotic arms. Adding this package fills a significant gap for the robotics community using Conan.

#### Details

This recipe targets the pure C++ core of OMPL 1.7.0.

**Dependencies & Optimization:**
- **Boost (Highly Optimized):** OMPL requires Boost, which can be heavy. To ensure stability on CI runners and faster consumption for users, this recipe explicitly disables unused Boost components via `options` (e.g., `without_python`, `without_mpi`, `without_log`, `without_locale`, `without_fiber`, etc.). It retains only the components explicitly required by OMPL (FileSystem, Graph, Serialization, ProgramOptions, etc.).
- **Eigen:** Linked against `eigen/3.4.0`.
- **Flann:** Exposed as an optional dependency (`with_flann`, default `True`) for nearest-neighbor acceleration.


**Build Configuration:**
* **C++ Standard:** Enforces C++17, as required by OMPL 1.7+.
* **Clean Build:** Explicitly disables OMPL's internal Python bindings, demos, and tests to provide a lightweight, focused C++ library package without requiring a system Python environment.


* **License:** BSD-3-Clause.

---

* [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
* [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
* [ ] If this is a bug fix, please link related issue or provide bug details
* [x] Tested locally with at least one configuration using a recent version of Conan