### PR TITLE
[glfw] fix hard dependency on opengl

### DIFF
--- a/recipes/glfw/all/conanfile.py
+++ b/recipes/glfw/all/conanfile.py
@@ -187,25 +187,6 @@ class GlfwConan(ConanFile):
         cmake.install()
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
-        self._create_cmake_module_alias_targets(
-            os.path.join(self.package_folder, self._module_file_rel_path),
-            {"glfw": "glfw::glfw"}
-        )
-
-    def _create_cmake_module_alias_targets(self, module_file, targets):
-        content = ""
-        for alias, aliased in targets.items():
-            content += textwrap.dedent(f"""\
-                if(TARGET {aliased} AND NOT TARGET {alias})
-                    add_library({alias} INTERFACE IMPORTED)
-                    set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
-                endif()
-            """)
-        save(self, module_file, content)
-
-    @property
-    def _module_file_rel_path(self):
-        return os.path.join("lib", "cmake", f"conan-official-{self.name}-targets.cmake")
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "glfw3")
@@ -227,9 +208,6 @@ class GlfwConan(ConanFile):
                 "AppKit", "Cocoa", "CoreFoundation", "CoreGraphics",
                 "CoreServices", "Foundation", "IOKit",
             ])
-        self.cpp_info.requires = ["opengl::opengl"]
-        if self.options.get_safe("vulkan_static"):
-            self.cpp_info.requires.append("vulkan-loader::vulkan-loader")
         if self.settings.os in ["Linux", "FreeBSD"]:
             if self.options.get_safe("with_x11", True):
                 # https://github.com/glfw/glfw/blob/3.4/src/CMakeLists.txt#L181-L218


### PR DESCRIPTION
### Summary
Changes to recipe:  **glfw/3.4**

#### Motivation
It was not possible to use `[platform_requires]` to replace GLFW system dependencies because hard requirements were duplicated in the conanfile.

#### Details
remove the duplicated requirements specified in the conanfile as GLFW >=3.4 loads library dependencies at runtime. This enables the dependencies on OpenGL and/or Vulkan to be skipped using `[platform_requires]`

Also remove some CMake build module generation that is no longer required.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
