### PR TITLE
[libx264] Run configure at the same location as the source folder

### DIFF
--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -357,7 +357,7 @@ class FFMpegConan(ConanFile):
         if self.options.with_sdl:
             self.requires("sdl/[^2.28]")
         if self.options.with_libx264:
-            self.requires("libx264/cci.20240224")
+            self.requires("libx264/[>=cci.20240224]")
         if self.options.with_libx265:
             self.requires("libx265/[>=3.4 <4]")
         if self.options.with_libvpx:

--- a/recipes/libx264/all/conanfile.py
+++ b/recipes/libx264/all/conanfile.py
@@ -1,7 +1,6 @@
 from conan import ConanFile
 from conan.tools.apple import is_apple_os, XCRun, fix_apple_shared_install_name
-from conan.tools.build import cross_building
-from conan.tools.env import Environment, VirtualBuildEnv
+from conan.tools.env import Environment
 from conan.tools.files import copy, rename, get, rmdir, chdir
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.layout import basic_layout

--- a/recipes/libx264/config.yml
+++ b/recipes/libx264/config.yml
@@ -1,7 +1,3 @@
 versions:
   "cci.20250910":
     folder: all
-  "cci.20240224":
-    folder: all
-  "cci.20220602":
-    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **libx264/cci.20250910**

#### Motivation

fixes #29491
/cc @timblechmann  

#### Details

As commented at #29491, the `configure` script is executed from `self.build_folder` and calls `configure` using its absolute path. This PR moves the execution to be done from `self.source_folder` instead, so the `configure` will be able to find other files, as it's using a relative path during its execution. 

This approach is "common" for some projects in ConanCenterIndex, for instance: `openssl`, `ffmpeg`, `crashpad`, `libalsa`. 

Built locally on Linux: [libx264-cci.20250910-linux-amd64-gcc13-release-static.log](https://github.com/user-attachments/files/25048271/libx264-cci.20250910-linux-amd64-gcc13-release-static.log)


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
