### PR TITLE
[harfbuzz] Add missing pkg-config components

### DIFF
--- a/recipes/harfbuzz/all/conanfile.py
+++ b/recipes/harfbuzz/all/conanfile.py
@@ -172,7 +172,8 @@ class HarfbuzzConan(ConanFile):
 
         # TODO in next Harfbuzz major version:
         # - rename "core" component to "harfbuzz"
-        # - check if https://github.com/conan-io/conan/issues/17815 is solved
+        # - add self.cpp_info.set_property("pkg_config_name", "none")
+        # - set "harfbuzz" as the pkg_config_name of the harfbuzz component
         self.cpp_info.components["core"].set_property("cmake_target_name", "harfbuzz::harfbuzz")
         self.cpp_info.components["core"].libs = ["harfbuzz"]
         self.cpp_info.components["core"].includedirs.append(os.path.join("include", "harfbuzz"))


### PR DESCRIPTION
### Summary
Changes to recipe:  **harfbuzz/12.3.0**

#### Motivation

Moving partial implementation of GTK PR: https://github.com/conan-io/conan-center-index/pull/29172

#### Details

Harfbuzz generates more .pc files when build.

https://github.com/harfbuzz/harfbuzz/blob/11.4.1/CMakeLists.txt#L982

The GTK project requires harfbuzz-subset component:

https://gitlab.gnome.org/GNOME/gtk/-/blob/4.18.6/meson.build?ref_type=tags#L435

Built locally on Linux: [harfbuzz-12.3.0-linux-amd64-gcc13-release-static.log](https://github.com/user-attachments/files/24593053/harfbuzz-12.3.0-linux-amd64-gcc13-release-static.log)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
