### PR TITLE
cpp-httplib: add version 0.30.0

### DIFF
--- a/recipes/cpp-httplib/all/conandata.yml
+++ b/recipes/cpp-httplib/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.30.0":
+    url: "https://github.com/yhirose/cpp-httplib/archive/v0.30.0.tar.gz"
+    sha256: "135adc029364a70d0c1769f60bef8a2cdc7915e2525eb3ec759e2084af7a7e7b"
   "0.29.0":
     url: "https://github.com/yhirose/cpp-httplib/archive/v0.29.0.tar.gz"
     sha256: "4bd78e4f1f7ccc92c7de717321cc6af8305f30ac037cbd2365862ad6bfaefe61"

--- a/recipes/cpp-httplib/config.yml
+++ b/recipes/cpp-httplib/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.30.0":
+    folder: all
   "0.29.0":
     folder: all
   "0.28.0":


### PR DESCRIPTION
### Summary
Changes to recipe: cpp-httplib/0.30.0

#### Motivation
Bump version of cpp-httplib. Bug fixes and improvements, including a [security fix](https://github.com/yhirose/cpp-httplib/security/advisories/GHSA-wpc6-j37r-jcx7).

#### Details
- **Release Notes:** https://github.com/yhirose/cpp-httplib/releases/tag/v0.30.0
- **Full changelog:** https://github.com/yhirose/cpp-httplib/compare/v0.29.0...v0.30.0

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
