### PR TITLE
mongo-cxx-driver: fix polyfill configuration

### DIFF
--- a/recipes/mongo-cxx-driver/all/conanfile.py
+++ b/recipes/mongo-cxx-driver/all/conanfile.py
@@ -23,13 +23,13 @@ class MongoCxxConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
-        "polyfill": ["std", "boost", "mnmlstc", "experimental"],
+        "polyfill": ["std", "boost", "mnmlstc", "experimental", "impls"],
         "with_ssl": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
-        "polyfill": "boost",
+        # "polyfill" default set in config_options()
         "with_ssl": True,
     }
 
@@ -39,6 +39,13 @@ class MongoCxxConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+
+        if valid_min_cppstd(self, 17):
+            self.options.polyfill = "std"
+        elif self._supports_impls_polyfill:
+            self.options.polyfill = "impls"
+        else:
+            self.options.polyfill = "boost"
 
     def configure(self):
         if self.options.shared:
@@ -58,7 +65,8 @@ class MongoCxxConan(ConanFile):
             "std": "17",
             "experimental": "14",
             "boost": "11",
-            "polyfill": "11"
+            "polyfill": "11",
+            "impls": "11",
         }[str(self.options.polyfill)]
 
     @property
@@ -79,7 +87,7 @@ class MongoCxxConan(ConanFile):
                 "clang": "3.5",
                 "apple-clang": "10"
             }
-        elif self.info.options.polyfill == "boost":
+        elif self.info.options.polyfill in ["boost", "impls"]:
             # C++11
             return {
                 "Visual Studio": "14",
@@ -92,9 +100,30 @@ class MongoCxxConan(ConanFile):
                 f"please, specify _compilers_minimum_version for {self.options.polyfill} polyfill"
             )
 
+    @property
+    def _supports_experimental_polyfill(self):
+        return Version(self.version) < "3.10"
+
+    @property
+    def _supports_impls_polyfill(self):
+        return Version(self.version) >= "3.10"
+
+    @property
+    def _supports_external_polyfill(self):
+        return Version(self.version) < 4
+
     def validate(self):
         if self.options.with_ssl and not bool(self.dependencies["mongo-c-driver"].options.with_ssl):
             raise ConanInvalidConfiguration("mongo-cxx-driver with_ssl=True requires mongo-c-driver with a ssl implementation")
+
+        if not self._supports_experimental_polyfill and self.options.polyfill == "experimental":
+            raise ConanInvalidConfiguration("experimental polyfill is no longer supported in mongo-cxx-driver versions 3.10+")
+
+        if not self._supports_impls_polyfill and self.options.polyfill == "impls":
+            raise ConanInvalidConfiguration("polyfill implementations are only supported in mongo-cxx-driver versions 3.10+")
+
+        if not self._supports_external_polyfill and self.options.polyfill in ["boost", "mnmlstc"]:
+            raise ConanInvalidConfiguration("external polyfill (boost or mnmlstc) is no longer supported in mongo-cxx-driver versions 4+")
 
         if self.options.polyfill == "mnmlstc":
             # TODO: add mnmlstc polyfill support
@@ -119,10 +148,19 @@ class MongoCxxConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["BSONCXX_POLY_USE_MNMLSTC"] = self.options.polyfill == "mnmlstc"
+
+        if self._supports_experimental_polyfill:
+            tc.variables["BSONCXX_POLY_USE_STD_EXPERIMENTAL"] = self.options.polyfill == "experimental"
+
+        if self._supports_impls_polyfill:
+            tc.variables["BSONCXX_POLY_USE_IMPLS"] = self.options.polyfill == "impls"
+
+        if self._supports_external_polyfill:
+            tc.variables["BSONCXX_POLY_USE_MNMLSTC"] = self.options.polyfill == "mnmlstc"
+            tc.variables["BSONCXX_POLY_USE_BOOST"] = self.options.polyfill == "boost"
+
         tc.variables["BSONCXX_POLY_USE_STD"] = self.options.polyfill == "std"
-        tc.variables["BSONCXX_POLY_USE_STD_EXPERIMENTAL"] = self.options.polyfill == "experimental"
-        tc.variables["BSONCXX_POLY_USE_BOOST"] = self.options.polyfill == "boost"
+
         tc.cache_variables["BUILD_VERSION"] = self.version
         tc.cache_variables["BSONCXX_LINK_WITH_STATIC_MONGOC"] = "OFF" if self.dependencies["mongo-c-driver"].options.shared else "ON"
         tc.cache_variables["MONGOCXX_LINK_WITH_STATIC_MONGOC"] = "OFF" if self.dependencies["mongo-c-driver"].options.shared else "ON"

--- a/recipes/mongo-cxx-driver/all/conanfile.py
+++ b/recipes/mongo-cxx-driver/all/conanfile.py
@@ -62,7 +62,6 @@ class MongoCxxConan(ConanFile):
         return {
             "std": "17",
             "boost": "11",
-            "polyfill": "11",
             "impls": "11",
         }[str(self.options.polyfill)]
 


### PR DESCRIPTION
### Summary

Changes to recipe:  **mongo-cxx-driver/x**

#### Motivation

Addresses issues with this recipe's polyfill handling mentioned in: https://github.com/conan-io/conan-center-index/issues/26000

#### Details

The polyfill configuration in the existing recipe does not properly reflect what is supported across the various mongo-cxx-driver versions. This PR makes the changes the model the following:

- As of 3.10:
  - `std::experimental` polyfill is no longer supported.
  - Polyfill implementations provided by mongo-cxx-driver are now supported.
- As of 4.0:
  - External polyfill from Boost or mnmlstc is no longer supported.

These changes were split from this version bump PR: https://github.com/conan-io/conan-center-index/pull/29013

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan