### PR TITLE
qt5: fix libpq library names on Windows for libpq/17+

### DIFF
--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -407,7 +407,7 @@ class QtConan(ConanFile):
         if self.options.get_safe("with_icu", False):
             self.requires("icu/74.2")
         if self.options.get_safe("with_harfbuzz", False) and not self.options.multiconfiguration:
-            self.requires("harfbuzz/8.3.0")
+            self.requires("harfbuzz/[>=8.3.0]")
         if self.options.get_safe("with_libjpeg", False) and not self.options.multiconfiguration:
             if self.options.with_libjpeg == "libjpeg-turbo":
                 self.requires("libjpeg-turbo/[>=3.0 <3.1]")


### PR DESCRIPTION
### Summary

libpq >=17 is built with meson, which uses a different filename convention for libraries on Windows. Fix this by explicitly expressing the library files, rather than `-l` flags (which are implicitly translated by qmake to actual filenames, since the msvc linker requires full filenames).

Additionally, use a version range for harfbuzz to align with the rest of the repository.



Fixes this error:
```
...
> 	cl -c -nologo -Zc:wchar_t -FS -Zc:rvalueCast -Zc:inline -Zc:strictStrings -Zc:throwingNew -Zc:referenceBinding -Zc:__cplusplus -O2 -MD -W0 -EHsc -DUNICODE -D_UNICODE -DWIN32 -D_ENABLE_EXTENDED_ALIGNED_STORAGE -DWIN64 -DSQLITE_API=__declspec(dllimport) -DNDEBUG -I. -IC:\workspace\cci_prod_PR-29320\conan-home\p\pcre27aa246bc7105f\p\include -IC:\workspace\cci_prod_PR-29320\conan-home\p\doublbca8d336f4f33\p\include -IC:\workspace\cci_prod_PR-29320\conan-home\p\freet18835c52068fd\p\include -IC:\workspace\cci_prod_PR-29320\conan-home\p\freet18835c52068fd\p\include\freetype2 -IC:\workspace\cci_prod_PR-29320\conan-home\p\libjp2056bdc0b1fa9\p\include -IC:\workspace\cci_prod_PR-29320\conan-home\p\libpn021b228b7ea45\p\include -IC:\workspace\cci_prod_PR-29320\conan-home\p\sqlit64327c3d1a7ec\p\include -IC:\workspace\cci_prod_PR-29320\conan-home\p\libmyf813b44f06efd\p\include -IC:\workspace\cci_prod_PR-29320\conan-home\p\libmyf813b44f06efd\p\include\mysql -IC:\workspace\cci_prod_PR-29320\conan-home\p\libpqc831941296d17\p\include -IC:\workspace\cci_prod_PR-29320\conan-home\p\opens81ddeb544f32c\p\include -IC:\workspace\cci_prod_PR-29320\conan-home\p\zlibe7061fb113fae\p\include -IC:\workspace\cci_prod_PR-29320\conan-home\p\zstdf533cf5aa3eb0\p\include -IC:\workspace\cci_prod_PR-29320\conan-home\p\md4cf373c38ba831d\p\include -IC:\workspace\cci_prod_PR-29320\conan-home\p\qt832ed58d5cddf\s\qt5\qtbase\mkspecs\win32-msvc -Fo @C:\Users\jenkins_ci\AppData\Local\Temp\main.obj.908.0.jom
> main.cpp
> 	link /NOLOGO /DYNAMICBASE /NXCOMPAT /OPT:REF /INCREMENTAL:NO /SUBSYSTEM:CONSOLE "/MANIFESTDEPENDENCY:type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' publicKeyToken='6595b64144ccf1df' language='*' processorArchitecture='*'" /MANIFEST:embed /OUT:psql.exe @C:\Users\jenkins_ci\AppData\Local\Temp\psql.exe.908.47.jom
> LINK : fatal error LNK1181: cannot open input file 'pq.lib'
> jom: C:\workspace\cci_prod_PR-29320\conan-home\p\b\qt595ff2484753a\b\build_folder\config.tests\psql\Makefile [psql.exe] Error 1181
 => source failed verification.
...


ERROR: Feature 'sql-psql' was enabled, but the pre-condition 'libs.psql' failed.
```
---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
