### PR TITLE
Added recipe: libvpl 2.17.0

### DIFF
--- a/recipes/libvpl/all/conandata.yml
+++ b/recipes/libvpl/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2.15.0":
+    url: "https://github.com/intel/libvpl/archive/v2.15.0.tar.gz"
+    sha256: "7218C3B8206B123204C3827CE0CF7C008D5C693C1F58AB461958D05FE6F847B3"

--- a/recipes/libvpl/all/conandata.yml
+++ b/recipes/libvpl/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "2.15.0":
-    url: "https://github.com/intel/libvpl/archive/v2.15.0.tar.gz"
-    sha256: "7218C3B8206B123204C3827CE0CF7C008D5C693C1F58AB461958D05FE6F847B3"
+  "2.16.0":
+    url: "https://github.com/intel/libvpl/archive/v2.16.0.tar.gz"
+    sha256: "D60931937426130DDAD9F1975C010543F0DA99E67EDB1C6070656B7947F633B6"

--- a/recipes/libvpl/all/conandata.yml
+++ b/recipes/libvpl/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "2.16.0":
-    url: "https://github.com/intel/libvpl/archive/v2.16.0.tar.gz"
-    sha256: "D60931937426130DDAD9F1975C010543F0DA99E67EDB1C6070656B7947F633B6"
+  "2.17.0":
+    url: "https://github.com/intel/libvpl/archive/v2.17.0.tar.gz"
+    sha256: "4de3e2faf1e8307fb282e4a43f443191810f6a6b0a484fffa7995ba1c814c6ec"

--- a/recipes/libvpl/all/conanfile.py
+++ b/recipes/libvpl/all/conanfile.py
@@ -90,7 +90,7 @@ class LibvplConan(ConanFile):
         if self.settings.os in ["Linux", "FreeBSD"]:
             disp.system_libs = ["dl", "pthread"]
         elif self.settings.os == "Windows":
-            disp.system_libs = ["advapi32"]
+            disp.system_libs = ["advapi32", "ole32"]
 
         # ------------------------------------------------------------------
         # api component (headers for the C API)

--- a/recipes/libvpl/all/conanfile.py
+++ b/recipes/libvpl/all/conanfile.py
@@ -39,6 +39,9 @@ class LibvplConan(ConanFile):
     def requirements(self):
         pass
 
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.13]")
+
     def layout(self):
         cmake_layout(self, src_folder="src")
 

--- a/recipes/libvpl/all/conanfile.py
+++ b/recipes/libvpl/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, replace_in_file
 from conan.tools.microsoft import is_msvc
 import os
 
@@ -32,8 +32,9 @@ class LibvplConan(ConanFile):
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
-        self.settings.rm_safe("compiler.cppstd")
-        self.settings.rm_safe("compiler.libcxx")
+
+    def export_sources(self):
+        export_conandata_patches(self)
 
     def requirements(self):
         if self.settings.os == "Linux":
@@ -49,6 +50,10 @@ class LibvplConan(ConanFile):
     def source(self):
         get(self, **self.conan_data["sources"][self.version],
             destination=self.source_folder, strip_root=True)
+
+        # INFO: Honor fPIC option. The upstream sets fPIC to ON always
+        replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"), "set(CMAKE_POSITION_INDEPENDENT_CODE true)", "")
+
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/recipes/libvpl/all/conanfile.py
+++ b/recipes/libvpl/all/conanfile.py
@@ -74,7 +74,12 @@ class LibvplConan(ConanFile):
         self.cpp_info.set_property("cmake_target_name", "VPL::VPL")
         self.cpp_info.set_property("cmake_target_aliases", ["VPL::dispatcher"])
         self.cpp_info.set_property("pkg_config_name", "vpl")
-        self.cpp_info.libs = ["vpl"]
+
+        # Handle debug suffix (only on Windows)
+        debug_suffix = ""
+        if self.settings.os == "Windows" and self.settings.build_type == "Debug":
+            debug_suffix = "d"
+        self.cpp_info.libs = [f"vpl{debug_suffix}"]
 
         # Add system libraries if needed
         if self.settings.os in ["Linux", "FreeBSD"]:

--- a/recipes/libvpl/all/conanfile.py
+++ b/recipes/libvpl/all/conanfile.py
@@ -37,12 +37,7 @@ class LibvplConan(ConanFile):
         export_conandata_patches(self)
 
     def requirements(self):
-        if self.settings.os == "Linux":
-            self.requires("libdrm/2.4.124")
-            self.requires("libva/2.21.0")
-            self.requires("xorg/system")
-            self.requires("wayland/1.22.0")
-            self.requires("wayland-protocols/1.45")
+        pass
 
     def layout(self):
         cmake_layout(self, src_folder="src")

--- a/recipes/libvpl/all/conanfile.py
+++ b/recipes/libvpl/all/conanfile.py
@@ -1,0 +1,97 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
+from conan.tools.microsoft import is_msvc
+import os
+
+required_conan_version = ">=2.1"
+
+
+class LibvplConan(ConanFile):
+    name = "libvpl"
+    description = "Intel® Video Processing Library (Intel® VPL) provides a single video processing API for encode, decode, and video processing that works across a wide range of accelerators."
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/intel/libvpl"
+    topics = ("video", "processing", "intel", "encode", "decode")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
+
+    def requirements(self):
+        if self.settings.os == "Linux":
+            self.requires("libdrm/2.4.124")
+            self.requires("libva/2.21.0")
+            self.requires("xorg/system")
+            self.requires("wayland/1.22.0")
+            self.requires("wayland-protocols/1.45")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version],
+            destination=self.source_folder, strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        # Generate a relocatable shared lib on Macos
+        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"
+        # Honor BUILD_SHARED_LIBS
+        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
+        tc.generate()
+
+    def build(self):
+        apply_conandata_patches(self)
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "vpl")
+        self.cpp_info.set_property("cmake_target_name", "VPL::VPL")
+        self.cpp_info.set_property("pkg_config_name", "libvpl")
+
+        # Set the library names based on the build type and platform
+        if self.settings.os == "Windows" and self.options.shared:
+            self.cpp_info.libs = ["vpl"]
+        else:
+            self.cpp_info.libs = ["vpl"]
+
+        # Add system libraries if needed
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs = ["dl", "pthread"]
+        elif self.settings.os == "Windows":
+            self.cpp_info.system_libs = ["advapi32"]
+
+    def system_requirements(self):
+        # System requirements are now handled by Conan packages in the requirements method
+        pass

--- a/recipes/libvpl/all/conanfile.py
+++ b/recipes/libvpl/all/conanfile.py
@@ -92,7 +92,7 @@ class LibvplConan(ConanFile):
         if self.settings.os in ["Linux", "FreeBSD"]:
             disp.system_libs = ["dl", "pthread"]
         elif self.settings.os == "Windows":
-            disp.system_libs = ["advapi32", "ole32"]
+            disp.system_libs = ["ole32", "gdi32", "uuid"]
 
         # ------------------------------------------------------------------
         # api component (headers for the C API)

--- a/recipes/libvpl/all/conanfile.py
+++ b/recipes/libvpl/all/conanfile.py
@@ -1,8 +1,10 @@
-from conan import ConanFile
-from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, replace_in_file
-from conan.tools.microsoft import is_msvc
 import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import is_apple_os
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, rmdir, replace_in_file
 
 required_conan_version = ">=2.1"
 
@@ -33,14 +35,12 @@ class LibvplConan(ConanFile):
         if self.options.shared:
             self.options.rm_safe("fPIC")
 
-    def export_sources(self):
-        export_conandata_patches(self)
-
-    def requirements(self):
-        pass
-
     def build_requirements(self):
         self.tool_requires("cmake/[>=3.13]")
+
+    def validate(self):
+        if is_apple_os(self):
+            raise ConanInvalidConfiguration(f"The library is not supported on Apple OS")
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -58,7 +58,6 @@ class LibvplConan(ConanFile):
         tc.generate()
 
     def build(self):
-        apply_conandata_patches(self)
         cmake = CMake(self)
         cmake.configure()
         cmake.build()

--- a/recipes/libvpl/all/test_package/CMakeLists.txt
+++ b/recipes/libvpl/all/test_package/CMakeLists.txt
@@ -4,4 +4,4 @@ project(test_package LANGUAGES CXX)
 find_package(vpl REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE VPL::VPL)
+target_link_libraries(${PROJECT_NAME} PRIVATE VPL::dispatcher)

--- a/recipes/libvpl/all/test_package/CMakeLists.txt
+++ b/recipes/libvpl/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(vpl REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE VPL::VPL)

--- a/recipes/libvpl/all/test_package/CMakeLists.txt
+++ b/recipes/libvpl/all/test_package/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES CXX)
 
-find_package(vpl REQUIRED)
+find_package(VPL REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE VPL::dispatcher)

--- a/recipes/libvpl/all/test_package/conanfile.py
+++ b/recipes/libvpl/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/libvpl/all/test_package/test_package.cpp
+++ b/recipes/libvpl/all/test_package/test_package.cpp
@@ -3,9 +3,25 @@
 #include <cstdlib>
 
 int main() {
+    // Initialize VPL loader
+    mfxLoader loader = MFXLoad();
+    if (!loader) {
+        std::cout << "Failed to create VPL loader" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    // Create a session
+    mfxSession session = nullptr;
+    mfxStatus sts = MFXCreateSession(loader, 0, &session);
+    if (sts != MFX_ERR_NONE) {
+        std::cout << "Failed to create session. Status: " << sts << std::endl;
+        MFXUnload(loader);
+        return EXIT_FAILURE;
+    }
+
     // Print the VPL API version
     mfxVersion version = { {0, 1} };
-    mfxStatus status = MFXQueryVersion(nullptr, &version);
+    mfxStatus status = MFXQueryVersion(session, &version);
 
     if (status == MFX_ERR_NONE) {
         std::cout << "VPL API version: " << version.Major << "." << version.Minor << std::endl;
@@ -13,14 +29,8 @@ int main() {
         std::cout << "Failed to query VPL API version. Status: " << status << std::endl;
     }
 
-    // Initialize VPL session
-    mfxLoader loader = MFXLoad();
-    if (!loader) {
-        std::cout << "Failed to create VPL loader" << std::endl;
-        return EXIT_FAILURE;
-    }
-
     // Clean up
+    MFXClose(session);
     MFXUnload(loader);
 
     return EXIT_SUCCESS;

--- a/recipes/libvpl/all/test_package/test_package.cpp
+++ b/recipes/libvpl/all/test_package/test_package.cpp
@@ -1,0 +1,27 @@
+#include <vpl/mfx.h>
+#include <iostream>
+#include <cstdlib>
+
+int main() {
+    // Print the VPL API version
+    mfxVersion version = { {0, 1} };
+    mfxStatus status = MFXQueryVersion(nullptr, &version);
+
+    if (status == MFX_ERR_NONE) {
+        std::cout << "VPL API version: " << version.Major << "." << version.Minor << std::endl;
+    } else {
+        std::cout << "Failed to query VPL API version. Status: " << status << std::endl;
+    }
+
+    // Initialize VPL session
+    mfxLoader loader = MFXLoad();
+    if (!loader) {
+        std::cout << "Failed to create VPL loader" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    // Clean up
+    MFXUnload(loader);
+
+    return EXIT_SUCCESS;
+}

--- a/recipes/libvpl/all/test_package/test_package.cpp
+++ b/recipes/libvpl/all/test_package/test_package.cpp
@@ -1,37 +1,24 @@
 #include <vpl/mfx.h>
+
 #include <iostream>
 #include <cstdlib>
 
 int main() {
-    // Initialize VPL loader
     mfxLoader loader = MFXLoad();
     if (!loader) {
-        std::cout << "Failed to create VPL loader" << std::endl;
-        return EXIT_FAILURE;
+        return 1;
     }
 
-    // Create a session
-    mfxSession session = nullptr;
+    mfxSession session{};
     mfxStatus sts = MFXCreateSession(loader, 0, &session);
-    if (sts != MFX_ERR_NONE) {
-        std::cout << "Failed to create session. Status: " << sts << std::endl;
+    if (sts == MFX_ERR_NONE) {
+        MFXClose(session);
         MFXUnload(loader);
-        return EXIT_FAILURE;
+        std::cout << "Linking OK, VPL runtime available on system" << std::endl;
+        return 0;
     }
 
-    // Print the VPL API version
-    mfxVersion version = { {0, 1} };
-    mfxStatus status = MFXQueryVersion(session, &version);
-
-    if (status == MFX_ERR_NONE) {
-        std::cout << "VPL API version: " << version.Major << "." << version.Minor << std::endl;
-    } else {
-        std::cout << "Failed to query VPL API version. Status: " << status << std::endl;
-    }
-
-    // Clean up
-    MFXClose(session);
     MFXUnload(loader);
-
-    return EXIT_SUCCESS;
+    std::cout << "Linking OK, VPL runtime unavailable on system" << std::endl;
+    return 0;
 }

--- a/recipes/libvpl/config.yml
+++ b/recipes/libvpl/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.15.0":
+    folder: all

--- a/recipes/libvpl/config.yml
+++ b/recipes/libvpl/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "2.15.0":
+  "2.16.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:
- **libvpl/2.16.0**

#### Motivation
To use Intel Quicksync for hardware video encoding either the [Intel Video Processing Library](https://github.com/intel/libvpl) (libvpl) or the outdated [Intel Media SDK](https://github.com/Intel-Media-SDK/MediaSDK) are required at build time. Then an additional runtime is need (e.g. via the intel drivers).

This PR adds the Intel Video Processing Library to conan, so that in a second step video processing libraries like ffmpeg can use it. As requested in this PR(https://github.com/conan-io/conan-center-index/pull/28202)

#### Details
This pr adds a recipe for libvpl built via CMake.

This recipe was tested on Windows-x64 and Linux-x64.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
