### PR TITLE
[xkbcommon] Fix bad format in config.yml to be able to build 1.4.1

### DIFF
--- a/recipes/xkbcommon/config.yml
+++ b/recipes/xkbcommon/config.yml
@@ -6,4 +6,4 @@ versions:
   "1.5.0":
     folder: all
   "1.4.1":
-    folder: all"
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **xkbcommon/1.4.1**

#### Motivation

Related to #29379


#### Details

Double quote in config.yml resulted in a missing built version for the last PR. 


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
