### PR TITLE
libcurl: fix openldap dependency

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -162,6 +162,8 @@ class LibcurlConan(ConanFile):
     def requirements(self):
         if self.options.with_ssl == "openssl":
             self.requires(f"openssl/[>=3 <4]")
+        if self.settings.os == "Linux" and self.options.with_ldap:
+            self.requires("openldap/[>=2.6 <3]")
         elif self.options.with_ssl == "libressl":
             self.requires("libressl/[>=3.5 <4]")
         elif self.options.with_ssl == "wolfssl":


### PR DESCRIPTION
### Summary
Changes to recipe:  **lib/[8.17.0]**

#### Motivation
bugfix: ldap feature of libcurl

#### Details
when the with_ldap option of libcurl is enabled, on linux it needs to link to openldap. This patch adds that dependency.
