### PR TITLE
[libsecret] Add version 0.21.7 and use version ranges for glib dependency

### DIFF
--- a/recipes/libsecret/all/conandata.yml
+++ b/recipes/libsecret/all/conandata.yml
@@ -1,10 +1,10 @@
 sources:
+  "0.21.7":
+    url: "https://download.gnome.org/sources/libsecret/0.21/libsecret-0.21.7.tar.xz"
+    sha256: "6b452e4750590a2b5617adc40026f28d2f4903de15f1250e1d1c40bfd68ed55e"
   "0.21.4":
     url: "https://download.gnome.org/sources/libsecret/0.21/libsecret-0.21.4.tar.xz"
     sha256: "163d08d783be6d4ab9a979ceb5a4fecbc1d9660d3c34168c581301cd53912b20"
   "0.20.5":
     url: "https://download.gnome.org/sources/libsecret/0.20/libsecret-0.20.5.tar.xz"
     sha256: "3fb3ce340fcd7db54d87c893e69bfc2b1f6e4d4b279065ffe66dac9f0fd12b4d"
-  "0.20.4":
-    url: "https://download.gnome.org/sources/libsecret/0.20/libsecret-0.20.4.tar.xz"
-    sha256: "325a4c54db320c406711bf2b55e5cb5b6c29823426aa82596a907595abb39d28"

--- a/recipes/libsecret/all/conanfile.py
+++ b/recipes/libsecret/all/conanfile.py
@@ -9,7 +9,7 @@ from conan.tools.meson import Meson, MesonToolchain
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.60.0 <2.0 || >=2.0.6"
+required_conan_version = ">=2.1"
 
 
 class LibsecretConan(ConanFile):
@@ -26,13 +26,11 @@ class LibsecretConan(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "crypto": [False, "libgcrypt", "gnutls"],
-        "with_libgcrypt": [True, False, "deprecated"],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "crypto": "libgcrypt",
-        "with_libgcrypt": "deprecated",
     }
 
     def config_options(self):
@@ -45,18 +43,16 @@ class LibsecretConan(ConanFile):
             self.options.rm_safe("fPIC")
         self.settings.rm_safe("compiler.cppstd")
         self.settings.rm_safe("compiler.libcxx")
-        if self.options.with_libgcrypt != "deprecated":
-            self.output.warning(f"The '{self.ref}:with_libgcrypt' option is deprecated. Use '{self.ref}:crypto' instead.")
 
     def layout(self):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("glib/2.78.3", transitive_headers=True, transitive_libs=True)
+        self.requires("glib/[>=2.78.3 <3]", transitive_headers=True, transitive_libs=True)
         if self.options.get_safe("crypto") == "libgcrypt":
             self.requires("libgcrypt/1.10.3")
         elif self.options.get_safe("crypto") == "gnutls":
-            self.requires("gnutls/3.8.2")
+            self.requires("gnutls/3.8.7")
 
     def validate(self):
         if self.settings.os == "Windows":
@@ -64,13 +60,10 @@ class LibsecretConan(ConanFile):
         if self.options.crypto == "gnutls" and Version(self.version) < "0.21.2":
             raise ConanInvalidConfiguration(f"{self.ref} does not support GnuTLS before version 0.21.2. Use -o '&:crypto=libgcrypt' instead.")
 
-    def package_id(self):
-        del self.info.options.with_libgcrypt
-
     def build_requirements(self):
-        self.tool_requires("meson/1.4.1")
+        self.tool_requires("meson/[>=1.4.0 <2]")
         if not self.conf.get("tools.gnu:pkg_config", check_type=str):
-            self.tool_requires("pkgconf/2.2.0")
+            self.tool_requires("pkgconf/[2.2 <3]")
         self.tool_requires("glib/<host_version>")
 
         if is_apple_os(self):
@@ -78,7 +71,7 @@ class LibsecretConan(ConanFile):
             # a different/incompatible libiconv than the one being exposed
             # in the runtime environment (DYLD_LIBRARY_PATH)
             # See https://github.com/conan-io/conan-center-index/pull/17502#issuecomment-1542492466
-            self.tool_requires("gettext/0.22.5")
+            self.tool_requires("gettext/[>=0.22 <1]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/libsecret/config.yml
+++ b/recipes/libsecret/config.yml
@@ -1,7 +1,7 @@
 versions:
+  "0.21.7":
+    folder: all
   "0.21.4":
     folder: all
   "0.20.5":
-    folder: all
-  "0.20.4":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **libsecret/0.21.7**

#### Motivation

Related to #29072. The wxWidgets uses the libsecret package as a dependency, and glib is also in the list, using a newer version due the new GTK4 package available.

#### Details

* Added latest release 0.21.7: https://download.gnome.org/sources/libsecret/0.21/

* Version 0.21.7 diff: https://gitlab.gnome.org/GNOME/libsecret/-/compare/0.21.4...0.21.7?from_project_id=1696

* Removed 0.20.4 from conandata.yml to stop publishing new revisions in Conan Center. The version 0.20.5 is used by keychain package.

* Updated glib, meson, pkgconfig and gettext to use version ranges.

* Using gnutls latest version available on Conan Center

* Removed deprecated option `with_libgcrypt`

Built locally on Linux:

* [libsecret-0.21.7-linux-amd64-gcc13-release-shared.log](https://github.com/user-attachments/files/24855961/libsecret-0.21.7-linux-amd64-gcc13-release-shared.log)
* [libsecret-0.21.7-linux-amd64-gcc13-release-static.log](https://github.com/user-attachments/files/24855962/libsecret-0.21.7-linux-amd64-gcc13-release-static.log)
* [libsecret-0.21.7-linux-armv8-gcc13-release-static.log](https://github.com/user-attachments/files/24855963/libsecret-0.21.7-linux-armv8-gcc13-release-static.log)


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
