### PR TITLE
Added recipe: libmng

### DIFF
--- a/recipes/libmng/all/conandata.yml
+++ b/recipes/libmng/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2.0.3":
+    url: "https://downloads.sourceforge.net/project/libmng/libmng-devel/2.0.3/libmng-2.0.3.tar.gz"
+    sha256: "CF112A1FB02F5B1C0FCE5CAB11EA8243852C139E669C44014125874B14B7DFAA"

--- a/recipes/libmng/all/conandata.yml
+++ b/recipes/libmng/all/conandata.yml
@@ -2,3 +2,8 @@ sources:
   "2.0.3":
     url: "https://downloads.sourceforge.net/project/libmng/libmng-devel/2.0.3/libmng-2.0.3.tar.gz"
     sha256: "CF112A1FB02F5B1C0FCE5CAB11EA8243852C139E669C44014125874B14B7DFAA"
+patches:
+  "2.0.3":
+    - patch_file: "patches/0001-define-true-false-libmng-jpeg.patch"
+      patch_description: "Fixes linux build without lcms"
+      patch_type: "portability"

--- a/recipes/libmng/all/conanfile.py
+++ b/recipes/libmng/all/conanfile.py
@@ -1,0 +1,59 @@
+import os
+
+from conan import ConanFile
+from conan.tools.gnu import Autotools, AutotoolsToolchain
+from conan.tools.files import copy, get, rmdir, rm
+from conan.tools.layout import basic_layout
+from conan.errors import ConanInvalidConfiguration
+
+required_conan_version = ">=1.53.0"
+
+class LibmngConan(ConanFile):
+    name = "libmng"
+    license = "libmng"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://sourceforge.net/projects/libmng/"
+    description = "Multiple-image Network Graphics library."
+    topics = ("mng", "png", "graphics")
+    settings = "os", "compiler", "build_type", "arch"
+    options = {"shared": [True, False], "fPIC": [True, False]}
+    default_options = {"shared": False, "fPIC": True}
+    package_type = "library"
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            self.options.rm_safe("fPIC")
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
+
+    def generate(self):
+        tc = AutotoolsToolchain(self)
+        tc.generate()
+
+    def build(self):
+        autotools = Autotools(self)
+        autotools.configure()
+        autotools.make()
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        autotools = Autotools(self)
+        autotools.install()
+
+        rm(self, "*.la", os.path.join(self.package_folder, "lib"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+        rmdir(self, os.path.join(self.package_folder, "etc"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["mng"]

--- a/recipes/libmng/all/conanfile.py
+++ b/recipes/libmng/all/conanfile.py
@@ -63,6 +63,7 @@ class LibmngConan(ConanFile):
 
     def build(self):
         cmake_lists = os.path.join(self.source_folder, "CMakeLists.txt")
+        replace_in_file(self, cmake_lists, "CMAKE_MINIMUM_REQUIRED(VERSION 2.6)", "CMAKE_MINIMUM_REQUIRED(VERSION 3.5)", strict=False)
         replace_in_file(self, cmake_lists, "${JPEG_LIBRARY}", "${JPEG_LIBRARIES}", strict=False)
         replace_in_file(self, cmake_lists, "${ZLIB_LIBRARY}", "${ZLIB_LIBRARIES}", strict=False)
         cmake = CMake(self)

--- a/recipes/libmng/all/conanfile.py
+++ b/recipes/libmng/all/conanfile.py
@@ -33,14 +33,16 @@ class LibmngConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("zlib/[>=1.2.11 <2]")
+        self.requires("zlib/[>=1.2.11 <2]", transitive_headers=True)
         if self.options.with_jpeg:
-            self.requires("libjpeg/9e")
+            self.requires("libjpeg/9e", transitive_headers=True)
         if self.options.with_lcms:
-            self.requires("lcms/2.14")
+            self.requires("lcms/2.14", transitive_headers=True)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        # Remove the pre-existing config.h file to allow CMake to generate its own
+        rm(self, "config.h", self.source_folder)
 
     def config_options(self):
         if self.settings.os == "Windows":

--- a/recipes/libmng/all/conanfile.py
+++ b/recipes/libmng/all/conanfile.py
@@ -2,7 +2,7 @@ import os
 
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout, CMakeDeps
-from conan.tools.files import copy, get, rmdir, rm
+from conan.tools.files import copy, get, rmdir, rm, replace_in_file
 from conan.errors import ConanInvalidConfiguration
 
 required_conan_version = ">=1.53.0"
@@ -62,6 +62,9 @@ class LibmngConan(ConanFile):
         deps.generate()
 
     def build(self):
+        cmake_lists = os.path.join(self.source_folder, "CMakeLists.txt")
+        replace_in_file(self, cmake_lists, "${JPEG_LIBRARY}", "${JPEG_LIBRARIES}", strict=False)
+        replace_in_file(self, cmake_lists, "${ZLIB_LIBRARY}", "${ZLIB_LIBRARIES}", strict=False)
         cmake = CMake(self)
         cmake.configure()
         cmake.build()

--- a/recipes/libmng/all/conanfile.py
+++ b/recipes/libmng/all/conanfile.py
@@ -56,6 +56,7 @@ class LibmngConan(ConanFile):
         tc.variables["BUILD_SHARED_LIBS"] = self.options.shared
         tc.variables["BUILD_STATIC_LIBS"] = not self.options.shared
         tc.variables["WITH_LCMS2"] = self.options.with_lcms
+        tc.variables["MNG_INSTALL_LIB_DIR"] = "lib"
         tc.generate()
 
         deps = CMakeDeps(self)
@@ -97,10 +98,6 @@ class LibmngConan(ConanFile):
         if self.settings.os == "Windows" and self.options.shared:
             self.cpp_info.defines.append("MNG_USE_DLL")
 
-        if self.settings.os == "Linux":
-            lib64_dir = os.path.join(self.package_folder, "lib64")
-            if os.path.isdir(lib64_dir):
-                self.cpp_info.libdirs.append("lib64")
-
-        if self.settings.os in ["Linux", "Android", "FreeBSD", "SunOS", "AIX"]:
+        if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("m")
+

--- a/recipes/libmng/all/conanfile.py
+++ b/recipes/libmng/all/conanfile.py
@@ -2,7 +2,7 @@ import os
 
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout, CMakeDeps
-from conan.tools.files import copy, get, rmdir, rm, replace_in_file
+from conan.tools.files import copy, get, rmdir, rm, replace_in_file, apply_conandata_patches, export_conandata_patches
 from conan.errors import ConanInvalidConfiguration
 
 required_conan_version = ">=1.53.0"
@@ -40,6 +40,10 @@ class LibmngConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
         # Remove the pre-existing config.h file to allow CMake to generate its own
         rm(self, "config.h", self.source_folder)
+        apply_conandata_patches(self)
+
+    def export_sources(self):
+        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -100,4 +104,3 @@ class LibmngConan(ConanFile):
 
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("m")
-

--- a/recipes/libmng/all/conanfile.py
+++ b/recipes/libmng/all/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout, CMakeDeps
 from conan.tools.files import copy, get, rmdir, rm, replace_in_file, apply_conandata_patches, export_conandata_patches
 from conan.errors import ConanInvalidConfiguration
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.21"
 
 class LibmngConan(ConanFile):
     name = "libmng"
@@ -35,6 +35,9 @@ class LibmngConan(ConanFile):
         self.requires("libjpeg/9f", transitive_headers=True)
         if self.options.with_lcms:
             self.requires("lcms/[>=2.14 <3]", transitive_headers=True)
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.5]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/libmng/all/conanfile.py
+++ b/recipes/libmng/all/conanfile.py
@@ -1,9 +1,8 @@
 import os
 
 from conan import ConanFile
-from conan.tools.gnu import Autotools, AutotoolsToolchain
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir, rm
-from conan.tools.layout import basic_layout
 from conan.errors import ConanInvalidConfiguration
 
 required_conan_version = ">=1.53.0"
@@ -16,12 +15,29 @@ class LibmngConan(ConanFile):
     description = "Multiple-image Network Graphics library."
     topics = ("mng", "png", "graphics")
     settings = "os", "compiler", "build_type", "arch"
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": False, "fPIC": True}
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "with_lcms": [True, False],
+        "with_jpeg": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "with_lcms": True,
+        "with_jpeg": True,
+    }
     package_type = "library"
 
     def layout(self):
-        basic_layout(self, src_folder="src")
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("zlib/[>=1.2.11 <2]")
+        if self.options.with_jpeg:
+            self.requires("libjpeg/9e")
+        if self.options.with_lcms:
+            self.requires("lcms/2.14")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -37,23 +53,35 @@ class LibmngConan(ConanFile):
         self.settings.rm_safe("compiler.cppstd")
 
     def generate(self):
-        tc = AutotoolsToolchain(self)
+        tc = CMakeToolchain(self)
+        tc.variables["BUILD_SHARED_LIBS"] = self.options.shared
+        tc.variables["BUILD_STATIC_LIBS"] = not self.options.shared
+        tc.variables["WITH_LCMS2"] = self.options.with_lcms
+        tc.variables["WITH_JPEG"] = self.options.with_jpeg
         tc.generate()
 
     def build(self):
-        autotools = Autotools(self)
-        autotools.configure()
-        autotools.make()
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
 
     def package(self):
         copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
-        autotools = Autotools(self)
-        autotools.install()
+        cmake = CMake(self)
+        cmake.install()
 
-        rm(self, "*.la", os.path.join(self.package_folder, "lib"))
         rmdir(self, os.path.join(self.package_folder, "share"))
-        rmdir(self, os.path.join(self.package_folder, "etc"))
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "mng")
+        self.cpp_info.set_property("cmake_target_name", "MNG::MNG")
         self.cpp_info.libs = ["mng"]
+
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("m")
+
+        # TODO: Remove after Conan 2.0
+        self.cpp_info.names["cmake_find_package"] = "MNG"
+        self.cpp_info.names["cmake_find_package_multi"] = "MNG"

--- a/recipes/libmng/all/conanfile.py
+++ b/recipes/libmng/all/conanfile.py
@@ -84,12 +84,23 @@ class LibmngConan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "mng")
         self.cpp_info.set_property("cmake_target_name", "MNG::MNG")
 
