### PR TITLE
[mysql-connector-cpp] Fix library installation for Debug build type

### DIFF
--- a/recipes/mysql-connector-cpp/all/conanfile.py
+++ b/recipes/mysql-connector-cpp/all/conanfile.py
@@ -118,10 +118,10 @@ class MysqlConnectorCppConan(ConanFile):
             if is_msvc_static_runtime(self):
                 lib += "-mt"
         self.cpp_info.libs = [lib]
+        self.cpp_info.libdirs = ["lib"] if self.settings.build_type == "Release" else [os.path.join("lib", "debug")]
 
         if self.settings.os == "Windows":
-            libdirs = [os.path.join("lib", "vs14") if self.settings.build_type == "Release" else os.path.join("lib", "debug", "vs14")]
-            self.cpp_info.libdirs = libdirs
+            self.cpp_info.libdirs = [os.path.join("lib", "vs14")] if self.settings.build_type == "Release" else [os.path.join("lib", "debug", "vs14")]
             self.cpp_info.bindirs = ["lib"]
             self.cpp_info.system_libs.extend(["dnsapi", "ws2_32"])
         if self.settings.os in ["Linux", "FreeBSD"]:


### PR DESCRIPTION
### Summary
Changes to recipe:  **mysql-connector-cpp/9.2.0**

#### Motivation

fixes #29253

/cc @esswl

#### Details

When installing this project on Windows + Debug, it uses a `debug` as part of the library path: https://github.com/mysql/mysql-connector-cpp/blob/9.2.0/mysql-concpp-config.cmake.in#L287

The result will be the following when installing the package:

```
mysql-connector-cpp/9.2.0: Package '94ebe6b8cf541fa37633f8ce1fb7d874623d05e8' built
mysql-connector-cpp/9.2.0: Build folder C:\Users\uilia\.conan2\p\b\mysqlda6a74e4f77b6\b\build
mysql-connector-cpp/9.2.0: Generating the package
mysql-connector-cpp/9.2.0: Packaging in folder C:\Users\uilia\.conan2\p\b\mysqlda6a74e4f77b6\p
mysql-connector-cpp/9.2.0: Calling package()
mysql-connector-cpp/9.2.0: Running CMake.install()
mysql-connector-cpp/9.2.0: RUN: cmake --install "C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/b/build" --config Debug --prefix "C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p"
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/lib/debug/vs14/mysqlcppconnx-static.lib
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/./INFO_SRC
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/./INFO_BIN
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/./mysql-concpp-config.cmake
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/./mysql-concpp-config-version.cmake
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/include/mysqlx/common_constants.h
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/include/mysqlx/common.h
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/include/mysqlx/xapi.h
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/include/mysqlx/xdevapi.h
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/include/mysqlx/common/api.h
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/include/mysqlx/common/error.h
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/include/mysqlx/common/op_if.h
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/include/mysqlx/common/settings.h
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/include/mysqlx/common/util.h
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/include/mysqlx/common/value.h
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/include/mysqlx/devapi/common.h
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/include/mysqlx/devapi/error.h
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/include/mysqlx/devapi/row.h
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/include/mysqlx/devapi/result.h
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/include/mysqlx/devapi/executable.h
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/include/mysqlx/devapi/document.h
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/include/mysqlx/devapi/settings.h
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/include/mysqlx/devapi/crud.h
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/include/mysqlx/devapi/collection_crud.h
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/include/mysqlx/devapi/table_crud.h
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/include/mysqlx/devapi/collations.h
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/include/mysqlx/devapi/mysql_charsets.h
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/include/mysqlx/devapi/mysql_collations.h
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/include/mysqlx/devapi/detail/error.h
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/include/mysqlx/devapi/detail/row.h
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/include/mysqlx/devapi/detail/result.h
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/include/mysqlx/devapi/detail/settings.h
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/include/mysqlx/devapi/detail/session.h
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/include/mysqlx/devapi/detail/crud.h
-- Installing: C:/Users/uilia/.conan2/p/b/mysqlda6a74e4f77b6/p/include/mysqlx/version_info.h
```

On Linux the same occurs, by adding debug as a folder suffix. Both full build logs can be checked with this patch applied:

- Linux + amd64 + GCC11 + Debug + Static: [mysql-connector-cpp-9.2.0-linux-amd64-gcc11-debug-static.log](https://github.com/user-attachments/files/24432855/mysql-connector-cpp-9.2.0-linux-amd64-gcc11-debug-static.log)
- Windows + amd64 + msvc194 + Debug + Static: [mysql-connector-cpp-9.2.0-windows-amd64-msvc194-debug-static.log](https://github.com/user-attachments/files/24432854/mysql-connector-cpp-9.2.0-windows-amd64-msvc194-debug-static.log)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
