### PR TITLE
openblas: disable target architecture autodetection

### DIFF
--- a/recipes/openblas/all/conandata.yml
+++ b/recipes/openblas/all/conandata.yml
@@ -11,3 +11,10 @@ sources:
   "0.3.24":
     url: "https://github.com/xianyi/OpenBLAS/archive/v0.3.24.tar.gz"
     sha256: "ceadc5065da97bd92404cac7254da66cc6eb192679cf1002098688978d4d5132"
+patches:
+  "0.3.30":
+    - patch_file: "patches/0.3.30/0001-disable-getarch.patch"
+      patch_type: "portability"
+      patch_description: >
+        Don't try to detect information about the build system to determine
+        architecture flags. This is essential for reproducible builds.

--- a/recipes/openblas/all/patches/0.3.30/0001-disable-getarch.patch
+++ b/recipes/openblas/all/patches/0.3.30/0001-disable-getarch.patch
@@ -1,0 +1,127 @@
+diff --git a/cmake/prebuild.cmake b/cmake/prebuild.cmake
+index 4c100a770..17b3b3355 100644
+--- a/cmake/prebuild.cmake
++++ b/cmake/prebuild.cmake
+@@ -94,8 +94,8 @@ else ()
+  set(BU "_")
+ endif ()
+ 
+-# Cannot run getarch on target if we are cross-compiling
+-if (DEFINED CORE AND CMAKE_CROSSCOMPILING AND NOT (${HOST_OS} STREQUAL "WINDOWSSTORE"))
++# Never run getarch, use value of CORE instead
++if (DEFINED CORE)
+   # Write to config as getarch would
+   if (DEFINED TARGET_CORE)
+   set(TCORE ${TARGET_CORE})
+@@ -1442,109 +1442,6 @@ endif ()
+   file(MAKE_DIRECTORY ${TARGET_CONF_DIR})
+   file(RENAME ${TARGET_CONF_TEMP} "${TARGET_CONF_DIR}/${TARGET_CONF}")
+ 
+-else(NOT CMAKE_CROSSCOMPILING)
+-  # compile getarch
+-  set(GETARCH_SRC
+-    ${PROJECT_SOURCE_DIR}/getarch.c
+-    ${CPUIDEMU}
+-  )
+-
+-  if ("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
+-    #Use generic for MSVC now
+-    message(STATUS "MSVC")
+-    set(GETARCH_FLAGS ${GETARCH_FLAGS} -DFORCE_GENERIC)
+-  else()
+-    if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+-      list(APPEND GETARCH_SRC ${PROJECT_SOURCE_DIR}/cpuid.S)
+-    endif()
+-    if (DEFINED TARGET_CORE)
+-    set(GETARCH_FLAGS ${GETARCH_FLAGS} -DFORCE_${TARGET_CORE})
+-  endif ()
+-  endif ()
+-
+-  if ("${CMAKE_SYSTEM_NAME}" STREQUAL "WindowsStore")
+-    # disable WindowsStore strict CRT checks
+-    set(GETARCH_FLAGS ${GETARCH_FLAGS} -D_CRT_SECURE_NO_WARNINGS)
+-  endif ()
+-
+-  set(GETARCH_DIR "${PROJECT_BINARY_DIR}/getarch_build")
+-  set(GETARCH_BIN "getarch${CMAKE_EXECUTABLE_SUFFIX}")
+-  file(MAKE_DIRECTORY "${GETARCH_DIR}")
+-  configure_file("${TARGET_CONF_TEMP}" "${GETARCH_DIR}/${TARGET_CONF}" COPYONLY)
+-  if (NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "WindowsStore")
+-    if (CMAKE_ASM_COMPILER_ID STREQUAL "")
+-      try_compile(GETARCH_RESULT "${GETARCH_DIR}"
+-        SOURCES ${GETARCH_SRC}
+-        CMAKE_FLAGS "-DCMAKE_ASM_COMPILER=${CMAKE_C_COMPILER}"
+-        COMPILE_DEFINITIONS ${EXFLAGS} ${GETARCH_FLAGS} -I"${GETARCH_DIR}" -I"${PROJECT_SOURCE_DIR}" -I"${PROJECT_BINARY_DIR}"
+-        OUTPUT_VARIABLE GETARCH_LOG
+-        COPY_FILE "${PROJECT_BINARY_DIR}/${GETARCH_BIN}"
+-      )
+-    else()
+-      try_compile(GETARCH_RESULT "${GETARCH_DIR}"
+-        SOURCES ${GETARCH_SRC}
+-        COMPILE_DEFINITIONS ${EXFLAGS} ${GETARCH_FLAGS} -I"${GETARCH_DIR}" -I"${PROJECT_SOURCE_DIR}" -I"${PROJECT_BINARY_DIR}"
+-        OUTPUT_VARIABLE GETARCH_LOG
+-        COPY_FILE "${PROJECT_BINARY_DIR}/${GETARCH_BIN}"
+-      )
+-    endif()
+-    if (NOT ${GETARCH_RESULT})
+-      MESSAGE(FATAL_ERROR "Compiling getarch failed ${GETARCH_LOG}")
+-    endif ()
+-  endif ()
+-  unset (HAVE_AVX2)
+-  unset (HAVE_AVX)
+-  unset (HAVE_FMA3)
+-  unset (HAVE_MMX)
+-  unset (HAVE_SSE)
+-  unset (HAVE_SSE2)
+-  unset (HAVE_SSE3)
+-  unset (HAVE_SSSE3)
+-  unset (HAVE_SSE4A)
+-  unset (HAVE_SSE4_1)
+-  unset (HAVE_SSE4_2)
+-  unset (HAVE_NEON)
+-  unset (HAVE_VFP)
+-  unset (HAVE_VFPV3)
+-  unset (HAVE_VFPV4)
+-  message(STATUS "Running getarch")
+-
+-  # use the cmake binary w/ the -E param to run a shell command in a cross-platform way
+-execute_process(COMMAND "${PROJECT_BINARY_DIR}/${GETARCH_BIN}" 0 OUTPUT_VARIABLE GETARCH_MAKE_OUT)
+-execute_process(COMMAND "${PROJECT_BINARY_DIR}/${GETARCH_BIN}" 1 OUTPUT_VARIABLE GETARCH_CONF_OUT)
+-
+-  message(STATUS "GETARCH results:\n${GETARCH_MAKE_OUT}")
+-
+-  # append config data from getarch to the TARGET file and read in CMake vars
+-  file(APPEND "${TARGET_CONF_TEMP}" ${GETARCH_CONF_OUT})
+-  ParseGetArchVars(${GETARCH_MAKE_OUT})
+-
+-  set(GETARCH2_DIR "${PROJECT_BINARY_DIR}/getarch2_build")
+-  set(GETARCH2_BIN "getarch_2nd${CMAKE_EXECUTABLE_SUFFIX}")
+-  file(MAKE_DIRECTORY "${GETARCH2_DIR}")
+-  configure_file("${TARGET_CONF_TEMP}" "${GETARCH2_DIR}/${TARGET_CONF}" COPYONLY)
+-  if (NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "WindowsStore")
+-    try_compile(GETARCH2_RESULT "${GETARCH2_DIR}"
+-      SOURCES "${PROJECT_SOURCE_DIR}/getarch_2nd.c"
+-    COMPILE_DEFINITIONS ${EXFLAGS} ${GETARCH_FLAGS} ${GETARCH2_FLAGS} -I"${GETARCH2_DIR}" -I"${PROJECT_SOURCE_DIR}" -I"${PROJECT_BINARY_DIR}"
+-      OUTPUT_VARIABLE GETARCH2_LOG
+-      COPY_FILE "${PROJECT_BINARY_DIR}/${GETARCH2_BIN}"
+-    )
+-
+-    if (NOT ${GETARCH2_RESULT})
+-      MESSAGE(FATAL_ERROR "Compiling getarch_2nd failed ${GETARCH2_LOG}")
+-    endif ()
+-  endif ()
+-
+-  # use the cmake binary w/ the -E param to run a shell command in a cross-platform way
+-execute_process(COMMAND "${PROJECT_BINARY_DIR}/${GETARCH2_BIN}" 0 OUTPUT_VARIABLE GETARCH2_MAKE_OUT)
+-execute_process(COMMAND "${PROJECT_BINARY_DIR}/${GETARCH2_BIN}" 1 OUTPUT_VARIABLE GETARCH2_CONF_OUT)
+-
+-  # append config data from getarch_2nd to the TARGET file and read in CMake vars
+-  file(APPEND "${TARGET_CONF_TEMP}" ${GETARCH2_CONF_OUT})
+-
+-  configure_file("${TARGET_CONF_TEMP}" "${TARGET_CONF_DIR}/${TARGET_CONF}" COPYONLY)
+-
+-  ParseGetArchVars(${GETARCH2_MAKE_OUT})
+-
++else()
++  message(FATAL_ERROR "OpenBLAS getarch is disabled for reproducible builds")
+ endif()


### PR DESCRIPTION
### Summary
Changes to recipe:  **openblas/0.3.30**

Fixes #12705.

#### Motivation

By default, OpenBLAS does runtime target architecture autodetection. This is incompatible with Conan's package ID computation, since the binaries now change depending on which CPU was in the build server.  
Specifically, the current binaries in Conan Center were built on a server with AVX-512 support, so they fail immediately with SIGILL on most consumer hardware (where Intel no longer supports AVX-512). This forces users to always add `--build=openblas/*`.

#### Details

This PR adds a patch that fully disables the automatic detection in CMake. It makes the `target` option mandatory for all builds (previously, it was only mandatory for cross-builds). If the user did not specify a `target`, a sensible default based on `settings.arch` is used (this logic already existed for the cross-compilation case).

If desired, I'll add a similar patch for older OpenBLAS releases as well.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
