### PR TITLE
onetbb: fix building on Clang 17+.

### DIFF
--- a/recipes/onetbb/all/conanfile.py
+++ b/recipes/onetbb/all/conanfile.py
@@ -146,6 +146,9 @@ class OneTBBConan(ConanFile):
                     os.path.join(hwloc_package_folder, "bin", "hwloc.dll").replace("\\", "/")
         if self.options.get_safe("build_apple_frameworks"):
             toolchain.variables["TBB_BUILD_APPLE_FRAMEWORKS"] = True
+        if self.settings.compiler == "clang":
+            # Avoid undefined version error on Clang 17+. See: https://github.com/uxlfoundation/oneTBB/issues/1274
+            toolchain.cache_variables["CMAKE_SHARED_LINKER_FLAGS"] = "-Wl,--undefined-version"
         if Version(self.version) <= "2021.10.0":
             toolchain.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5"  # CMake 4 support
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **onetbb/***

#### Motivation
This PR fixes onetbb not building on Clang version 17 and above.

#### Details
Clang 17, or rather its linker LLD [changed default behaviour](https://reviews.llvm.org/D135402) and now throws errors when building onetbb. This PR tells LLD to use the old behaviour.

See the upstream issue:
https://github.com/uxlfoundation/oneTBB/issues/1274

As far as I can tell, there are no relevant issues open on conan-center-index.

Tested on Linux while building for Android:
```bash
conan create onetbb/all/conanfile.py --version 2021.10.0 -b missing -pr=android-14
```
`android-14` profile:
```
include(default)

[settings]
os=Android
os.api_level=34
arch=armv8
compiler=clang
compiler.version=18
compiler.libcxx=c++_shared
compiler.cppstd=20
[conf]
# This is the default when installing google-android-ndk-r27d-installer on Debian
tools.android:ndk_path=/usr/lib/android-sdk/ndk/27.3.13750724/
```
default profile:
```
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=14
os=Linux
[tool_requires]
!cmake/*: cmake/[>=3 <4]
```

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
