### PR TITLE
Remove unsupported OUTPUT_DIR option to idlc_generate call

### DIFF
--- a/recipes/cyclonedds-cxx/all/cmake/Generate.cmake
+++ b/recipes/cyclonedds-cxx/all/cmake/Generate.cmake
@@ -39,14 +39,13 @@ else()
 endif()
 
 function(IDLCXX_GENERATE)
-  set(one_value_keywords TARGET DEFAULT_EXTENSIBILITY BASE_DIR)
+  set(one_value_keywords TARGET DEFAULT_EXTENSIBILITY)
   set(multi_value_keywords FILES FEATURES INCLUDES WARNINGS)
   cmake_parse_arguments(
     IDLCXX "" "${one_value_keywords}" "${multi_value_keywords}" "" ${ARGN})
 
   idlc_generate_generic(TARGET ${IDLCXX_TARGET}
     BACKEND ${_idlcxx_shared_lib}
-    BASE_DIR ${IDLCXX_BASE_DIR}
     FILES ${IDLCXX_FILES}
     FEATURES ${IDLCXX_FEATURES}
     INCLUDES ${IDLCXX_INCLUDES}


### PR DESCRIPTION
### Summary
Changes to recipe:  **cyclonedds-cxx/0.10.5**

#### Motivation
This is a bug in the helper cmake function 'idlcxx_generate' which calls the underlying 'idlc_generate_generic' function in the **cyclonedds** base package. An unsupported argument ('OUTPUT_DIR') is passed to the resulting in potential errors generating output files.

#### Details
Simply removed the `OUTPUT_DIR` argument from the function and resulting call. The called function can be viewed here: https://github.com/eclipse-cyclonedds/cyclonedds/blob/2cdd114cbd18340c606573b4cc8dc20cc161ec5a/cmake/Modules/Generate.cmake#L35 and as can be seen, there is no `OUTPUT_DIR` argument.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
