### PR TITLE
openapv: Add version 0.2.1.0

### DIFF
--- a/recipes/openapv/all/conandata.yml
+++ b/recipes/openapv/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.2.1.0":
+    url: "https://github.com/AcademySoftwareFoundation/openapv/archive/refs/tags/v0.2.1.0.tar.gz"
+    sha256: "60da432ba2727d5ec7bcf7f2d251eecdec14ced31e07deddb584b38719a691d5"
   "0.2.0.4":
     url: "https://github.com/AcademySoftwareFoundation/openapv/archive/refs/tags/v0.2.0.4.tar.gz"
     sha256: "1d8d31b0758d4b968d9b2ab483b3edb6de3440edcb27f14801ef42d6f2368e55"

--- a/recipes/openapv/config.yml
+++ b/recipes/openapv/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.2.1.0":
+    folder: "all"
   "0.2.0.4":
     folder: "all"


### PR DESCRIPTION
### Summary
Changes to recipe:  **openapv/0.2.1.0**

#### Motivation
Small detail improvements regarding additional metadata handling.

#### Details
* https://github.com/AcademySoftwareFoundation/openapv/releases/tag/v0.2.1.0
* https://github.com/AcademySoftwareFoundation/openapv/compare/v0.2.0.4...v0.2.1.0

Only build related change is addition of code-coverage support which shouldn't be of interest for the package.

Left 0.2.0.4 in as it is referenced in the ffmpeg recipe.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
