### PR TITLE
boost: Prepare fix for openssl handling due to problems building 1.90.0

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1554,6 +1554,12 @@ class BoostConan(ConanFile):
         if self._with_zstd:
             contents += create_library_config("zstd", "zstd")
 
+        # As boost >= 1.90.0 searches for libssl, if a system library is installed it will find it.
+        # Unlike lzma etc., none of -sNO_SSL/-sNO_OPENSSL style params worked. So suggested on the
+        # cpplang#boost slack, giving an invalid/empty library search path for openssl prevents
+        # the search to happen and builds without ssl.
+        contents += "\nusing openssl : : <ssl-name>NOSUCHFILE ;"
+
         if not self.options.without_python:
             # https://www.boost.org/doc/libs/1_70_0/libs/python/doc/html/building/configuring_boost_build.html
             contents += f'\nusing python : {self._python_version} : "{self._python_executable}" : "{self._python_includes}" : "{self._python_library_dir}" ;'


### PR DESCRIPTION
### Summary
Changes to recipe:  **boost/1.90.0**

#### Motivation
On the weekend I found a problem with boost/1.90.0 if there is a system-installed openssl available: #29433

It needs to be fixed so that people with a system SSL installed for other reason can:
a) Build boost/1.90.0
b) Don't accidentially get a library linked to a non-managed system library unintended.

#### Details
This is not final and needs some input from someone understanding the dependency graph logic in the recipe better. I'd suggest we keep ssl of by default. Only library involved I see so far is `boost_cobalt_io_ssl` which isn't represented at all in the dependency logic yet and thus - leading to the reported error.

Needs input on how to properly integrated it in the logic. Alternatively I'd be also fine with forcing it to not be available via just keeping the else-path from the `user-config.jam`build logic.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details. Fixes #29433
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
