### PR TITLE
[pfr] Mark as deprecated in favor of Boost package

### DIFF
--- a/recipes/pfr/all/conanfile.py
+++ b/recipes/pfr/all/conanfile.py
@@ -19,6 +19,7 @@ class PfrConan(ConanFile):
     license = "BSL-1.0"
     package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
+    deprecated = "boost"
 
     @property
     def _min_cppstd(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **pfr/2.2.0**

#### Motivation

The recipe for PFR is actually a module from [Boost.PFR](https://github.com/boostorg/pfr). The release 2.2.0 listed in Conan Center is from 2023, but at the same time, as under Boost Organization, all new releases are under Boost and follow its updates as well. As a result, this separate recipe is not only behind the PFR distributed with the Boost package in Conan Center, but also results in duplicated maintenance. 

#### Details

Version 2.2.0 and others were created because this project has an [independent implementation without Boost](https://github.com/apolukhin/pfr_non_boost). In case using Conan, people can use a newer revision by consuming `boost` package, and it will be under the `Boost::headers` target.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
