### PR TITLE
[Boost] Fix expected libraries for boost cobalt

### DIFF
--- a/recipes/boost/all/dependencies/dependencies-1.90.0.yml
+++ b/recipes/boost/all/dependencies/dependencies-1.90.0.yml
@@ -40,8 +40,6 @@ dependencies:
   cobalt:
   - container
   - context
-  cobalt_io:
-  - cobalt
   container: []
   context: []
   contract:
@@ -167,8 +165,8 @@ libs:
   - boost_chrono
   cobalt:
   - boost_cobalt
-  cobalt_io:
-  - boost_cobalt_io
+  - boost_cobalt_io_ssl
+  - boost_cobalt_io 
   container:
   - boost_container
   context:


### PR DESCRIPTION
### Summary
Changes to recipe:  **boost/1.90.0**

#### Motivation
When I try to build boost on my computer I get the error:

> ERROR: boost/1.90.0: Error in package_info() method, line 2024
	raise ConanException(f"These libraries were built, but were not used in any boost module: {non_used}")
	ConanException: These libraries were built, but were not used in any boost module: {'boost_cobalt_io_ssl'}


#### Details
While creating the library boost-cobalt, the two libraries boost-cobalt-io and boost-cobalt-io-ssl (if openssl is present) are also created:
cf.
https://github.com/boostorg/cobalt/blame/boost-1.90.0/CMakeLists.txt#L90
https://github.com/boostorg/cobalt/blame/boost-1.90.0/CMakeLists.txt#L118

or the commits
https://github.com/boostorg/cobalt/commit/ee0e7d31295d3c387a773a00b65560e3d679177c
https://github.com/boostorg/cobalt/commit/8f749942f510fe49ff967c69aadd3eadde6c5f70

My problem was solved by adding these libraries to the list of libraries conan expects to be created if cobalt is built.

Surprisingly, I was able to build boost 1.89.0 which seems to have the same library structure.

I tested this on Linux (Ubuntu 24.04) with gcc-14.
---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
