### PR TITLE
wt: fix regression on windows when building with libpq/17+

### DIFF
--- a/recipes/wt/all/conanfile.py
+++ b/recipes/wt/all/conanfile.py
@@ -212,9 +212,7 @@ class WtConan(ConanFile):
             tc.variables["MYSQL_DEFINITIONS"] = ";".join(f"-D{d}" for d in libmysqlclient_cppinfo.defines)
             tc.variables["MYSQL_FOUND"] = True
         if self.options.get_safe("with_postgres"):
-            tc.variables["POSTGRES_PREFIX"] = self._cmakify_path_list([self.dependencies["libpq"].package_folder])
-            tc.variables["POSTGRES_LIBRARIES"] = self._cmakify_path_list(self._find_libraries("libpq"))
-            tc.variables["POSTGRES_INCLUDE"] = self._cmakify_path_list(self.dependencies["libpq"].cpp_info.aggregated_components().includedirs)
+            # There's alredy a patch to call find_package(PostgreSQL REQUIRED CONFIG)
             tc.variables["POSTGRES_FOUND"] = True
         if self.options.get_safe("with_mssql") and self.settings.os != "Windows":
             tc.variables["ODBC_PREFIX"] = self._cmakify_path_list([self.dependencies["odbc"].package_folder])
@@ -234,6 +232,7 @@ class WtConan(ConanFile):
         tc.generate()
 
         deps = CMakeDeps(self)
+        deps.set_property("libpq", "cmake_additional_variables_prefixes", ["POSTGRES"])
         deps.generate()
 
     def _patch_sources(self):


### PR DESCRIPTION
### Summary

The internal logic of the wt recipe is not capable of finding the correct library files for `libpq/17.x` on Windows, as the meson build system generates different filenames than the ones expected by the recipe.

For libpq, the recipe already calls `find_package` (which works correctly), so this fix just relies on that and removes the redundant definition of `POSTGRES_LIBRARIES`. 

Longer term, the same approach should be followed for other dependencies in this recipe - the generators and CMake have the correct information, this kind of assumptions in recipes are otherwise very fragile.

Fixes issue as reported in https://github.com/conan-io/conan/issues/19460#issuecomment-3748622117


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
