### PR TITLE
[goldy] Add new recipe

### DIFF
--- a/recipes/goldy/all/conandata.yml
+++ b/recipes/goldy/all/conandata.yml
@@ -1,0 +1,23 @@
+sources:
+  "0.1.0":
+    url: "https://github.com/koubaa/goldy/archive/refs/tags/v0.1.0.tar.gz"
+    sha256: "cd3cfd4cd313bd8f0cb48dd58da098fa572e861198fafac101e49096e5748da8"
+
+binaries:
+  "0.1.0":
+    "Windows":
+      "x86_64":
+        url: "https://github.com/koubaa/goldy/releases/download/v0.1.0/goldy_ffi-windows-x64.zip"
+        sha256: "7abd86b278756c8c73171ef2df4f248667e0fbcaab5f23dc2521ca569bead7a9"
+    "Linux":
+      "x86_64":
+        url: "https://github.com/koubaa/goldy/releases/download/v0.1.0/goldy_ffi-linux-x64.tar.gz"
+        sha256: "ccbc4152b4867c3bc5261ae56a046b087d76bf51063424799365711d52f49c01"
+    "Macos":
+      "x86_64":
+        url: "https://github.com/koubaa/goldy/releases/download/v0.1.0/goldy_ffi-macos-x64.tar.gz"
+        sha256: "632a12c2daf6cceb2cb4b5306e049abd613f6a309d62a329421acaa34070d7ce"
+      "armv8":
+        url: "https://github.com/koubaa/goldy/releases/download/v0.1.0/goldy_ffi-macos-arm64.tar.gz"
+        sha256: "53bdf0a288f39f6044d18851d9c41afdab35260929f64665cacac0630003aa34"
+

