### PR TITLE
libvpx/1.16.0: Version bump

### DIFF
--- a/recipes/libvpx/all/conandata.yml
+++ b/recipes/libvpx/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "1.15.2":
-    url: "https://github.com/webmproject/libvpx/archive/refs/tags/v1.15.2.tar.gz"
-    sha256: "26fcd3db88045dee380e581862a6ef106f49b74b6396ee95c2993a260b4636aa"
+  "1.16.0":
+    url: "https://github.com/webmproject/libvpx/archive/refs/tags/v1.16.0.tar.gz"
+    sha256: "7a479a3c66b9f5d5542a4c6a1b7d3768a983b1e5c14c60a9396edc9b649e015c"

--- a/recipes/libvpx/config.yml
+++ b/recipes/libvpx/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.15.2":
+  "1.16.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **libvpx/1.16.0**

#### Motivation
While looking into build issues when preparing my dependencies on riscv64, I saw that libvpx is available in a new version. (Still looking at the build issues, but if it should be anything recipe-related, I'd make it a separate PR.)

#### Details
* official release tag, commit ID matching the one from github: https://chromium.googlesource.com/webm/libvpx/+/refs/tags/v1.16.0
* https://github.com/webmproject/libvpx/compare/v1.15.2...v1.16.0

The one thing I'm a bit unsure about is, that for many targets, it appears the configure script validates c++17 compatibility:
```
            check_add_cxxflags -std=gnu++11
            check_add_cxxflags -std=gnu++17
```

This sparks two questions:
1. Currently there is no check at all. Does conan assume, if nothing is specified in the recipe, it is at least building c++11 or would previous standards also be viable? (Never used conan with anything before 17 myself...). Manually tried with a cppstd=11 profile on macOS and it did build.
2. If we introduce a check for 17, should we keep the previous version too, so that there is a supported version compatible with an older standard?

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
