### PR TITLE
make xkeyboard-config in xkbcommon optional

### DIFF
--- a/recipes/xkbcommon/all/conanfile.py
+++ b/recipes/xkbcommon/all/conanfile.py
@@ -27,6 +27,7 @@ class XkbcommonConan(ConanFile):
         "with_x11": [True, False],
         "with_wayland": [True, False],
         "xkbregistry": [True, False],
+        "with_xkeyboard_config": [True, False],
     }
     default_options = {
         "shared": False,
@@ -34,6 +35,7 @@ class XkbcommonConan(ConanFile):
         "with_x11": True,
         "with_wayland": True,
         "xkbregistry": True,
+        "with_xkeyboard_config": True
     }
     implements = ["auto_shared_fpic"]
     languages = ["C"]
@@ -48,7 +50,8 @@ class XkbcommonConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("xkeyboard-config/system")
+        if self.options.with_xkeyboard_config:
+            self.requires("xkeyboard-config/system")
         if self.options.get_safe("with_x11"):
             self.requires("xorg/system")
         if self.options.xkbregistry:
@@ -116,7 +119,8 @@ class XkbcommonConan(ConanFile):
     def package_info(self):
         self.cpp_info.components["libxkbcommon"].set_property("pkg_config_name", "xkbcommon")
         self.cpp_info.components["libxkbcommon"].libs = ["xkbcommon"]
-        self.cpp_info.components["libxkbcommon"].requires = ["xkeyboard-config::xkeyboard-config"]
+        if self.options.with_xkeyboard_config:
+            self.cpp_info.components["libxkbcommon"].requires = ["xkeyboard-config::xkeyboard-config"]
         self.cpp_info.components["libxkbcommon"].resdirs = ["res"]
 
         if self.options.get_safe("with_x11"):

--- a/recipes/xkbcommon/all/test_package/CMakeLists.txt
+++ b/recipes/xkbcommon/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 project(test_package LANGUAGES CXX)
 
 find_package(xkbcommon REQUIRED COMPONENTS libxkbcommon)


### PR DESCRIPTION
### Summary
Changes to recipe:  **xkbcommon**

#### Motivation
It is possible on some embedded platforms that use `libxkbcommon`, for `xkeyboard-config` to not be present, e.g. platforms that are Wayland only and do not have legacy X11 capability.

#### Details
Makes the `xkeyboard-config` dependency optional, but defaults to `True`. This reflects the [upstream meson build config](https://github.com/xkbcommon/libxkbcommon/blob/master/meson.build) where `xkeyboard-config` is checked but is not a required dependency.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
