### PR TITLE
gdal: Bumped version to 3.12.1

### DIFF
--- a/recipes/gdal/config.yml
+++ b/recipes/gdal/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "3.12.0":
+  "3.12.1":
     folder: "post_3.5.0"
   "3.8.3": # last version to support c++11, newer versions >=3.10 require c++17
     folder: "post_3.5.0"

--- a/recipes/gdal/post_3.5.0/conandata.yml
+++ b/recipes/gdal/post_3.5.0/conandata.yml
@@ -1,12 +1,12 @@
 sources:
-  "3.12.0":
-    url: "https://github.com/OSGeo/gdal/releases/download/v3.12.0/gdal-3.12.0.tar.gz"
-    sha256: "44c95baabe6c1a047c1ebe5043e38dd73e4936bc4c481db14efbfd03342eab73"
+  "3.12.1":
+    url: "https://github.com/OSGeo/gdal/releases/download/v3.12.1/gdal-3.12.1.tar.gz"
+    sha256: "266cbadf8534d1de831db8834374afd95603e0a6af4f53d0547ae0d46bd3d2d1"
   "3.8.3":
     url: "https://github.com/OSGeo/gdal/releases/download/v3.8.3/gdal-3.8.3.tar.gz"
     sha256: "f7a30387a8239e9da26200f787a02136df2ee6473e86b36d05ad682761a049ea"
 patches:
-  "3.12.0":
+  "3.12.1":
     - patch_file: "patches/3.12.x/0-replace-find-package.patch"
     - patch_file: "patches/3.12.x/2-allow-cycles-in-cmake-targets.patch"
   "3.8.3":


### PR DESCRIPTION
### Summary
Changes to recipe:  **gdal/3.12.1**

#### Motivation
Adding the latest patch version for GDAL (lots of bugfixes). It does not change anything relevant to CMake or the recipe itself.

Latest release notes: https://github.com/OSGeo/gdal/blob/v3.12.1/NEWS.md
Diff: https://github.com/OSGeo/gdal/compare/v3.12.0...v3.12.1

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
