### PR TITLE
openscenegraph: use version range for fontconfig+freetype

### DIFF
--- a/recipes/openscenegraph/all/conanfile.py
+++ b/recipes/openscenegraph/all/conanfile.py
@@ -241,6 +241,7 @@ class OpenSceneGraphConanFile(ConanFile):
         if is_apple_os(self):
             tc.preprocessor_definitions["GL_SILENCE_DEPRECATION"] = "1"
 
+        tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0042"] = "NEW"  # macOS: use @rpath for shared libs
         tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support 
         tc.generate()
 


### PR DESCRIPTION
### Summary
openscenegraph: use version ranges for fontconfig and freetype


---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