--- a/recipes/goldy/all/conanfile.py
+++ b/recipes/goldy/all/conanfile.py
@@ -1,0 +1,105 @@
+from conan import ConanFile
+from conan.tools.files import copy, get, download, load
+from conan.errors import ConanInvalidConfiguration
+import os
+
+
+required_conan_version = ">=2.0"
+
+
+class GoldyConan(ConanFile):
+    name = "goldy"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/koubaa/goldy"
+    description = "Modern GPU library with Slang shader support"
+    topics = ("gpu", "graphics", "vulkan", "rendering", "slang")
+    package_type = "shared-library"
+
+    settings = "os", "arch", "compiler", "build_type"
+
+    # Supported platforms for pre-built binaries
+    _supported_platforms = {
+        ("Windows", "x86_64"),
+        ("Linux", "x86_64"),
+        ("Macos", "x86_64"),
+        ("Macos", "armv8"),
+    }
+
+    def export_sources(self):
+        copy(self, "conandata.yml", src=self.recipe_folder, dst=self.export_sources_folder)
+
+    def validate(self):
+        key = (str(self.settings.os), str(self.settings.arch))
+        if key not in self._supported_platforms:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} does not support {self.settings.os} {self.settings.arch}. "
+                f"Supported: Windows x86_64, Linux x86_64, macOS x86_64/armv8"
+            )
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def build(self):
+        # Download pre-built native library
+        os_name = str(self.settings.os)
+        arch = str(self.settings.arch)
+        binary_info = self.conan_data["binaries"][self.version][os_name][arch]
+
+        self.output.info(f"Downloading pre-built goldy_ffi for {os_name} {arch}...")
+
+        filename = binary_info["url"].split("/")[-1]
+        download(self, url=binary_info["url"], filename=filename, sha256=binary_info["sha256"])
+
+        # Extract the archive
+        if filename.endswith(".zip"):
+            import zipfile
+            with zipfile.ZipFile(filename, 'r') as zip_ref:
+                zip_ref.extractall("binary")
+        else:
+            import tarfile
+            with tarfile.open(filename, 'r:gz') as tar_ref:
+                tar_ref.extractall("binary")
+
+    def package(self):
+        # Copy license
+        copy(self, "LICENSE", src=self.source_folder,
+             dst=os.path.join(self.package_folder, "licenses"))
+
+        # Copy headers from source
+        copy(self, "*.h", src=os.path.join(self.source_folder, "cpp", "include"),
+             dst=os.path.join(self.package_folder, "include"))
+        copy(self, "*.hpp", src=os.path.join(self.source_folder, "cpp", "include"),
+             dst=os.path.join(self.package_folder, "include"))
+
+        # Copy native library from pre-built binary
+        binary_dir = os.path.join(self.build_folder, "binary")
+
+        if self.settings.os == "Windows":
+            copy(self, "goldy_ffi.dll", src=os.path.join(binary_dir, "lib"),
+                 dst=os.path.join(self.package_folder, "bin"))
+            copy(self, "goldy_ffi.dll.lib", src=os.path.join(binary_dir, "lib"),
+                 dst=os.path.join(self.package_folder, "lib"))
+            # Rename the import library
+            old_path = os.path.join(self.package_folder, "lib", "goldy_ffi.dll.lib")
+            new_path = os.path.join(self.package_folder, "lib", "goldy_ffi.lib")
+            if os.path.exists(old_path):
+                os.rename(old_path, new_path)
+        elif self.settings.os == "Linux":
+            copy(self, "libgoldy_ffi.so", src=os.path.join(binary_dir, "lib"),
+                 dst=os.path.join(self.package_folder, "lib"))
+        elif self.settings.os == "Macos":
+            copy(self, "libgoldy_ffi.dylib", src=os.path.join(binary_dir, "lib"),
+                 dst=os.path.join(self.package_folder, "lib"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["goldy_ffi"]
+
+        self.cpp_info.set_property("cmake_file_name", "goldy")
+        self.cpp_info.set_property("cmake_target_name", "goldy::goldy")
+
+        if self.settings.os == "Windows":
+            self.cpp_info.bindirs = ["bin"]
+            # DLL needs to be in PATH at runtime
+            self.runenv_info.append_path("PATH", os.path.join(self.package_folder, "bin"))
+

--- a/recipes/goldy/all/test_package/CMakeLists.txt
+++ b/recipes/goldy/all/test_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_goldy LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(goldy REQUIRED CONFIG)
+
+add_executable(test_goldy test_goldy.cpp)
+target_link_libraries(test_goldy PRIVATE goldy::goldy)
+

--- a/recipes/goldy/all/test_package/conanfile.py
+++ b/recipes/goldy/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import can_run
+import os
+
+
+class GoldyTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindir, "test_goldy")
+            self.run(cmd, env="conanrun")
+

--- a/recipes/goldy/all/test_package/test_goldy.cpp
+++ b/recipes/goldy/all/test_package/test_goldy.cpp
@@ -1,0 +1,17 @@
+// Test that goldy headers can be included and library can be linked
+#include <goldy.h>
+#include <iostream>
+
+int main() {
+    // Just verify we can call a function from the library
+    // Don't actually create an instance (requires GPU)
+    std::cout << "Goldy C API header included successfully" << std::endl;
+    
+    // Check that symbols are available by taking address of a function
+    auto fn = &goldy_instance_create;
+    (void)fn;  // Suppress unused warning
+    
+    std::cout << "Goldy library linked successfully" << std::endl;
+    return 0;
+}
+

--- a/recipes/goldy/config.yml
+++ b/recipes/goldy/config.yml
@@ -1,0 +1,4 @@
+versions:
+  "0.1.0":
+    folder: all
+


### PR DESCRIPTION
## Description

Add new recipe for **Goldy**, a modern GPU library with Slang shader support.

- **Homepage**: https://github.com/koubaa/goldy
- **License**: MIT
- **Version**: 0.1.0

## Architecture

Goldy provides:
- **Header-only C++ wrapper** (`goldy.hpp`) - C++ RAII wrapper built from source
- **Pre-built native library** (`goldy_ffi`) - C ABI, downloaded as pre-built binary

This follows the standard pattern for C++ packages wrapping native libraries with stable C ABI (similar to CUDA runtime, Vulkan loader, Intel MKL).

## Supported Platforms

| OS | Architecture |
|----|--------------|
| Windows | x86_64 |
| Linux | x86_64 |
| macOS | x86_64, armv8 |

## Tested

- [x] `conan create . --version=0.1.0` passes locally on Windows
- [x] Test package builds and links successfully
- [x] License file included

## Checklist

- [x] Followed [recipe conventions](https://github.com/conan-io/conan-center-index/blob/master/docs/review_process.md)
- [x] `conandata.yml` contains version info and SHA256 hashes
- [x] `config.yml` maps versions to folders
- [x] Test package validates header inclusion and library linking