### PR TITLE
intx: add version 0.15.0

### DIFF
--- a/recipes/intx/all/conandata.yml
+++ b/recipes/intx/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.15.0":
+    url: "https://github.com/chfast/intx/archive/refs/tags/v0.15.0.tar.gz"
+    sha256: "7db5d37ae5e9c3787a12c27e53a28be840a35ee51101c3ac15412ce259191600"
   "0.14.0":
     url: "https://github.com/chfast/intx/archive/refs/tags/v0.14.0.tar.gz"
     sha256: "63b1ba7834c6a85d0dde5140cc2aa91bbdbb6cc56e7cb5f4380f43bef90bff3d"

--- a/recipes/intx/config.yml
+++ b/recipes/intx/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.15.0":
+    folder: all
   "0.14.0":
     folder: all
   "0.13.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **intx/0.15.0**

#### Motivation
This new version of intx adds some new feature and also Conan package support locally.
https://github.com/chfast/intx/releases/tag/v0.15.0

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
