### PR TITLE
Add 5.6.0 version of hazelcast cpp client

### DIFF
--- a/recipes/hazelcast-cpp-client/all/conandata.yml
+++ b/recipes/hazelcast-cpp-client/all/conandata.yml
@@ -2,6 +2,3 @@ sources:
   "5.6.0":
     url: "https://github.com/hazelcast/hazelcast-cpp-client/archive/v5.6.0.tar.gz"
     sha256: "de2666b64ddc4976fef5893df720c05b450ab257876ddab7ffbc70adaf24a05c"
-  "5.5.0":
-    url: "https://github.com/hazelcast/hazelcast-cpp-client/archive/v5.5.0.tar.gz"
-    sha256: "ca894972060e501c52a4a7f0ad94e4d495233cd98347ded6f3bde5eb4e42ffe1"

--- a/recipes/hazelcast-cpp-client/config.yml
+++ b/recipes/hazelcast-cpp-client/config.yml
@@ -1,5 +1,3 @@
 versions:
   "5.6.0":
     folder: all
-  "5.5.0":
-    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **hazelcast-cpp-client/5.6.0**

#### Motivation
Minor bug fixes and improvements. See [release notes](https://github.com/hazelcast/hazelcast-cpp-client/releases/tag/v5.6.0) 

#### Details
We have a new hazelcast-cpp-client release (some minor improvements, compact serialization i not in beta anymore) 


#### Maintainers edit

* Stop publishing revisions for 5.5.0 version.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
