### PR TITLE
dispenso: add version 1.5.0

### DIFF
--- a/recipes/dispenso/all/conandata.yml
+++ b/recipes/dispenso/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.5.0":
+    url: "https://github.com/facebookincubator/dispenso/archive/refs/tags/v1.5.0.tar.gz"
+    sha256: "1773991c164b723567fcdf922651f75e7d2611ab36efd87dd0cd3ef20b135e2f"
   "1.3.0":
     url: "https://github.com/facebookincubator/dispenso/archive/refs/tags/v1.3.0.tar.gz"
     sha256: "824afe8d0d36bfd9bc9b1cbe9be89e7f3ed642a3612766d1c99d5f8dfc647c63"

--- a/recipes/dispenso/config.yml
+++ b/recipes/dispenso/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.5.0":
+    folder: all
   "1.3.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **dispenso/1.5.0**

fixes #29869

#### Motivation
Add dispenso to Conan Center Index.

[dispenso](https://github.com/facebookincubator/dispenso) is a high-performance C++ library for parallel programming from Meta. It provides work-stealing thread pools, parallel for loops, futures, task graphs, pipelines, and concurrent containers. MIT licensed, requires C++14, no external dependencies beyond pthreads.

#### Details
New recipe for dispenso 1.5.0. Includes `conandata.yml`, `conanfile.py`, `config.yml`, and `test_package`.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan
---