### PR TITLE
add cgal/6.0.3 and cgal/6.1.1

### DIFF
--- a/recipes/cgal/all/conandata.yml
+++ b/recipes/cgal/all/conandata.yml
@@ -38,9 +38,15 @@ sources:
   "6.0.2":
     sha256: 11eaf69d6d21083c6074c2187267cee28541fc462d6b7cbb3deb599007b64f3a
     url: https://github.com/CGAL/cgal/releases/download/v6.0.2/CGAL-6.0.2-library.tar.xz
+  "6.0.3":
+    sha256: 5c82166e6934397a523f2cb0aa35921d17e97f56fbc24e649a8627ef60a76a5c
+    url: https://github.com/CGAL/cgal/releases/download/v6.0.3/CGAL-6.0.3-library.tar.xz
   "6.1":
     sha256: ef4861f1a55417d1e884306c9408ff64fdf39362a38443f17885c55f7f19278a
     url: https://github.com/CGAL/cgal/releases/download/v6.1/CGAL-6.1-library.tar.xz
+  "6.1.1":
+    sha256: 37e9fffe48a83209b070e1914c6aa0a7bae8076749712ab78b53245e176e0e0e
+    url: https://github.com/CGAL/cgal/releases/download/v6.1.1/CGAL-6.1.1-library.tar.xz
 patches:
   "5.3.2":
     - patch_file: "patches/0001-fix-for-conan.patch"

--- a/recipes/cgal/config.yml
+++ b/recipes/cgal/config.yml
@@ -25,5 +25,9 @@ versions:
     folder: all
   "6.0.2":
     folder: all
+  "6.0.3":
+    folder: all
   "6.1":
+    folder: all
+  "6.1.1":
     folder: all


### PR DESCRIPTION
### Summary

Changes to recipe:  add **cgal/6.0.3** and **cgal/6.1.1**

#### Motivation

This PR adds support for CGAL versions 6.0.3 and 6.1.1 to the conan-center-index. Those two new versions of CGAL are the latest bug-fixes releases. See

  - https://www.cgal.org/2026/01/26/cgal603/
  - https://www.cgal.org/2026/01/26/cgal611/


#### Details

No change but the bump of the version.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
