### PR TITLE
[wayland] make scanner optional and add other os support

### DIFF
--- a/recipes/wayland/all/conanfile.py
+++ b/recipes/wayland/all/conanfile.py
@@ -29,33 +29,51 @@ class WaylandConan(ConanFile):
         "fPIC": [True, False],
         "enable_libraries": [True, False],
         "enable_dtd_validation": [True, False],
+        "enable_scanner": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "enable_libraries": True,
         "enable_dtd_validation": True,
+        "enable_scanner": True
     }
 
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
+        if not self.options.get_safe("enable_scanner", True):
+            self.options.rm_safe("enable_dtd_validation")
         self.settings.rm_safe("compiler.cppstd")
         self.settings.rm_safe("compiler.libcxx")
+
+    def config_options(self):
+        if self.settings.os not in ("Linux", "Android"):
+            del self.options.enable_libraries
+            del self.options.enable_scanner
 
     def layout(self):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        if self.options.enable_libraries:
+        if self.options.get_safe("enable_libraries"):
             self.requires("libffi/[>=3.4.4 <4]")
-        if self.options.enable_dtd_validation:
-            self.requires("libxml2/[>=2.12.5 <3]")
-        self.requires("expat/[>=2.6.2 <3]")
+        if self.options.get_safe("enable_scanner", True):
+            self.requires("expat/[>=2.6.2 <3]")
+            if self.options.enable_dtd_validation:
+                self.requires("libxml2/[>=2.12.5 <3]")
+
+    def validate_build(self):
+        if os.getenv('CONAN_CENTER_BUILD_SERVICE') is not None and self.settings.os == "Macos":
+            # https://github.com/conan-io/conan/issues/19195
+            raise ConanInvalidConfiguration(
+                "Macos build disabled on CCI as test package requires pkg-config")
 
     def validate(self):
-      if self.settings.os not in ("Linux", "Android"):
-            raise ConanInvalidConfiguration(f"{self.ref} only supports Linux or Android")
+      if self.info.settings.os == "Windows":
+          raise ConanInvalidConfiguration(f"{self.ref} does not support Windows")
+      if not (self.options.get_safe("enable_libraries") or self.options.get_safe("enable_scanner", True)):
+          raise ConanInvalidConfiguration(f"Either libraries or scanner must be enabled")
 
     def build_requirements(self):
         self.tool_requires("meson/[>=1.4.0 <2]")
@@ -67,6 +85,13 @@ class WaylandConan(ConanFile):
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
+    def _is_build_require(self):
+        if self.options.get_safe("enable_scanner", True) and self.dependencies["expat"].is_build_context:
+            return True
+        if self.options.get_safe("enable_libraries") and self.dependencies["libffi"].is_build_context:
+            return True
+        return False
+
     def generate(self):
         env = VirtualBuildEnv(self)
         env.generate()
@@ -77,19 +102,19 @@ class WaylandConan(ConanFile):
         pkg_config_deps = PkgConfigDeps(self)
         if not can_run(self):
             pkg_config_deps.build_context_activated = ["wayland"]
-        elif self.dependencies["expat"].is_build_context:  # wayland is being built as build_require
+        elif self._is_build_require():
             # If wayland is the build_require, all its dependencies are treated as build_requires
             pkg_config_deps.build_context_activated = [dep.ref.name for _, dep in self.dependencies.host.items()]
         pkg_config_deps.generate()
         tc = MesonToolchain(self)
         tc.project_options["libdir"] = "lib"
         tc.project_options["datadir"] = "res"
-        tc.project_options["libraries"] = self.options.enable_libraries
-        tc.project_options["dtd_validation"] = self.options.enable_dtd_validation
+        tc.project_options["libraries"] = bool(self.options.get_safe("enable_libraries", False))
+        tc.project_options["dtd_validation"] = bool(self.options.get_safe("enable_dtd_validation", False))
+        tc.project_options["scanner"] = bool(self.options.get_safe("enable_scanner", True))
         tc.project_options["documentation"] = False
         if not can_run(self):
             tc.project_options["build.pkg_config_path"] = self.generators_folder
