### PR TITLE
Qt5: fix separate iOS build

### DIFF
--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -793,6 +793,11 @@ class QtConan(ConanFile):
             args += ["-no-framework"]
             if cross_building(self):
                 args.append(f"QMAKE_APPLE_DEVICE_ARCHS={to_apple_arch(self)}")
+        elif is_apple_os(self):
+            sdk = str(self.settings.os.sdk)
+            args += [f"-sdk {sdk}"]
+            if sdk.endswith("simulator"):
+                args += [f"QMAKE_APPLE_SIMULATOR_ARCHS={to_apple_arch(self)}"]
         elif self.settings.os == "Android":
             args += [f"-android-ndk-platform android-{self.settings.os.api_level}"]
             args += [f"-android-abis {android_abi(self)}"]


### PR DESCRIPTION
### Summary
Changes to recipe:  **qt/5.15.x**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
ensures that Qt 5 is built only for platform defined by the host profile

I think it fixes #28809

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
By default Qt 5 for iOS is built for both x86_64 simulator and arm64 device resulting in fat static libs. The `-sdk` config param selects platform (device / simulator) and `QMAKE_APPLE_SIMULATOR_ARCHS` variable selects simulator architecture.

Without this change I've faced Qt build error on an Apple Silicon Mac running macOS 15.

The change applies to other Apple non-macOS platforms as well.

Note: it's already possible to have the same behavior without recipe modification using the recipe's `config` option. For example:
- to build only for arm64 simulator, the value would be `-sdk iphonesimulator QMAKE_APPLE_SIMULATOR_ARCHS=arm64`
- to build only for [arm64] device, the value would be `-sdk iphoneos`

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
