### PR TITLE
msys2: allow ARM native build

### DIFF
--- a/recipes/msys2/all/conanfile.py
+++ b/recipes/msys2/all/conanfile.py
@@ -74,8 +74,8 @@ class MSYS2Conan(ConanFile):
     def validate_build(self):
         if self.settings.os != "Windows":
             raise ConanInvalidConfiguration("Only Windows supported")
-        if self.settings.arch != "x86_64":
-            raise ConanInvalidConfiguration("Only Windows x64 supported")
+        if self.settings.arch not in ["x86_64", "armv8"]:
+            raise ConanInvalidConfiguration("Only Windows x64 or ARM supported")
 
     def compatibility(self):
         if self.settings.arch == "armv8":


### PR DESCRIPTION

### Summary
Changes to recipe:  **msys2/cci.latest**

#### Motivation
Native build of msys2 just works on armv8. 

#### Details
Success build in https://github.com/eirikb/proof-of-conan/actions/runs/21473927364/job/61853044999
I could then build gettext, libgettext, cairo, pango and gtk etc. all natively on windows on ARM


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
