### PR TITLE
return back 5.5.0 version of hazelcast cpp client

### DIFF
--- a/recipes/hazelcast-cpp-client/all/conandata.yml
+++ b/recipes/hazelcast-cpp-client/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "5.6.0":
     url: "https://github.com/hazelcast/hazelcast-cpp-client/archive/v5.6.0.tar.gz"
     sha256: "de2666b64ddc4976fef5893df720c05b450ab257876ddab7ffbc70adaf24a05c"
+  "5.5.0":
+    url: "https://github.com/hazelcast/hazelcast-cpp-client/archive/v5.5.0.tar.gz"
+    sha256: "ca894972060e501c52a4a7f0ad94e4d495233cd98347ded6f3bde5eb4e42ffe1"

--- a/recipes/hazelcast-cpp-client/config.yml
+++ b/recipes/hazelcast-cpp-client/config.yml
@@ -1,3 +1,5 @@
 versions:
   "5.6.0":
     folder: all
+  "5.5.0":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe (revert it back):  **hazelcast-cpp-client/[5.5.0]**

#### Motivation
as a part of #29456 we had added 5.6.0 but for some reason there were a commit added to delete 5.5.0, but we also want to have ability to still have 5.5.0 as well

#### Details
We want both versions to be available in conan


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

[AbrilRBS](https://github.com/AbrilRBS) and [franramirez688](https://github.com/franramirez688) can you please take a look again thanks 

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
