### PR TITLE
librdkafka: add version 2.13.0

### DIFF
--- a/recipes/librdkafka/all/conandata.yml
+++ b/recipes/librdkafka/all/conandata.yml
@@ -1,15 +1,8 @@
 sources:
-  "2.12.1":
-    url: "https://github.com/edenhill/librdkafka/archive/v2.12.1.tar.gz"
-    sha256: "ec103fa05cb0f251e375f6ea0b6112cfc9d0acd977dc5b69fdc54242ba38a16f"
   "2.13.0":
     url: "https://github.com/edenhill/librdkafka/archive/v2.13.0.tar.gz"
     sha256: "3bd351601d8ebcbc99b9a1316cae1b83b00edbcf9411c34287edf1791c507600"
 patches:
-  "2.12.1":
-    - patch_file: patches/0001-Change-library-names-1-9-1.patch
-    - patch_file: patches/0002-Change-library-targets-and-result-variables-2-5-0.patch
-    - patch_file: patches/0004-Fix_compilation_with_CMake_and_without_CURL.patch
   "2.13.0":
     - patch_file: patches/0001-Change-library-names-1-9-1.patch
     - patch_file: patches/0002-Change-library-targets-and-result-variables-2-5-0.patch

--- a/recipes/librdkafka/config.yml
+++ b/recipes/librdkafka/config.yml
@@ -1,6 +1,4 @@
 versions:
-  "2.12.1":
-    folder: all
   "2.13.0":
     folder: all
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **librdkafka/2.13.0**

#### Motivation
latest version of librdkafka with [bugfixes and features](https://github.com/confluentinc/librdkafka/releases/tag/v2.13.0)

#### Details

No relevant cmake changes since 2.12.1: https://github.com/confluentinc/librdkafka/compare/v2.12.1...v2.13.0


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
