### PR TITLE
[meson] Bump version to 1.10.0

### DIFF
--- a/recipes/meson/all/conandata.yml
+++ b/recipes/meson/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.10.0":
+    url: "https://github.com/mesonbuild/meson/archive/1.10.0.tar.gz"
+    sha256: "cad50c9484cbc3d4e5a45b1c2662d079be9a848aaa4cef02de7dbec412b0eede"
   "1.9.1":
     url: "https://github.com/mesonbuild/meson/archive/1.9.1.tar.gz"
     sha256: "febaa8f7c1916521c53eb5fd11c0641b5eb4741c2c6e9b42c288ed62d9e4fd2c"

--- a/recipes/meson/config.yml
+++ b/recipes/meson/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.10.0":
+    folder: all
   "1.9.1":
     folder: all
   "1.8.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  **meson/1.10.0**

#### Motivation

Meson 1.10. was officially released one month ago:

- https://github.com/mesonbuild/meson/releases/tag/1.10.0
- https://mesonbuild.com/Release-notes-for-1-10-0.html

#### Details

The PR https://github.com/conan-io/conan-center-index/pull/27864 includes CapyPDF 0.19.0, which requires Meson >=1.10.0

Tested locally on Linux: [meson-1.10.0-linux-amd64-gcc11-release.log](https://github.com/user-attachments/files/24584435/meson-1.10.0-linux-amd64-gcc11-release.log)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
