### PR TITLE
Fix python lib detection

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1010,8 +1010,8 @@ class BoostConan(ConanFile):
             libdir = os.path.join(os.path.dirname(libdest), "libs")
 
         candidates = [ldlibrary, library]
-        library_prefixes = [""] if is_msvc(self) else ["", "lib"]
-        library_suffixes = [".lib"] if is_msvc(self) else [".so", ".dll.a", ".a"]
+        library_prefixes = [""] if is_msvc(self) or self._is_clang_cl else ["", "lib"]
+        library_suffixes = [".lib"] if is_msvc(self) or self._is_clang_cl else [".so", ".dll.a", ".a"]
         if with_dyld:
             library_suffixes.insert(0, ".dylib")
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **boost**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
https://github.com/conan-io/conan-center-index/issues/29292

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
Allow the python libs detection to detect windows type libraries when compiling with clang (was only msvc)


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