-        lib_name = "libmng" if self.settings.compiler == "msvc" else "mng"
+        if self.settings.os == "Windows" and self.options.shared:
+            lib_name = "mng"
+        else:
+            lib_name = "libmng" if self.settings.compiler == "msvc" else "mng"
         self.cpp_info.libs = [lib_name]
         self.cpp_info.requires = ["zlib::zlib", "libjpeg::libjpeg"]
 
         if self.options.with_lcms:
             self.cpp_info.requires.append("lcms::lcms")
+
+        if self.settings.os == "Windows" and self.options.shared:
+            self.cpp_info.defines.append("MNG_USE_DLL")
+
+        if self.settings.os == "Linux":
+            lib64_dir = os.path.join(self.package_folder, "lib64")
+            if os.path.isdir(lib64_dir):
+                self.cpp_info.libdirs.append("lib64")
 
         if self.settings.os in ["Linux", "Android", "FreeBSD", "SunOS", "AIX"]:
             self.cpp_info.system_libs.append("m")

--- a/recipes/libmng/all/conanfile.py
+++ b/recipes/libmng/all/conanfile.py
@@ -19,13 +19,11 @@ class LibmngConan(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "with_lcms": [True, False],
-        "with_jpeg": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "with_lcms": True,
-        "with_jpeg": True,
     }
     package_type = "library"
 
