### PR TITLE
libpq: Disable non-essential dependencies by default

### DIFF
--- a/recipes/libpq/meson/conanfile.py
+++ b/recipes/libpq/meson/conanfile.py
@@ -40,11 +40,11 @@ class LibpqConan(ConanFile):
         # but this is True by default in upstream
         "with_icu": False,
         "with_zlib": True,
-        "with_zstd": True,
-        "with_libxml2": True,
+        "with_zstd": False,
+        "with_libxml2": False,
         "with_lz4": True,
-        "with_xslt": True,
-        "with_readline": True,
+        "with_xslt": False,
+        "with_readline": False,
         "disable_rpath": False,
     }
 


### PR DESCRIPTION
This helps build for mingw etc ([mingw-shared.txt](https://github.com/user-attachments/files/24525131/log.txt)) and makes sure we're not compiling usually-unused features by default.

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
