### PR TITLE
libpng: add version 1.6.54

### DIFF
--- a/recipes/libpng/all/conandata.yml
+++ b/recipes/libpng/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.6.54":
+    url: "https://download.sourceforge.net/libpng/libpng-1.6.54.tar.xz"
+    sha256: "01c9d8a303c941ec2c511c14312a3b1d36cedb41e2f5168ccdaa85d53b887805"
   "1.6.53":
     url: "https://download.sourceforge.net/libpng/libpng-1.6.53.tar.xz"
     sha256: "1d3fb8ccc2932d04aa3663e22ef5ef490244370f4e568d7850165068778d98d4"

--- a/recipes/libpng/config.yml
+++ b/recipes/libpng/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.6.54":
+    folder: all
   "1.6.53":
     folder: all
   "1.6.40":


### PR DESCRIPTION
### Summary

Changes to recipe:  **libpng/1.6.54**
Closes #29378

#### Motivation

Version 1.6.54 fixes two CVEs:
- Fixed CVE-2026-22695 (medium severity): Heap buffer over-read in png_image_read_direct_scaled. (Reported and fixed by Petr Simecek.)
- Fixed CVE-2026-22801 (medium severity): Integer truncation causing heap buffer over-read in png_image_write_*.

#### Details

- update `config.yml` to point `1.6.54` to the `all` folder
- add url and sha256 for the new version

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