@@ -34,8 +32,7 @@ class LibmngConan(ConanFile):
 
     def requirements(self):
         self.requires("zlib/[>=1.2.11 <2]", transitive_headers=True)
-        if self.options.with_jpeg:
-            self.requires("libjpeg/9e", transitive_headers=True)
+        self.requires("libjpeg/9e", transitive_headers=True)
         if self.options.with_lcms:
             self.requires("lcms/2.14", transitive_headers=True)
 
@@ -59,7 +56,6 @@ class LibmngConan(ConanFile):
         tc.variables["BUILD_SHARED_LIBS"] = self.options.shared
         tc.variables["BUILD_STATIC_LIBS"] = not self.options.shared
         tc.variables["WITH_LCMS2"] = self.options.with_lcms
-        tc.variables["WITH_JPEG"] = self.options.with_jpeg
         tc.generate()
 
         deps = CMakeDeps(self)
@@ -84,19 +80,12 @@ class LibmngConan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "mng")
         self.cpp_info.set_property("cmake_target_name", "MNG::MNG")
 
-        # Define the component
-        comp = self.cpp_info.components["mng"]
-        comp.libs = ["mng"]
-        comp.requires = ["zlib::zlib"]
-        if self.options.with_jpeg:
-            comp.requires.append("libjpeg::libjpeg")
-        if self.options.with_lcms:
-            comp.requires.append("lcms::lcms")
+        lib_name = "libmng" if self.settings.compiler == "msvc" else "mng"
+        self.cpp_info.libs = [lib_name]
+        self.cpp_info.requires = ["zlib::zlib", "libjpeg::libjpeg"]
 
