### PR TITLE
libraw: Add 0.22.0

### DIFF
--- a/recipes/libraw/all/conandata.yml
+++ b/recipes/libraw/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.22.0":
+    url: "https://github.com/LibRaw/LibRaw/archive/0.22.0.tar.gz"
+    sha256: "5a11327a9cef2496d6a4335e8da30a1604460b6c545a30fe7588cf4c00a0fcae"
   "0.21.5b":
     url: "https://github.com/LibRaw/LibRaw/archive/0.21.5b.tar.gz"
     sha256: "f60e8377dec42e50f59ed2860ba00bcb59773e04afbf7bd6bd9367ac3529e0e8"

--- a/recipes/libraw/config.yml
+++ b/recipes/libraw/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.22.0":
+    folder: all
   "0.21.5b":
     folder: all
   "0.21.2":


### PR DESCRIPTION



### Summary
Changes to recipe:  **lib/0.22.0**

#### Motivation
Latest version is missing many modern cameras (no camera update since 0.21.0 release, as release branches only get bugfixes).

#### Details
* https://github.com/LibRaw/LibRaw/releases/tag/0.22.0
* https://github.com/LibRaw/LibRaw/compare/0.21.5b...0.22.0

Large changes inside the code, but build-wise only few file additions that are covered by the glob in the CMakeLists.txt anyway. Running a untagged "pre-rc1" from a few weeks ago for a while which contains most of the changes and was build with this base receipe.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
