### PR TITLE
[mcap] Change from broken header-only to regular library

### DIFF
--- a/recipes/mcap/all/CMakeLists.txt
+++ b/recipes/mcap/all/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 4.1.0)
+project(Mcap CXX)
+
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+
+option(MCAP_COMPRESSION_LZ4 "Build mcap with lz4 support" OFF)
+option(MCAP_COMPRESSION_ZSTD "Build mcap with zstd support" OFF)
+
+file(GLOB_RECURSE private_sources "include/mcap/*.inl")
+file(GLOB_RECURSE public_sources "include/mcap/*.hpp")
+
+add_library(mcap)
+target_sources(mcap
+    PUBLIC
+        FILE_SET public_headers TYPE HEADERS BASE_DIRS include FILES ${public_sources}
+    PRIVATE
+        ${private_sources}
+        mcap.cpp
+)
+
+if(MCAP_COMPRESSION_LZ4)
+    find_package(lz4 REQUIRED CONFIG)
+    target_link_libraries(mcap PRIVATE lz4::lz4)
+else()
+    target_compile_definitions(mcap PUBLIC MCAP_COMPRESSION_NO_LZ4)
+endif()
+if(MCAP_COMPRESSION_ZSTD)
+    find_package(zstd REQUIRED CONFIG)
+    target_link_libraries(mcap PRIVATE zstd::zstd)
+else()
+    target_compile_definitions(mcap PUBLIC MCAP_COMPRESSION_NO_ZSTD)
+endif()
+
+if(NOT BUILD_SHARED_LIBS)
+    # Disable symbols exports
+    target_compile_definitions(mcap PUBLIC MCAP_PUBLIC=)
+endif()
+
+install(TARGETS mcap
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+    ARCHIVE DESTINATION lib
+    FILE_SET public_headers DESTINATION include
+)

--- a/recipes/mcap/all/conanfile.py
+++ b/recipes/mcap/all/conanfile.py
@@ -1,7 +1,8 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
-from conan.tools.files import get, copy
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get
 from conan.tools.layout import basic_layout
 from conan.tools.scm import Version
 from conan.tools.microsoft import is_msvc
@@ -18,9 +19,22 @@ class McapConan(ConanFile):
     license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/foxglove/mcap"
-    topics = ("serialization", "deserialization", "recording", "header-only")
-    package_type = "header-library"
+    topics = ("serialization", "deserialization", "recording")
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "with_lz4": [True, False],
+        "with_zstd": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "with_lz4": True,
+        "with_zstd": True,
+    }
+    implements = ["auto_shared_fpic"]
 
     @property
     def _min_cppstd(self):
@@ -31,7 +45,7 @@ class McapConan(ConanFile):
         return {
             "Visual Studio": "16",
             "msvc": "191",
-            "gcc": "9",
+            "gcc": "7",
             "clang": "9",
             "apple-clang": "12",
         }
@@ -44,24 +58,34 @@ class McapConan(ConanFile):
         if Version(self.version) < "0.3.0":
             self.license = "Apache-2.0"
 
+    def export_sources(self):
+        # Upstream library does not ship with a build system.
+        export_source_path = os.path.join(self.export_sources_folder, "src", "cpp", "mcap")
+        copy(self, "CMakeLists.txt", src=self.recipe_folder, dst=export_source_path)
+        copy(self, "mcap.cpp", src=self.recipe_folder, dst=export_source_path)
+
     def layout(self):
-        basic_layout(self, src_folder="src")
+        cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("lz4/1.9.4")
-        self.requires("zstd/1.5.5")
+        if self.options.with_lz4:
+            self.requires("lz4/[>=1.9.4]")
+        if self.options.with_zstd:
+            self.requires("zstd/[>=1.5.5]")
         if Version(self.version) < "0.1.1":
