### PR TITLE
cgns: add version 4.5.1

### DIFF
--- a/recipes/cgns/all/conandata.yml
+++ b/recipes/cgns/all/conandata.yml
@@ -1,8 +1,14 @@
 sources:
+  "4.5.1":
+    url: "https://github.com/CGNS/CGNS/archive/v4.5.1.tar.gz"
+    sha256: "ae63b0098764803dd42b7b2a6487cbfb3c0ae7b22eb01a2570dbce49316ad279"
   "4.3.0":
     url: "https://github.com/CGNS/CGNS/archive/v4.3.0.tar.gz"
     sha256: "7709eb7d99731dea0dd1eff183f109eaef8d9556624e3fbc34dc5177afc0a032"
 patches:
+  "4.5.1":
+    - patch_file: "patches/4.5.1-fix_find_hdf5.patch"
+    - patch_file: "patches/4.5.1-fix_static_or_shared.patch"
   "4.3.0":
     - patch_file: "patches/4.3.0-fix_find_hdf5.patch"
     - patch_file: "patches/4.3.0-fix_static_or_shared.patch"

--- a/recipes/cgns/all/patches/4.5.1-fix_find_hdf5.patch
+++ b/recipes/cgns/all/patches/4.5.1-fix_find_hdf5.patch
@@ -1,0 +1,23 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -597,7 +597,7 @@ add_library(cgns_static STATIC ${cgns_FILES} $<$<BOOL:${CGNS_ENABLE_FORTRAN}>:$<
+ add_library(CGNS::cgns-static ALIAS cgns_static)
+ # Needed to work around a CMake > 3.8 bug on Windows with MSVS and Intel Fortran
+ set_property(TARGET cgns_static PROPERTY LINKER_LANGUAGE C)
+-target_link_libraries(cgns_static PRIVATE $<$<BOOL:${CGNS_ENABLE_HDF5}>:hdf5-${CG_HDF5_LINK_TYPE}>)
++target_link_libraries(cgns_static PRIVATE $<$<BOOL:${CGNS_ENABLE_HDF5}>:HDF5::HDF5>)
+
+ # Build a shared version of the library
+ if(CGNS_BUILD_SHARED)
+@@ -614,8 +614,8 @@ if(CGNS_BUILD_SHARED)
+     target_compile_definitions(cgns_shared PRIVATE -DBUILD_DLL)
+     target_compile_definitions(cgns_shared INTERFACE -DUSE_DLL)
+   endif ()
+-  if (CGNS_ENABLE_HDF5 AND HDF5_LIBRARY)
+-    target_link_libraries(cgns_shared PUBLIC hdf5-${CG_HDF5_LINK_TYPE} $<$<NOT:$<PLATFORM_ID:Windows>>:${CMAKE_DL_LIBS}>)
++  if (CGNS_ENABLE_HDF5)
++    target_link_libraries(cgns_shared PUBLIC HDF5::HDF5 $<$<NOT:$<PLATFORM_ID:Windows>>:${CMAKE_DL_LIBS}>)
+     if(HDF5_NEED_ZLIB AND ZLIB_LIBRARY)
+       target_link_libraries(cgns_shared PUBLIC ${ZLIB_LIBRARY})
+     endif()

--- a/recipes/cgns/all/patches/4.5.1-fix_static_or_shared.patch
+++ b/recipes/cgns/all/patches/4.5.1-fix_static_or_shared.patch
@@ -1,0 +1,23 @@
+Enforces that either static or dynamic libs are built
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -695,7 +695,9 @@ if(CGNS_BUILD_SHARED)
+ endif()
+
+
++if(NOT CGNS_BUILD_SHARED)
+ set (install_targets cgns_static)
++endif()
+ if(CGNS_BUILD_SHARED)
+   set(install_targets ${install_targets} cgns_shared)
+ endif ()
+@@ -771,7 +773,6 @@ install(EXPORT cgns-targets
+ # Tools #
+ #########
+
+-add_subdirectory(tools)
+
+ #########
+ # Tests #

--- a/recipes/cgns/config.yml
+++ b/recipes/cgns/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "4.5.1":
+    folder: all
   "4.3.0":
     folder: all


### PR DESCRIPTION
## Summary

- Added CGNS version 4.5.1 (released January 2025)
- Created version-specific patches for HDF5 target naming and static/shared build fixes

CGNS 4.5.1 fixes compatibility with HDF5 2.0 when building with parallel support enabled.

### Changes
- Updated `config.yml` with new version
- Updated `conandata.yml` with source URL and sha256
- Added `4.5.1-fix_find_hdf5.patch` - fixes HDF5 target naming to use `HDF5::HDF5`
- Added `4.5.1-fix_static_or_shared.patch` - ensures correct static/shared library installation