### PR TITLE
libraw: Add optional file size limit setting for libraw 0.22+

### DIFF
--- a/recipes/libraw/all/CMakeLists.txt
+++ b/recipes/libraw/all/CMakeLists.txt
@@ -59,6 +59,11 @@ if (LIBRAW_WITH_JASPER)
     target_link_libraries(raw PUBLIC Jasper::Jasper)
 endif ()
 
+if (LIBRAW_MAX_CR3_RAW_FILE_SIZE)
+    message("Canon CR3/CRM raw size limit override: ${LIBRAW_MAX_CR3_RAW_FILE_SIZE}")
+    target_compile_definitions(raw PUBLIC "-DLIBRAW_MAX_CR3_RAW_FILE_SIZE=${LIBRAW_MAX_CR3_RAW_FILE_SIZE}LL")
+endif ()
+
 include(GNUInstallDirs)
 if(LIBRAW_BUILD_THREAD_SAFE)
     add_library(raw_r ${libraw_LIB_SRCS})

--- a/recipes/libraw/all/conanfile.py
+++ b/recipes/libraw/all/conanfile.py
@@ -1,10 +1,12 @@
 import os
 
 from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd, stdcpp_library
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get
 from conan.tools.microsoft import is_msvc
+from conan.tools.scm import Version
 
 required_conan_version = ">=1.53.0"
 
@@ -24,6 +26,11 @@ class LibRawConan(ConanFile):
         "with_jpeg": [False, "libjpeg", "libjpeg-turbo", "mozjpeg"],
         "with_lcms": [True, False],
         "with_jasper": [True, False],
+
+        # Option to override the maximum file size for .CR3 (including .CRM) files.
+        # The default limit of 2 GB can be way too small for canon raw movie files (.CRM).
+        # Value in bytes. For example 17592186044416 for 16 TB file support
+        "libraw_max_cr3_raw_file_size": [None, "ANY"],
     }
     default_options = {
         "shared": False,
@@ -32,6 +39,7 @@ class LibRawConan(ConanFile):
         "with_jpeg": "libjpeg",
         "with_lcms": True,
         "with_jasper": True,
+        "libraw_max_cr3_raw_file_size": None,
     }
     exports_sources = ["CMakeLists.txt"]
 
@@ -44,6 +52,8 @@ class LibRawConan(ConanFile):
             del self.options.fPIC
         if is_msvc(self):
             del self.options.build_thread_safe
+        if Version(self.version) < '0.22.0':
+            del self.options.libraw_max_cr3_raw_file_size
 
     def configure(self):
         if self.options.shared:
@@ -69,6 +79,10 @@ class LibRawConan(ConanFile):
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._min_cppstd)
+        if self.options.get_safe("libraw_max_cr3_raw_file_size") and \
+                (not str(self.options.libraw_max_cr3_raw_file_size).isdigit() \
+                 or int(self.options.libraw_max_cr3_raw_file_size) < 268435456):
+            raise ConanInvalidConfiguration("-o='libraw/*:libraw_max_cr3_raw_file_size' should be a positive integer and not too small")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -81,6 +95,8 @@ class LibRawConan(ConanFile):
         tc.variables["LIBRAW_WITH_JPEG"] = bool(self.options.with_jpeg)
         tc.variables["LIBRAW_WITH_LCMS"] = self.options.with_lcms
         tc.variables["LIBRAW_WITH_JASPER"] = self.options.with_jasper
+        if self.options.get_safe("libraw_max_cr3_raw_file_size"):
+            tc.cache_variables["LIBRAW_MAX_CR3_RAW_FILE_SIZE"] = self.options.libraw_max_cr3_raw_file_size
         tc.generate()
 
         deps = CMakeDeps(self)
@@ -106,6 +122,9 @@ class LibRawConan(ConanFile):
             self.cpp_info.components["libraw_"].system_libs.append("ws2_32")
             if not self.options.shared:
                 self.cpp_info.components["libraw_"].defines.append("LIBRAW_NODLL")
+
+        if self.options.get_safe("libraw_max_cr3_raw_file_size"):
+            self.cpp_info.components["libraw_"].defines.append("LIBRAW_MAX_CR3_RAW_FILE_SIZE={}LL".format(self.options.libraw_max_cr3_raw_file_size))
 
         requires = []
         if self.options.with_jpeg == "libjpeg":

--- a/recipes/libraw/all/test_package/test_package.cpp
+++ b/recipes/libraw/all/test_package/test_package.cpp
@@ -1,8 +1,12 @@
 #include <libraw/libraw.h>
+#include <libraw/libraw_version.h>
 #include <iostream>
 
 int main()
 {
     std::cout << libraw_version() << "\n";
+    #if LIBRAW_MAJOR_VERSION >= 0 && LIBRAW_MINOR_VERSION >= 22
+        std::cout << "Maximum Canon CR3/CRM file size: " << LIBRAW_MAX_CR3_RAW_FILE_SIZE << "\n";
+    #endif
     return 0;
 }


### PR DESCRIPTION
### Summary
Changes to recipe:  **libraw/0.22.0+**

#### Motivation
Traditionally the libraw was internally using 32 bit types for calculating file read positions/offsets etc. This has now been fixed for a while in master & is part of the code released in libraw 0.22.0. However, the upstream decided to keep most limits to 2GB/4GB.

For data from Canon cameras this is a problem as the crm (Canon raw movie) file format easily exceed this limit as a few seconds of up to 8K raw video frames sum up quickly. Thus, the limits are intentionally build so that they can be changed via a define: https://github.com/LibRaw/LibRaw/issues/693

This change allows to optionally set the limit. I'd really welcome this change upstreamed. I have been using this option handling in my personal CCI with commits from master as my versions and cleaned it up now for 0.22. Works well and if not set just matches the default behaviour.

#### Details
Fully optional option, default behaviour is to be ignored. Was using this with the limit for 16 TB (17592186044416) but my largest memory card is 512 GB. But as mentioned in the upstream issue, I tested with a clip filling the card and had no issue up to that limit. (Did my tests with basically this conan package change as that was the easiest way to try in my tool anyway.)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