-            self.requires("fmt/9.1.0")
-
-    def package_id(self):
-        self.info.clear()
+            self.requires("fmt/[>=9.1.0]")
 
     def validate(self):
         if Version(self.version) < "0.1.1" and is_msvc(self):
             raise ConanInvalidConfiguration("Visual Studio compiler has been supported since 0.1.1")
 
-        if self.settings.compiler.get_safe("cppstd"):
-            check_min_cppstd(self, self._min_cppstd)
+        if Version(self.version) < "0.7.0" and self.options.shared:
+            raise ConanInvalidConfiguration("Shared library has been supported since 0.7.0")
+
+        if Version(self.version) < "1.1.1" and (not self.options.with_lz4 or not self.options.with_zstd):
+            raise ConanInvalidConfiguration("lz4 and zstd are optional since 1.1.1")
+
+        check_min_cppstd(self, self._min_cppstd)
         minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
         if minimum_version and Version(self.settings.compiler.version) < minimum_version:
             raise ConanInvalidConfiguration(
@@ -71,10 +95,38 @@ class McapConan(ConanFile):
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["MCAP_COMPRESSION_LZ4"] = bool(self.options.with_lz4)
+        tc.variables["MCAP_COMPRESSION_ZSTD"] = bool(self.options.with_zstd)
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        if self.options.with_zstd:
+            deps.set_property("zstd", "cmake_target_name", "zstd::zstd")
+        deps.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure(build_script_folder=self._source_package_path)
+        cmake.build()
+
     def package(self):
         copy(self, "LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self._source_package_path)
-        copy(self, "*", dst=os.path.join(self.package_folder, "include"), src=os.path.join(self._source_package_path, "include"))
+        cmake = CMake(self)
+        cmake.install()
 
     def package_info(self):
-        self.cpp_info.bindirs = []
-        self.cpp_info.libdirs = []
+        self.cpp_info.components["mcap"].set_property("cmake_target_name", "mcap::mcap")
+        self.cpp_info.components["mcap"].set_property("pkg_config_name", "mcap")
+        self.cpp_info.components["mcap"].libs = ["mcap"]
+        if not self.options.shared:
+            self.cpp_info.components["mcap"].defines.append("MCAP_PUBLIC=")
+        if self.options.with_lz4:
+            self.cpp_info.components["mcap"].requires.append("lz4::lz4")
+        else:
+            self.cpp_info.components["mcap"].defines.append("MCAP_COMPRESSION_NO_LZ4=1")
+        if self.options.with_zstd:
+            self.cpp_info.components["mcap"].requires.append("zstd::zstd")
+        else:
+            self.cpp_info.components["mcap"].defines.append("MCAP_COMPRESSION_NO_ZSTD=1")

--- a/recipes/mcap/all/mcap.cpp
+++ b/recipes/mcap/all/mcap.cpp
@@ -1,0 +1,2 @@
+#define MCAP_IMPLEMENTATION
+#include <mcap/mcap.hpp>

--- a/recipes/mcap/all/test_package/test_package.cpp
+++ b/recipes/mcap/all/test_package/test_package.cpp
@@ -1,4 +1,3 @@
-#define MCAP_IMPLEMENTATION
 #include <mcap/reader.hpp>
 #include <mcap/writer.hpp>
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **mcap/***

- Library now supports self-contained builds in shared and static configuration.
- Exposed upstream options.

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
- The library was previously treated as "header-only", but that does not correctly reflect how this library wants to be integrated. The required use of the `MCAP_IMPLEMENTATION` macro in the test package clearly showcases this defect.
- Symbol visibility was always defaulted for use as a shared library.
- Config options supported by the upstream library were not exposed.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
- The upstream library is compatible down to GCC7 (tested), therefor lowered requirements.
- The upstream library does not have a build system for building a reusable library - added one.
- Switch between shared and static library (Supported upstream since 0.7.0)
- Optional linkage against `zstd` and `lz4` (Supported upstream since 1.1.1)
- Correctly configure symbol visibility depending on build type

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan
  - Tested for for all package versions 0.1.1 to 2.1.1

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
