### PR TITLE
[fltk] Disable Wayland backend by default to avoid using from the system

### DIFF
--- a/recipes/fltk/all/conanfile.py
+++ b/recipes/fltk/all/conanfile.py
@@ -101,6 +101,10 @@ class FltkConan(ConanFile):
         tc.cache_variables["FLTK_BUILD_FLUID"] = False
         if self.settings.compiler.get_safe("runtime") is not None:
             tc.cache_variables["FLTK_MSVC_RUNTIME_DLL"] = "MT" not in msvc_runtime_flag(self)
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            tc.cache_variables["FLTK_BACKEND_X11"] = True
+            # INFO: Disable Wayland backend to avoid using from system
+            tc.cache_variables["FLTK_BACKEND_WAYLAND"] = False
         tc.generate()
         tc = CMakeDeps(self)
         tc.generate()


### PR DESCRIPTION
### Summary
Changes to recipe:  **fltk/1.4.4**

#### Motivation

The Wayland support is enabled by default; the recipe does not list it as a dependency, causing fltk to consume Wayland from the system if installed. This PR disables the Wayland backend by default.

fixes #29022
/cc @jputcu

#### Details

Both X11 and Wayland are enabled by default:

* Wayland: https://github.com/fltk/fltk/blob/release-1.4.4/CMake/options.cmake#L280
* X11: https://github.com/fltk/fltk/blob/release-1.4.4/CMake/options.cmake#L114

Another option would be expanding the recipe to support Wayland via a new option.

Tested locally on Linux with Wayland dev installed using APT: [fltk-1.4.4-linux-amd64-gcc13-release-static.log](https://github.com/user-attachments/files/24888240/fltk-1.4.4-linux-amd64-gcc13-release-static.log)


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
