### PR TITLE
Add crosscompilation support to perf

### DIFF
--- a/recipes/perf/all/test_package/conanfile.py
+++ b/recipes/perf/all/test_package/conanfile.py
@@ -1,13 +1,13 @@
 from conan import ConanFile
-
+from conan.tools.build import can_run
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "VirtualBuildEnv"
     test_type = "explicit"
 
-    def build_requirements(self):
-        self.tool_requires(self.tested_reference_str)
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def test(self):
-        self.run("perf version")
+        if can_run(self):
+            self.run("perf version", env="conanrun")


### PR DESCRIPTION
### Summary
Changes to recipe:  **perf/***

#### Motivation
The current implementation of the perf recipe does not support crosscompilation at all.

#### Details
Similar to the Linux kernel builds, `perf` needs `ARCH` to be set in order to crosscompile. Since it is not being set on the current impl, the builds fail with cryptic errors.

Unfortunately the archs we set on `self.settings.arch` don't match perf's expectations, so I had to come up with a map. This map is likely incomplete, I expect the community to iterate over it eventually. I validated this builds on x86, armv7 and armv8.


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
