### PR TITLE
libavrocpp: make boost dependency optional

### DIFF
--- a/recipes/libavrocpp/all/conanfile.py
+++ b/recipes/libavrocpp/all/conanfile.py
@@ -24,7 +24,7 @@ class LibavrocppConan(ConanFile):
     default_options = {
         "shared": False,
         "fPIC": True,
-        "with_boost": True
+        "with_boost": False
     }
 
     def config_options(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **libavrocpp/1.12.1**

#### Motivation
Add the possibility to disable boost dependency

#### Details
libavrocpp boost dependency seems to be optional if tests aren't built:
* https://github.com/apache/avro/blob/release-1.12.1/lang/c%2B%2B/CMakeLists.txt#L63
* https://github.com/apache/avro/blob/release-1.12.1/lang/c%2B%2B/CMakeLists.txt#L81-L86

I've set `with_boost` to `True` by default in order to not break the current behavior.

The situation around boost and libavrocpp seems to be a bit weird. Fortunately it looks like the boost dependency will be dropped in avro 1.13.0 (https://issues.apache.org/jira/browse/AVRO-4178).

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
