### PR TITLE
onetbb: disable tbbmalloc_proxy on msvc ARM

### DIFF
--- a/recipes/onetbb/all/conanfile.py
+++ b/recipes/onetbb/all/conanfile.py
@@ -42,16 +42,16 @@ class OneTBBConan(ConanFile):
 
     @property
     def _has_tbbmalloc(self):
-        return Version(self.version) < "2021.5.0" or self.options.get_safe("tbbmalloc")
+        return self.options.get_safe("tbbmalloc")
 
     @property
     def _has_tbbproxy(self):
-        return Version(self.version) < "2021.6.0" or self.options.get_safe("tbbproxy")
+        return self.options.get_safe("tbbproxy")
 
     @property
     def _tbbbind_hwloc_version(self):
         # TBB expects different variables depending on the version
-        return "2_5" if Version(self.version) >= "2021.4.0" else "2_4"
+        return "2_5"
 
     @property
     def _tbbbind_supported(self):
@@ -80,19 +80,17 @@ class OneTBBConan(ConanFile):
         export_conandata_patches(self)
 
     def config_options(self):
-        if Version(self.version) < "2021.5.0":
-            del self.options.tbbmalloc
-        if Version(self.version) < "2021.6.0" or (self.settings.compiler == "msvc" and self.settings.arch == "armv8"):
+        if self.settings.compiler == "msvc" and self.settings.arch == "armv8":
             del self.options.tbbproxy
         if not self._tbbbind_supported:
             del self.options.tbbbind
-        if Version(self.version) < "2021.6.0" or self.settings.os == "Android":
+        if self.settings.os == "Android":
             del self.options.interprocedural_optimization
         if not self._tbb_apple_frameworks_supported:
             del self.options.build_apple_frameworks
 
     def configure(self):
-        if Version(self.version) >= "2021.6.0" and not self.options.tbbmalloc:
+        if not self.options.tbbmalloc:
             self.options.rm_safe("tbbproxy")
 
     def layout(self):
@@ -125,11 +123,10 @@ class OneTBBConan(ConanFile):
         toolchain = CMakeToolchain(self)
         toolchain.variables["TBB_TEST"] = False
         toolchain.variables["TBB_STRICT"] = False
-        if Version(self.version) >= "2021.5.0":
-            toolchain.variables["TBBMALLOC_BUILD"] = self.options.tbbmalloc
+        toolchain.variables["TBBMALLOC_BUILD"] = self.options.tbbmalloc
         if self.options.get_safe("interprocedural_optimization") is not None:
             toolchain.variables["TBB_ENABLE_IPO"] = self.options.interprocedural_optimization
-        if Version(self.version) >= "2021.6.0" and self.options.get_safe("tbbmalloc"):
+        if self.options.get_safe("tbbmalloc"):
             toolchain.variables["TBBMALLOC_PROXY_BUILD"] = self.options.get_safe("tbbproxy")
         toolchain.variables["TBB_DISABLE_HWLOC_AUTOMATIC_SEARCH"] = not self._tbbbind_build
         if self._tbbbind_explicit_hwloc:

--- a/recipes/onetbb/all/conanfile.py
+++ b/recipes/onetbb/all/conanfile.py
@@ -82,7 +82,7 @@ class OneTBBConan(ConanFile):
     def config_options(self):
         if Version(self.version) < "2021.5.0":
             del self.options.tbbmalloc
-        if Version(self.version) < "2021.6.0":
+        if Version(self.version) < "2021.6.0" or (self.settings.compiler == "msvc" and self.settings.arch == "armv8"):
             del self.options.tbbproxy
         if not self._tbbbind_supported:
             del self.options.tbbbind
@@ -130,7 +130,7 @@ class OneTBBConan(ConanFile):
         if self.options.get_safe("interprocedural_optimization") is not None:
             toolchain.variables["TBB_ENABLE_IPO"] = self.options.interprocedural_optimization
         if Version(self.version) >= "2021.6.0" and self.options.get_safe("tbbmalloc"):
-            toolchain.variables["TBBMALLOC_PROXY_BUILD"] = self.options.tbbproxy
+            toolchain.variables["TBBMALLOC_PROXY_BUILD"] = self.options.get_safe("tbbproxy")
         toolchain.variables["TBB_DISABLE_HWLOC_AUTOMATIC_SEARCH"] = not self._tbbbind_build
         if self._tbbbind_explicit_hwloc:
             hwloc_package_folder = self.dependencies["hwloc"].package_folder

--- a/recipes/onetbb/all/conanfile.py
+++ b/recipes/onetbb/all/conanfile.py
@@ -41,14 +41,6 @@ class OneTBBConan(ConanFile):
     }
 
     @property
-    def _has_tbbmalloc(self):
-        return self.options.get_safe("tbbmalloc")
-
-    @property
-    def _has_tbbproxy(self):
-        return self.options.get_safe("tbbproxy")
-
-    @property
     def _tbbbind_hwloc_version(self):
         # TBB expects different variables depending on the version
         return "2_5"
@@ -205,7 +197,7 @@ class OneTBBConan(ConanFile):
             tbb.system_libs = ["m", "dl", "rt", "pthread"]
 
         # tbbmalloc
-        if self._has_tbbmalloc:
+        if self.options.get_safe("tbbmalloc"):
             tbbmalloc = self.cpp_info.components["tbbmalloc"]
 
             tbbmalloc.set_property("cmake_target_name", "TBB::tbbmalloc")
@@ -220,7 +212,7 @@ class OneTBBConan(ConanFile):
                 tbbmalloc.system_libs = ["dl", "pthread"]
 
             # tbbmalloc_proxy
-            if self._has_tbbproxy:
+            if self.options.get_safe("tbbproxy"):
                 tbbproxy = self.cpp_info.components["tbbmalloc_proxy"]
 
                 tbbproxy.set_property("cmake_target_name", "TBB::tbbmalloc_proxy")


### PR DESCRIPTION
cf https://github.com/uxlfoundation/oneTBB/blob/f1862f38f83568d96e814e469ab61f88336cc595/CMakeLists.txt#L299


### Summary
Changes to recipe:  **onetbb/***

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

#### Details
currently, windows arm consumption fails with 
```
CMake Error at build/msvc-194-armv8-14-release/generators/cmakedeps_macros.cmake:81 (message):
  Library 'tbbmalloc_proxy' not found in package.  If 'tbbmalloc_proxy' is a
  system library, declare it with 'cpp_info.system_libs' property
```
current recipe failure: https://github.com/ericLemanissier/cocorepo/actions/runs/21390030639/job/61574537734
fixed recipe success: https://github.com/ericLemanissier/cocorepo/actions/runs/21391026257/job/61577815393

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
