### PR TITLE
fltk, 1.4.4: hide font descriptor dtor

### DIFF
--- a/recipes/fltk/all/conandata.yml
+++ b/recipes/fltk/all/conandata.yml
@@ -8,6 +8,7 @@ sources:
 patches:
   "1.4.4":
     - patch_file: "patches/1.4.4-0001-fix-resources.patch"
+    - patch_file: "patches/1.4.4-0002-hide-font-descriptor-dtor.patch"
   "1.3.9":
     - patch_file: "patches/1.3.9-0001-remove-fluid.patch"
     - patch_file: "patches/1.3.9-0002-fix-resources.patch"

--- a/recipes/fltk/all/patches/1.4.4-0002-hide-font-descriptor-dtor.patch
+++ b/recipes/fltk/all/patches/1.4.4-0002-hide-font-descriptor-dtor.patch
@@ -1,0 +1,33 @@
+diff --git a/FL/Fl_Graphics_Driver.H b/FL/Fl_Graphics_Driver.H
+index 1059e12b0..0578447cf 100644
+--- a/FL/Fl_Graphics_Driver.H
++++ b/FL/Fl_Graphics_Driver.H
+@@ -395,7 +395,7 @@ public:
+   Fl_Font_Descriptor *next;
+   Fl_Fontsize size; /**< font size */
+   Fl_Font_Descriptor(const char* fontname, Fl_Fontsize size);
+-  virtual FL_EXPORT ~Fl_Font_Descriptor() {}
++  virtual FL_EXPORT ~Fl_Font_Descriptor(); // {}
+   int ascent, descent;
+   unsigned int listbase;// base of display list, 0 = none
+ };
+diff --git a/src/Fl_Graphics_Driver.cxx b/src/Fl_Graphics_Driver.cxx
+index 1fc645e8c..44a4a4b5a 100644
+--- a/src/Fl_Graphics_Driver.cxx
++++ b/src/Fl_Graphics_Driver.cxx
+@@ -797,6 +797,15 @@ Fl_Font_Descriptor::Fl_Font_Descriptor(const char* name, Fl_Fontsize Size) {
+   size = Size;
+ }
+ 
++// Fl_Font_Descriptor destructor
++// Note: must not be implemented in the header file with FL_EXPORT (#1357)
++// If compiled with FL_DLL defined, the error message would be:
++// "Fl_Font_Descriptor::~Fl_Font_Descriptor()' definition is marked dllimport"
++// Note: In FLTK 1.5 we have a different solution.
++
++Fl_Font_Descriptor::~Fl_Font_Descriptor() {
++}
++
+ Fl_Scalable_Graphics_Driver::Fl_Scalable_Graphics_Driver() : Fl_Graphics_Driver() {
+   line_width_ = 0;
+   fontsize_ = -1;


### PR DESCRIPTION
### Summary
Changes to recipe:  **fltk/1.4.4**

#### Motivation
This one fixes mingw usage of fltk. The patch is taken "as is" from fltk author, [link](https://github.com/fltk/fltk/issues/1357#issuecomment-3711682522)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan
