### PR TITLE
harfbuzz: old versions will not get newer revisions

### DIFF
--- a/recipes/harfbuzz/all/conandata.yml
+++ b/recipes/harfbuzz/all/conandata.yml
@@ -1,10 +1,6 @@
+# Only keep the most recent version
+# Harbuzz is backwards compatible, see https://github.com/conan-io/conan-center-index/pull/28188#issue-3331432127
 sources:
   "12.3.0":
     url: "https://github.com/harfbuzz/harfbuzz/releases/download/12.3.0/harfbuzz-12.3.0.tar.xz"
     sha256: "8660ebd3c27d9407fc8433b5d172bafba5f0317cb0bb4339f28e5370c93d42b7"
-  "11.4.1":
-    url: "https://github.com/harfbuzz/harfbuzz/releases/download/11.4.1/harfbuzz-11.4.1.tar.xz"
-    sha256: "7aafab93115eb56cdc9a931ab7d19ff60d7f2937b599d140f17236f374e32698"
-  "8.3.0":
-    url: "https://github.com/harfbuzz/harfbuzz/releases/download/8.3.0/harfbuzz-8.3.0.tar.xz"
-    sha256: "109501eaeb8bde3eadb25fab4164e993fbace29c3d775bcaa1c1e58e2f15f847"

--- a/recipes/harfbuzz/config.yml
+++ b/recipes/harfbuzz/config.yml
@@ -1,7 +1,3 @@
 versions:
   "12.3.0":
     folder: all
-  "11.4.1":
-    folder: all
-  "8.3.0":
-    folder: all


### PR DESCRIPTION
### Summary
Maintain a single version of harfbuzz - as it is indefinitely backwards compatible and recipes that depend on it already use a version range.



---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
