### PR TITLE
spdlog: Expose SPDLOG_PREVENT_CHILD_FD option

### DIFF
--- a/recipes/spdlog/all/conanfile.py
+++ b/recipes/spdlog/all/conanfile.py
@@ -28,6 +28,7 @@ class SpdlogConan(ConanFile):
         "wchar_console": [True, False],
         "no_exceptions": [True, False],
         "use_std_fmt": [True, False],
+        "prevent_child_fd": [True, False],
     }
     default_options = {
         "shared": False,
@@ -38,6 +39,7 @@ class SpdlogConan(ConanFile):
         "wchar_console": False,
         "no_exceptions": False,
         "use_std_fmt": False,
+        "prevent_child_fd": False,
     }
 
     def export_sources(self):
@@ -124,6 +126,7 @@ class SpdlogConan(ConanFile):
             tc.cache_variables["SPDLOG_INSTALL"] = True
             tc.cache_variables["SPDLOG_NO_EXCEPTIONS"] = self.options.no_exceptions
             tc.cache_variables["SPDLOG_USE_STD_FORMAT"] = self.options.get_safe("use_std_fmt")
+            tc.cache_variables["SPDLOG_PREVENT_CHILD_FD"] = self.options.get_safe("prevent_child_fd")
             if self.settings.os in ("iOS", "tvOS", "watchOS"):
                 tc.cache_variables["SPDLOG_NO_TLS"] = True
             tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0091"] = "NEW"
@@ -190,6 +193,8 @@ class SpdlogConan(ConanFile):
             self.cpp_info.components["libspdlog"].defines.append("SPDLOG_UTF8_TO_WCHAR_CONSOLE")
         if self.options.no_exceptions:
             self.cpp_info.components["libspdlog"].defines.append("SPDLOG_NO_EXCEPTIONS")
+        if self.options.get_safe("prevent_child_fd"):
+            self.cpp_info.components["libspdlog"].defines.append("SPDLOG_PREVENT_CHILD_FD")
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["libspdlog"].system_libs = ["pthread"]
         if self.options.header_only and self.settings.os in ("iOS", "tvOS", "watchOS"):


### PR DESCRIPTION
Expose the SPDLOG_PREVENT_CHILD_FD library option from the recipe.


### Summary
Changes to recipe:  **spdlog/[version]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