-        tc.project_options["scanner"] = True
         tc.generate()
 
     def _patch_sources(self):
@@ -110,25 +135,26 @@ class WaylandConan(ConanFile):
         rmdir(self, pkg_config_dir)
 
     def package_info(self):
-        self.cpp_info.components["wayland-scanner"].set_property("pkg_config_name", "wayland-scanner")
-        self.cpp_info.components["wayland-scanner"].resdirs = ["res"]
-        self.cpp_info.components["wayland-scanner"].includedirs = []
-        self.cpp_info.components["wayland-scanner"].libdirs = []
-        self.cpp_info.components["wayland-scanner"].set_property("component_version", self.version)
-        self.cpp_info.components["wayland-scanner"].requires = ["expat::expat"]
-        if self.options.enable_dtd_validation:
-            self.cpp_info.components["wayland-scanner"].requires.append("libxml2::libxml2")
-        pkgconfig_variables = {
-            'datarootdir': '${prefix}/res',
-            'pkgdatadir': '${datarootdir}/wayland',
-            'bindir': '${prefix}/bin',
-            'wayland_scanner': '${bindir}/wayland-scanner',
-        }
-        self.cpp_info.components["wayland-scanner"].set_property(
-            "pkg_config_custom_content",
-            "\n".join(f"{key}={value}" for key,value in pkgconfig_variables.items()))
+        if self.options.get_safe("enable_scanner", True):
+            self.cpp_info.components["wayland-scanner"].set_property("pkg_config_name", "wayland-scanner")
+            self.cpp_info.components["wayland-scanner"].resdirs = ["res"]
+            self.cpp_info.components["wayland-scanner"].includedirs = []
+            self.cpp_info.components["wayland-scanner"].libdirs = []
+            self.cpp_info.components["wayland-scanner"].set_property("component_version", self.version)
+            self.cpp_info.components["wayland-scanner"].requires = ["expat::expat"]
+            if self.options.enable_dtd_validation:
+                self.cpp_info.components["wayland-scanner"].requires.append("libxml2::libxml2")
+            pkgconfig_variables = {
+                'datarootdir': '${prefix}/res',
+                'pkgdatadir': '${datarootdir}/wayland',
+                'bindir': '${prefix}/bin',
+                'wayland_scanner': '${bindir}/wayland-scanner',
+            }
+            self.cpp_info.components["wayland-scanner"].set_property(
+                "pkg_config_custom_content",
+                "\n".join(f"{key}={value}" for key,value in pkgconfig_variables.items()))
 
-        if self.options.enable_libraries:
+        if self.options.get_safe("enable_libraries"):
             self.cpp_info.components["wayland-server"].libs = ["wayland-server"]
             self.cpp_info.components["wayland-server"].set_property("pkg_config_name", "wayland-server")
             self.cpp_info.components["wayland-server"].requires = ["libffi::libffi"]

--- a/recipes/wayland/all/test_package/CMakeLists.txt
+++ b/recipes/wayland/all/test_package/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES C)
 
-find_package(wayland COMPONENTS wayland-client REQUIRED)
-
-add_executable(test_package test_package.c)
-target_link_libraries(test_package PRIVATE wayland::wayland-client)
+if (CONAN_WAYLAND_LIBRARIES_ENABLED)
+    find_package(wayland COMPONENTS wayland-client REQUIRED)
+    add_executable(test_package test_package.c)
+    target_link_libraries(test_package PRIVATE wayland::wayland-client)
+endif()


### PR DESCRIPTION
### Summary
Changes to recipe:  **wayland/1.22.0**

#### Motivation

Makes an option available to build the scanner which mirrors the upstream meson build options. This also
enables building the scanner on a non-Linux build system as part of a cross compilation.

This also provides a workaround for #28861 by disabling the scanner during the host build, and making it available as a `tool_require` for the build system with the libraries disabled.

#### Details

* adds the option `enable_scanner`
* Relaxes the platform restrictions
* Deletes options that are not relevant to non-Linux platforms.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
