### PR TITLE
[spdlog] Fix SPDLOG_WCHAR_CONSOLE CMake variable

### DIFF
--- a/recipes/spdlog/all/conanfile.py
+++ b/recipes/spdlog/all/conanfile.py
@@ -3,7 +3,7 @@ from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
 from conan.tools.files import get, copy, rmdir, replace_in_file, apply_conandata_patches, export_conandata_patches
-from conan.tools.microsoft import check_min_vs, is_msvc, is_msvc_static_runtime
+from conan.tools.microsoft import is_msvc_static_runtime
 from conan.tools.scm import Version
 import os
 


### PR DESCRIPTION
### Summary

Changes to recipe:  **spdlog/1.16**

#### Motivation

fixes #29265

/cc @csbillhardt

#### Details
 
As reported on #29265, there is a typo for the CMake variable `SPDLOG_WCHAR_CONSOLE`: https://github.com/gabime/spdlog/blob/v1.16.0/CMakeLists.txt#L113

This PR fixes that issue and replaces `CMakeToolchain` to use `cache_variables` instead of `variables` as before. 


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
