### PR TITLE
qtmultimedia: fixes

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -61,6 +61,7 @@ class QtConan(ConanFile):
         "with_dbus": [True, False],
         "with_ffmpeg": [True, False],
         "with_gstreamer": [True, False],
+        "with_pipewire": [True, False],
         "with_pulseaudio": [True, False],
         "with_gssapi": [True, False],
         "with_md4c": [True, False],
@@ -103,6 +104,7 @@ class QtConan(ConanFile):
         "with_dbus": False,
         "with_ffmpeg": True,
         "with_gstreamer": False,
+        "with_pipewire": True,
         "with_pulseaudio": False,
         "with_gssapi": False,
         "with_md4c": True,
@@ -243,6 +245,9 @@ class QtConan(ConanFile):
         if not self.options.get_safe("qtmultimedia"):
             del self.options.with_gstreamer
             del self.options.with_pulseaudio
+            del self.options.with_pipewire
+        elif self.settings.os != "Linux" or Version(self.version) < Version("6.10.0"):
+            del self.options.with_pipewire
 
         if self.settings.os in ("FreeBSD", "Linux"):
             if self.options.get_safe("qtwebengine"):
@@ -410,6 +415,8 @@ class QtConan(ConanFile):
             self.requires("gst-plugins-base/1.19.2")
         if self.options.get_safe("with_pulseaudio", False):
             self.requires("pulseaudio/14.2")
+        if self.options.get_safe("with_pipewire", False)
+            self.requires("pipewire/1.2.7")
         if self.options.with_dbus:
             self.requires("dbus/1.15.8")
         if self.settings.os in ['Linux', 'FreeBSD'] and self.options.with_gssapi:
@@ -1424,6 +1431,8 @@ class QtConan(ConanFile):
             multimedia_reqs = ["Network", "Gui"]
             if self.options.get_safe("with_pulseaudio", False):
                 multimedia_reqs.append("pulseaudio::pulse")
+            if self.options.get_safe("with_pipewire", False):
+                multimedia_reqs.append("pipewire::pipewire")
             if self.options.get_safe("with_ffmpeg", False):
                 multimedia_reqs.append("ffmpeg::ffmpeg")
             _create_module("Multimedia", multimedia_reqs)


### PR DESCRIPTION
### Summary
Changes to recipe:  **qt/6.x.x**

#### Motivation
The way QtMultimedia is built does not comply with the recommended configurations by Qt and has some relics/dead code.

#### Details

* the preferred backend of QtMultimedia on all platforms is FFmpeg. The AVFoundation/WMF/GStreamer backends do not receive any significant work and all active development and bug fixes go into the the FFmpeg backend. It should be used as default backend if QtMultimedia is used
* openal is not a dependency in Qt-6 and should be removed from the options/dependencies
* the ALSA backend is "experimental" and the use is highly discouraged. We should probably remove it from Qt completely. On linux the recommended audio backend is PipeWire (compare #18533), but PulseAudio is also supported with some caveats
* there has been an odd workaround for throwing when alsa or pulseaudio was enabled. this is more than questionable, as it would render qtmultimedia useless.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

Disclaimer:
it is still untested, as i don't have a proper conan2 setup at the moment (will try to set it up). It is part of a push by the qtmultimedia team to update binary distributions