### PR TITLE
[pango] Use version ranges for Cairo dependency

### DIFF
--- a/recipes/pango/all/conanfile.py
+++ b/recipes/pango/all/conanfile.py
@@ -78,7 +78,7 @@ class PangoConan(ConanFile):
             self.requires("xorg/system")  # for xorg::xrender
         if self.options.with_cairo:
             # "pango/pangocairo.h" includes "cairo.h"
-            self.requires("cairo/1.18.0", transitive_headers=True)
+            self.requires("cairo/[>=1.18.0 <2]", transitive_headers=True)
         self.requires("glib/[>=2.82 <3]", transitive_headers=True, transitive_libs=True)
         self.requires("fribidi/1.0.13")
         # "pango/pango-coverage.h" includes "hb.h"


### PR DESCRIPTION
### Summary
Changes to recipe:  **pango/1.57.0**

#### Motivation

Related to #29381 #29369 #29172

#### Details

When building GTK4 (PR #29382), there is a conflict regarding Cairo version: Pango wants cairo/1.18.0, but [GTK actually needs >=1.18.2](https://gitlab.gnome.org/GNOME/gtk/-/blob/4.18.6/meson.build?ref_type=tags#L25), that's why the version ranges feature is used in GTK recipe, resulting in the following version conflict:

```text
Resolved version ranges
    cairo/[>=1.18 <2]: cairo/1.18.4
    cmake/[>=3.18]: cmake/4.2.1
    expat/[>=2.6.2 <3]: expat/2.7.3
    fontconfig/[>=2.15 <3]: fontconfig/2.17.1
    freetype/[>=2.13.2 <3]: freetype/2.14.1
    gdk-pixbuf/[>=2.42 <3]: gdk-pixbuf/2.44.4
    glib/[^2.82]: glib/2.85.3
    libffi/[>=3.4.4 <4]: libffi/3.4.8
    libjpeg/[>=9e]: libjpeg/9f
    libpng/[>=1.6 <2]: libpng/1.6.54
    libtiff/[>=4.6.0 <5]: libtiff/4.7.1
    libxft/[~2.3]: libxft/2.3.9
    meson/[>=1.2.2 <2]: meson/1.10.0
    meson/[>=1.2.3 <2]: meson/1.10.0
    meson/[>=1.3.1 <2]: meson/1.10.0
    meson/[>=1.3.2 <2]: meson/1.10.0
    meson/[>=1.4.0 <2]: meson/1.10.0
    meson/[>=1.5 <2]: meson/1.10.0
    ninja/[>=1.10.2 <2]: ninja/1.13.2
    pango/[>=1.50.7 <2]: pango/1.57.0
    pkgconf/[>=2.1.0 <3]: pkgconf/2.5.1
    pkgconf/[>=2.1 <3]: pkgconf/2.5.1
    pkgconf/[>=2.2 <3]: pkgconf/2.5.1
    xz_utils/[>=5.4.5 <6]: xz_utils/5.8.1
    zlib/[>=1.2.11 <2]: zlib/1.3.1
    zstd/[~1.5]: zstd/1.5.7
ERROR: Version conflict: Conflict between cairo/1.18.0 and cairo/1.18.4 in the graph.
Conflict originates from pango/1.57.0

Run 'conan graph info ... --format=html > graph.html' and open 'graph.html' to inspect the conflict graphically.
```

Local build logs:

* [pango-1.57.0-linux-amd64-gcc13-release-shared.log](https://github.com/user-attachments/files/24759393/pango-1.57.0-linux-amd64-gcc13-release-shared.log)
* [pango-1.57.0-linux-amd64-gcc13-release-static.log](https://github.com/user-attachments/files/24759394/pango-1.57.0-linux-amd64-gcc13-release-static.log)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan



---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