-        # Make sure the main target has the same properties as the component
-        self.cpp_info.libs = comp.libs
-        self.cpp_info.requires = comp.requires
+        if self.options.with_lcms:
+            self.cpp_info.requires.append("lcms::lcms")
 
         if self.settings.os in ["Linux", "Android", "FreeBSD", "SunOS", "AIX"]:
-            comp.system_libs.append("m")
-            self.cpp_info.system_libs = comp.system_libs
+            self.cpp_info.system_libs.append("m")

--- a/recipes/libmng/all/patches/0001-define-true-false-libmng-jpeg.patch
+++ b/recipes/libmng/all/patches/0001-define-true-false-libmng-jpeg.patch
@@ -1,0 +1,19 @@
+diff --git a/libmng_jpeg.c b/libmng_jpeg.c
+index f5c43a4bd..50dc12a6b 100644
+--- a/libmng_jpeg.c
++++ b/libmng_jpeg.c
+@@ -57,6 +57,14 @@
+ /* ************************************************************************** */
+ 
+ #include "libmng.h"
++
++/* conan: define TRUE/FALSE for jpeg */
++#ifndef TRUE
++#define TRUE 1
++#endif
++#ifndef FALSE
++#define FALSE 0
++#endif
+ #include "libmng_data.h"
+ #include "libmng_error.h"
+ #include "libmng_trace.h"

--- a/recipes/libmng/all/test_package/CMakeLists.txt
+++ b/recipes/libmng/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(PackageTest CXX)
+
+find_package(libmnl REQUIRED)
+
+add_executable(example example.cpp)
+target_link_libraries(example libmnl::libmnl)

--- a/recipes/libmng/all/test_package/CMakeLists.txt
+++ b/recipes/libmng/all/test_package/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 project(PackageTest CXX)
 
-find_package(libmnl REQUIRED)
+find_package(mng REQUIRED)
 
 add_executable(example example.cpp)
-target_link_libraries(example libmnl::libmnl)
+target_link_libraries(example MNG::MNG)

--- a/recipes/libmng/all/test_package/conanfile.py
+++ b/recipes/libmng/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+
+class LibmnlTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "example")
+            self.run(bin_path, env="conanrun")

--- a/recipes/libmng/all/test_package/conanfile.py
+++ b/recipes/libmng/all/test_package/conanfile.py
@@ -4,7 +4,7 @@ from conan import ConanFile
 from conan.tools.build import can_run
 from conan.tools.cmake import cmake_layout, CMake
 
-class LibmnlTestConan(ConanFile):
+class LibmngTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
     test_type = "explicit"

--- a/recipes/libmng/all/test_package/conanfile.py
+++ b/recipes/libmng/all/test_package/conanfile.py
@@ -12,6 +12,9 @@ class LibmngTestConan(ConanFile):
     def requirements(self):
         self.requires(self.tested_reference_str)
 
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.5]")
+
     def layout(self):
         cmake_layout(self)
 

--- a/recipes/libmng/all/test_package/example.cpp
+++ b/recipes/libmng/all/test_package/example.cpp
@@ -1,0 +1,14 @@
+#include <iostream>
+#include <cstdlib>
+#include <libmnl/libmnl.h>
+
+int main() {
+    struct mnl_socket *nl = mnl_socket_open(NETLINK_NETFILTER);
+    if (nl == NULL) {
+        std::cerr << "mnl_socket_open\n";
+        return EXIT_FAILURE;
+    }
+    mnl_socket_close(nl);
+
+    return EXIT_SUCCESS;
+}

--- a/recipes/libmng/all/test_package/example.cpp
+++ b/recipes/libmng/all/test_package/example.cpp
@@ -3,11 +3,11 @@
 #include <libmng.h>
 
 // Callback functions required by libmng
-mng_ptr mng_malloc(mng_size_t size) {
-    return malloc(size);
+mng_ptr MNG_DECL mng_malloc(mng_size_t size) {
+    return calloc(1, size);
 }
 
-void mng_free(mng_ptr ptr, mng_size_t size) {
+void MNG_DECL mng_free(mng_ptr ptr, mng_size_t size) {
     free(ptr);
 }
 

--- a/recipes/libmng/all/test_package/example.cpp
+++ b/recipes/libmng/all/test_package/example.cpp
@@ -1,14 +1,29 @@
 #include <iostream>
 #include <cstdlib>
-#include <libmnl/libmnl.h>
+#include <libmng.h>
+
+// Callback functions required by libmng
+mng_ptr mng_malloc(mng_size_t size) {
+    return malloc(size);
+}
+
+void mng_free(mng_ptr ptr, mng_size_t size) {
+    free(ptr);
+}
 
 int main() {
-    struct mnl_socket *nl = mnl_socket_open(NETLINK_NETFILTER);
-    if (nl == NULL) {
-        std::cerr << "mnl_socket_open\n";
+    // Initialize libmng
+    mng_handle handle = mng_initialize(NULL, mng_malloc, mng_free, NULL);
+    if (handle == MNG_NULL) {
+        std::cerr << "mng_initialize failed\n";
         return EXIT_FAILURE;
     }
-    mnl_socket_close(nl);
+
+    // Get version information
+    std::cout << "libmng version: " << mng_version_text() << std::endl;
+
+    // Cleanup
+    mng_cleanup(&handle);
 
     return EXIT_SUCCESS;
 }

--- a/recipes/libmng/config.yml
+++ b/recipes/libmng/config.yml
@@ -1,0 +1,3 @@
+versions:
+  2.0.3:
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **libmng/2.0.3**

#### Motivation

Library to read and write Multiple-image Network Graphics (MNG) files which are the animation equivalents to PNG.

While the format itself is quite old, it is for example still used by qt imageformats. The PR https://github.com/conan-io/conan-center-index/pull/28480 would benefit from libmng being available in conan.

Related issues: https://github.com/conan-io/conan-center-index/issues/27255 https://github.com/conan-io/conan-center-index/issues/3106


#### Details
CMake based recipe with minor patches to make it compatible with the conan dependency provider. Small portability patch to support linux builds with lcms disabled.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
