### PR TITLE
libvpx: Fix handling of unknown platforms & only require yasm when needed

### DIFF
--- a/recipes/libvpx/all/conanfile.py
+++ b/recipes/libvpx/all/conanfile.py
@@ -69,7 +69,8 @@ class LibVPXConan(ConanFile):
             raise ConanInvalidConfiguration("iOS platform with x86/x86_64 architectures only supports 'iphonesimulator' SDK option")
 
     def build_requirements(self):
-        self.tool_requires("yasm/1.3.0")
+        if self.settings.arch in ["x86", "x86_64"]:
+            self.tool_requires("yasm/1.3.0")
         if self._settings_build.os == "Windows":
             self.win_bash = True
             if not self.conf.get("tools.microsoft.bash:path", check_type=str):
@@ -92,6 +93,11 @@ class LibVPXConan(ConanFile):
                 'mips': 'mips32',
                 'mips64': 'mips64',
                 'sparc': 'sparc'}.get(str(self.settings.arch))
+        if arch is None:
+            # Fallback for unknown architectures. This is supported by upstream to be used
+            # when no specific target set is provided by the configure script.
+            return 'generic-gnu'
+
         compiler = str(self.settings.compiler)
         os_name = str(self.settings.os)
         if str(self.settings.compiler) == "Visual Studio":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libvpx/1.16.0**

#### Motivation
When trying to build my dependencies on riscv64, I hit several roadblocks. One was failing to build libvpx. See details for the two reasons.

#### Details
1. **yasm** not building on riscv64. However, it was libvpx requiering it and according to https://chromium.googlesource.com/webm/libvpx/+/refs/tags/v1.16.0/README it is totally only needed when targeting x64 or x86.

> All x86 targets require the NASM[0] or Yasm[1] assembler be installed[2].

So tested this on arm64 and on riscv64 and both allowed to build (while on arm64 yasm was building without problem, it is not needed and all the arm64 including neon builds fine).

The other point is that the configure supports a certain set of target platforms in https://chromium.googlesource.com/webm/libvpx/+/refs/tags/v1.16.0/configure

While riscv64 has no specific target, there is a target for generic builds without platform specific optimization named `generic-gnu`. So second suggestion is about that as a fallback if no platform mapping is available.

**Build log from riscv64**

<details>
<summary>Show build log</summary>

`conan create all --version=1.16.0 --build=missing` with a default profile from `conan profile detect`

```

======== Exporting recipe to the cache ========
libvpx/1.16.0: Exporting package recipe: /conan-center-index/recipes/libvpx/all/conanfile.py
libvpx/1.16.0: exports: File 'conandata.yml' found. Exporting it...
libvpx/1.16.0: Copied 1 '.yml' file: conandata.yml
libvpx/1.16.0: Copied 1 '.py' file: conanfile.py
libvpx/1.16.0: Exported to cache folder: /root/.conan2/p/libvp9b08e70f18d5c/e
libvpx/1.16.0: Exported: libvpx/1.16.0#83d0695fb94901b099e2f61e583cc9ca (2026-02-05 18:57:43 UTC)

======== Input profiles ========
Profile host:
[settings]
arch=riscv64
build_type=Release
compiler=gcc
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=13
os=Linux

Profile build:
[settings]
arch=riscv64
build_type=Release
compiler=gcc
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=13
os=Linux


======== Computing dependency graph ========
Graph root
    cli
Requirements
    libvpx/1.16.0#83d0695fb94901b099e2f61e583cc9ca - Cache

======== Computing necessary packages ========
Connecting to remote 'conancenter' anonymously
libvpx/1.16.0: Main binary package 'd93021ca1b0388001b5e47a93a6fad181eaf4da4' missing
libvpx/1.16.0: Checking 11 compatible configurations
libvpx/1.16.0: Compatible configurations not found in cache, checking servers
libvpx/1.16.0: '8504e1327aaf0eaf6c53e39fd9a93d79225414cd': compiler.cppstd=98
libvpx/1.16.0: '2feb84571d918e71480d516d0dce86bd77a3f39c': compiler.cppstd=gnu98
libvpx/1.16.0: '6df19610c22f9a59bd105956bef08b4655bf0ad0': compiler.cppstd=11
libvpx/1.16.0: 'b0e1663e1b47e0df00d98d099ba427db9bfc4c11': compiler.cppstd=gnu11
libvpx/1.16.0: '061ab2486c0fee0535e33f0bdc7e3944ccd70606': compiler.cppstd=14
libvpx/1.16.0: '2374f7b015bb1ea27f959e94e360bd4a1b2d64af': compiler.cppstd=gnu14
libvpx/1.16.0: '3f8b7db296bf0a04c90d42eb3b1b34221ac93fc8': compiler.cppstd=17
libvpx/1.16.0: '82e03a9d621056ddeb89fb64957cb85213e88259': compiler.cppstd=20
libvpx/1.16.0: '8f1fa2d1956bb02a98c2e54d74720bca96cc4f55': compiler.cppstd=gnu20
libvpx/1.16.0: 'bb292f29a3eb78b6df360a1366b053fe0d96973b': compiler.cppstd=23
libvpx/1.16.0: '578baccfffe97e7a1800d21c29f08aa3ec840cdb': compiler.cppstd=gnu23
libvpx/1.16.0: No compatible configuration found

A new experimental approach for binary compatibility detection is available.
    Enable it by setting the core.graph:compatibility_mode=optimized conf
    and get improved performance when querying multiple compatible binaries in remotes.

Requirements
    libvpx/1.16.0#83d0695fb94901b099e2f61e583cc9ca:d93021ca1b0388001b5e47a93a6fad181eaf4da4 - Build

======== Installing packages ========
libvpx/1.16.0: Calling source() in /root/.conan2/p/libvp9b08e70f18d5c/s/src
libvpx/1.16.0: Uncompressing v1.16.0.tar.gz to .

-------- Installing package libvpx/1.16.0 (1 of 1) --------
libvpx/1.16.0: Building from source
libvpx/1.16.0: Package libvpx/1.16.0:d93021ca1b0388001b5e47a93a6fad181eaf4da4
libvpx/1.16.0: settings: os=Linux arch=riscv64 compiler=gcc compiler.cppstd=gnu17 compiler.libcxx=libstdc++11 compiler.version=13 build_type=Release
libvpx/1.16.0: options: fPIC=True shared=False
libvpx/1.16.0: Copying sources to build folder
libvpx/1.16.0: Building your package in /root/.conan2/p/b/libvp90f7f3ef9f940/b
libvpx/1.16.0: Calling generate()
libvpx/1.16.0: Generators folder: /root/.conan2/p/b/libvp90f7f3ef9f940/b/build-release/conan
libvpx/1.16.0: Generating aggregated env files
libvpx/1.16.0: Generated aggregated env files: ['conanbuild.sh', 'conanrun.sh']
libvpx/1.16.0: Calling build()
libvpx/1.16.0: RUN: "/root/.conan2/p/b/libvp90f7f3ef9f940/b/src/configure" --disable-shared --enable-static --prefix=/tmp_install --libdir=/tmp_install/lib --disable-examples --disable-unit-tests --disable-tools --disable-docs --enable-vp9-highbitdepth --as=yasm --target=generic-gnu 
  disabling shared
  disabling examples
  disabling unit_tests
  disabling tools
  disabling docs
  enabling vp9_highbitdepth
  enabling vp8_encoder
  enabling vp8_decoder
  enabling vp9_encoder
  enabling vp9_decoder
Configuring for target 'generic-gnu'
  enabling generic
  enabling pic
using compiler as linker
  enabling webm_io
  enabling libyuv
Creating makefiles for generic-gnu libs

libvpx/1.16.0: RUN: make -j8
    [CREATE] vpx_scale_rtcd.h
    [CREATE] vpx_dsp_rtcd.h
    [CREATE] vp8_rtcd.h
    [CREATE] vp9_rtcd.h
    [DEP] vp8/vp8_ratectrl_rtc.cc.d
    [DEP] vp9/ratectrl_rtc.cc.d
    [DEP] vp8/encoder/temporal_filter.c.d
    [DEP] vp8/encoder/treewriter.c.d
    [DEP] vp8/encoder/tokenize.c.d
    [DEP] vp8/common/vp8_skin_detection.c.d
    [DEP] vp8/encoder/segmentation.c.d
    [DEP] vp8/encoder/rdopt.c.d
    [DEP] vp8/encoder/ratectrl.c.d
    [DEP] vp8/encoder/vp8_quantize.c.d
    [DEP] vp8/encoder/picklpf.c.d
    [DEP] vp8/encoder/pickinter.c.d
    [DEP] vp8/encoder/onyx_if.c.d
    [DEP] vp8/encoder/modecosts.c.d
    [DEP] vp8/encoder/mcomp.c.d
    [DEP] vp8/encoder/lookahead.c.d
    [DEP] vp8/encoder/denoising.c.d
    [DEP] vp8/encoder/firstpass.c.d
    [DEP] vp8/encoder/ethreading.c.d
    [DEP] vp8/encoder/encodemv.c.d
    [DEP] vp8/encoder/encodemb.c.d
    [DEP] vp8/encoder/encodeintra.c.d
    [DEP] vp8/encoder/encodeframe.c.d
    [DEP] vp8/encoder/dct.c.d
    [DEP] vp8/encoder/copy_c.c.d
    [DEP] vp8/encoder/boolhuff.c.d
    [DEP] vp8/encoder/bitstream.c.d
    [DEP] vp8/vp8_cx_iface.c.d
    [DEP] vp8/common/treecoder.c.d
    [DEP] vp8/common/swapyv12buffer.c.d
    [DEP] vp8/common/setupintrarecon.c.d
    [DEP] vp8/common/reconintra4x4.c.d
    [DEP] vp8/common/reconintra.c.d
    [DEP] vp8/common/reconinter.c.d
    [DEP] vp8/common/quant_common.c.d
    [DEP] vp8/common/modecont.c.d
    [DEP] vp8/common/mbpitch.c.d
    [DEP] vp8/common/loopfilter_filters.c.d
    [DEP] vp8/common/vp8_loopfilter.c.d
    [DEP] vp8/common/rtcd.c.d
    [DEP] vp8/common/idctllm.c.d
    [DEP] vp8/common/idct_blk.c.d
    [DEP] vp8/common/generic/systemdependent.c.d
    [DEP] vp8/common/findnearmv.c.d
    [DEP] vp8/common/filter.c.d
    [DEP] vp8/common/extend.c.d
    [DEP] vp8/common/entropymv.c.d
    [DEP] vp8/common/entropymode.c.d
    [DEP] vp8/common/entropy.c.d
    [DEP] vp8/common/dequantize.c.d
    [DEP] vp8/common/blockd.c.d
    [DEP] vp8/common/alloccommon.c.d
    [DEP] vp9/encoder/vp9_mbgraph.c.d
    [DEP] vp9/encoder/vp9_tpl_model.c.d
    [DEP] vp9/encoder/vp9_temporal_filter.c.d
    [DEP] vp9/encoder/vp9_ext_ratectrl.c.d
    [DEP] vp9/encoder/vp9_noise_estimate.c.d
    [DEP] vp9/encoder/vp9_skin_detection.c.d
    [DEP] vp9/encoder/vp9_alt_ref_aq.c.d
    [DEP] vp9/encoder/vp9_aq_complexity.c.d
    [DEP] vp9/encoder/vp9_aq_cyclicrefresh.c.d
    [DEP] vp9/encoder/vp9_aq_360.c.d
    [DEP] vp9/encoder/vp9_aq_variance.c.d
    [DEP] vp9/encoder/vp9_treewriter.c.d
    [DEP] vp9/encoder/vp9_tokenize.c.d
    [DEP] vp9/encoder/vp9_resize.c.d
    [DEP] vp9/encoder/vp9_svc_layercontext.c.d
    [DEP] vp9/encoder/vp9_subexp.c.d
    [DEP] vp9/encoder/vp9_speed_features.c.d
    [DEP] vp9/encoder/vp9_segmentation.c.d
    [DEP] vp9/encoder/vp9_pickmode.c.d
    [DEP] vp9/encoder/vp9_rdopt.c.d
    [DEP] vp9/encoder/vp9_rd.c.d
    [DEP] vp9/encoder/vp9_ratectrl.c.d
    [DEP] vp9/encoder/vp9_quantize.c.d
    [DEP] vp9/encoder/vp9_picklpf.c.d
    [DEP] vp9/encoder/vp9_encoder.c.d
    [DEP] vp9/encoder/vp9_mcomp.c.d
    [DEP] vp9/encoder/vp9_multi_thread.c.d
    [DEP] vp9/encoder/vp9_lookahead.c.d
    [DEP] vp9/encoder/vp9_frame_scale.c.d
    [DEP] vp9/encoder/vp9_firstpass.c.d
    [DEP] vp9/encoder/vp9_extend.c.d
    [DEP] vp9/encoder/vp9_ethread.c.d
    [DEP] vp9/encoder/vp9_encodemv.c.d
    [DEP] vp9/encoder/vp9_encodemb.c.d
    [DEP] vp9/encoder/vp9_encodeframe.c.d
    [DEP] vp9/encoder/vp9_dct.c.d
    [DEP] vp9/encoder/vp9_cost.c.d
    [DEP] vp9/encoder/vp9_context_tree.c.d
    [DEP] vp9/encoder/vp9_bitstream.c.d
    [DEP] vp9/vp9_cx_iface.c.d
    [DEP] vp9/common/vp9_scan.c.d
    [DEP] vp9/common/vp9_common_data.c.d
    [DEP] vp9/common/vp9_reconintra.c.d
    [DEP] vp9/common/vp9_reconinter.c.d
    [DEP] vp9/common/vp9_quant_common.c.d
    [DEP] vp9/common/vp9_mvref_common.c.d
    [DEP] vp9/common/vp9_thread_common.c.d
    [DEP] vp9/common/vp9_loopfilter.c.d
    [DEP] vp9/common/vp9_tile_common.c.d
    [DEP] vp9/common/vp9_seg_common.c.d
    [DEP] vp9/common/vp9_scale.c.d
    [DEP] vp9/common/vp9_rtcd.c.d
    [DEP] vp9/common/vp9_pred_common.c.d
    [DEP] vp9/common/vp9_filter.c.d
    [DEP] vp9/common/vp9_idct.c.d
    [DEP] vp9/common/vp9_frame_buffers.c.d
    [DEP] vp9/common/vp9_entropymv.c.d
    [DEP] vp9/common/vp9_entropymode.c.d
    [DEP] vp9/common/vp9_entropy.c.d
    [DEP] vp9/common/vp9_blockd.c.d
    [DEP] vp9/common/vp9_alloccommon.c.d
    [DEP] vp9/vp9_iface_common.c.d
    [DEP] vpx_config.c.d
    [DEP] vp9/decoder/vp9_job_queue.c.d
    [DEP] vp9/decoder/vp9_dsubexp.c.d
    [DEP] vp9/decoder/vp9_decoder.c.d
    [DEP] vp9/decoder/vp9_detokenize.c.d
    [DEP] vp9/decoder/vp9_decodeframe.c.d
    [DEP] vp9/decoder/vp9_decodemv.c.d
    [DEP] vp9/vp9_dx_iface.c.d
    [DEP] vp8/decoder/threading.c.d
    [DEP] vp8/decoder/onyxd_if.c.d
    [DEP] vp8/decoder/detokenize.c.d
    [DEP] vp8/decoder/decodeframe.c.d
    [DEP] vp8/decoder/decodemv.c.d
    [DEP] vp8/decoder/dboolhuff.c.d
    [DEP] vp8/vp8_dx_iface.c.d
    [DEP] vpx_util/vpx_write_yuv_frame.c.d
    [DEP] vpx_util/vpx_thread.c.d
    [DEP] vpx_dsp/vpx_dsp_rtcd.c.d
    [DEP] vpx_dsp/variance.c.d
    [DEP] vpx_dsp/sum_squares.c.d
    [DEP] vpx_dsp/subtract.c.d
    [DEP] vpx_dsp/sad.c.d
    [DEP] vpx_dsp/skin_detection.c.d
    [DEP] vpx_dsp/avg.c.d
    [DEP] vpx_dsp/quantize.c.d
    [DEP] vpx_dsp/inv_txfm.c.d
    [DEP] vpx_dsp/fwd_txfm.c.d
    [DEP] vpx_dsp/loopfilter.c.d
    [DEP] vpx_dsp/vpx_convolve.c.d
    [DEP] vpx_dsp/intrapred.c.d
    [DEP] vpx_dsp/bitreader_buffer.c.d
    [DEP] vpx_dsp/bitreader.c.d
    [DEP] vpx_dsp/sse.c.d
    [DEP] vpx_dsp/psnr.c.d
    [DEP] vpx_dsp/bitwriter_buffer.c.d
    [DEP] vpx_dsp/bitwriter.c.d
    [DEP] vpx_dsp/prob.c.d
    [DEP] vpx_scale/vpx_scale_rtcd.c.d
    [DEP] vpx_scale/generic/gen_scalers.c.d
    [DEP] vpx_scale/generic/yv12extend.c.d
    [DEP] vpx_scale/generic/yv12config.c.d
    [DEP] vpx_scale/generic/vpx_scale.c.d
    [DEP] vpx_mem/vpx_mem.c.d
    [DEP] vpx/src/vpx_image.c.d
    [DEP] vpx/src/vpx_codec.c.d
    [DEP] vpx/src/vpx_encoder.c.d
    [DEP] vpx/src/vpx_decoder.c.d
    [CREATE] libs.doxy
    [CC] vpx/src/vpx_decoder.c.o
    [CC] vpx/src/vpx_encoder.c.o
    [CC] vpx/src/vpx_codec.c.o
    [CC] vpx/src/vpx_image.c.o
    [CC] vpx_mem/vpx_mem.c.o
    [CC] vpx_scale/generic/vpx_scale.c.o
    [CC] vpx_scale/generic/yv12config.c.o
    [CC] vpx_scale/generic/yv12extend.c.o
    [CC] vpx_scale/generic/gen_scalers.c.o
    [CC] vpx_scale/vpx_scale_rtcd.c.o
    [CC] vpx_dsp/prob.c.o
    [CC] vpx_dsp/bitwriter.c.o
    [CC] vpx_dsp/bitwriter_buffer.c.o
    [CC] vpx_dsp/psnr.c.o
    [CC] vpx_dsp/sse.c.o
    [CC] vpx_dsp/bitreader.c.o
    [CC] vpx_dsp/bitreader_buffer.c.o
    [CC] vpx_dsp/intrapred.c.o
    [CC] vpx_dsp/vpx_convolve.c.o
    [CC] vpx_dsp/loopfilter.c.o
    [CC] vpx_dsp/fwd_txfm.c.o
    [CC] vpx_dsp/inv_txfm.c.o
    [CC] vpx_dsp/quantize.c.o
    [CC] vpx_dsp/avg.c.o
    [CC] vpx_dsp/skin_detection.c.o
    [CC] vpx_dsp/sad.c.o
    [CC] vpx_dsp/subtract.c.o
    [CC] vpx_dsp/sum_squares.c.o
    [CC] vpx_dsp/variance.c.o
    [CC] vpx_dsp/vpx_dsp_rtcd.c.o
    [CC] vpx_util/vpx_thread.c.o
    [CC] vpx_util/vpx_write_yuv_frame.c.o
    [CC] vp8/common/alloccommon.c.o
    [CC] vp8/common/blockd.c.o
    [CC] vp8/common/dequantize.c.o
    [CC] vp8/common/entropy.c.o
    [CC] vp8/common/entropymode.c.o
    [CC] vp8/common/entropymv.c.o
    [CC] vp8/common/extend.c.o
    [CC] vp8/common/filter.c.o
    [CC] vp8/common/findnearmv.c.o
    [CC] vp8/common/generic/systemdependent.c.o
    [CC] vp8/common/idct_blk.c.o
    [CC] vp8/common/idctllm.c.o
    [CC] vp8/common/rtcd.c.o
    [CC] vp8/common/vp8_loopfilter.c.o
    [CC] vp8/common/loopfilter_filters.c.o
    [CC] vp8/common/mbpitch.c.o
    [CC] vp8/common/modecont.c.o
    [CC] vp8/common/quant_common.c.o
    [CC] vp8/common/reconinter.c.o
    [CC] vp8/common/reconintra.c.o
    [CC] vp8/common/reconintra4x4.c.o
    [CC] vp8/common/setupintrarecon.c.o
    [CC] vp8/common/swapyv12buffer.c.o
    [CC] vp8/common/treecoder.c.o
    [CC] vp8/vp8_cx_iface.c.o
    [CC] vp8/encoder/bitstream.c.o
    [CC] vp8/encoder/boolhuff.c.o
    [CC] vp8/encoder/copy_c.c.o
    [CC] vp8/encoder/dct.c.o
    [CC] vp8/encoder/encodeframe.c.o
    [CC] vp8/encoder/encodeintra.c.o
    [CC] vp8/encoder/encodemb.c.o
    [CC] vp8/encoder/encodemv.c.o
    [CC] vp8/encoder/ethreading.c.o
    [CC] vp8/encoder/firstpass.c.o
    [CC] vp8/encoder/denoising.c.o
    [CC] vp8/encoder/lookahead.c.o
    [CC] vp8/encoder/mcomp.c.o
    [CC] vp8/encoder/modecosts.c.o
    [CC] vp8/encoder/onyx_if.c.o
    [CC] vp8/encoder/pickinter.c.o
    [CC] vp8/encoder/picklpf.c.o
    [CC] vp8/encoder/vp8_quantize.c.o
    [CC] vp8/encoder/ratectrl.c.o
    [CC] vp8/encoder/rdopt.c.o
    [CC] vp8/encoder/segmentation.c.o
    [CC] vp8/common/vp8_skin_detection.c.o
    [CC] vp8/encoder/tokenize.c.o
    [CC] vp8/encoder/treewriter.c.o
    [CC] vp8/encoder/temporal_filter.c.o
    [CC] vp8/vp8_dx_iface.c.o
    [CC] vp8/decoder/dboolhuff.c.o
    [CC] vp8/decoder/decodemv.c.o
    [CC] vp8/decoder/decodeframe.c.o
    [CC] vp8/decoder/detokenize.c.o
    [CC] vp8/decoder/onyxd_if.c.o
    [CC] vp8/decoder/threading.c.o
    [CC] vp9/vp9_iface_common.c.o
    [CC] vp9/common/vp9_alloccommon.c.o
    [CC] vp9/common/vp9_blockd.c.o
    [CC] vp9/common/vp9_entropy.c.o
    [CC] vp9/common/vp9_entropymode.c.o
    [CC] vp9/common/vp9_entropymv.c.o
    [CC] vp9/common/vp9_frame_buffers.c.o
    [CC] vp9/common/vp9_idct.c.o
    [CC] vp9/common/vp9_filter.c.o
    [CC] vp9/common/vp9_pred_common.c.o
    [CC] vp9/common/vp9_rtcd.c.o
    [CC] vp9/common/vp9_scale.c.o
    [CC] vp9/common/vp9_seg_common.c.o
    [CC] vp9/common/vp9_tile_common.c.o
    [CC] vp9/common/vp9_loopfilter.c.o
    [CC] vp9/common/vp9_thread_common.c.o
    [CC] vp9/common/vp9_mvref_common.c.o
    [CC] vp9/common/vp9_quant_common.c.o
    [CC] vp9/common/vp9_reconinter.c.o
    [CC] vp9/common/vp9_reconintra.c.o
    [CC] vp9/common/vp9_common_data.c.o
    [CC] vp9/common/vp9_scan.c.o
    [CC] vp9/vp9_cx_iface.c.o
    [CC] vp9/encoder/vp9_bitstream.c.o
    [CC] vp9/encoder/vp9_context_tree.c.o
    [CC] vp9/encoder/vp9_cost.c.o
    [CC] vp9/encoder/vp9_dct.c.o
    [CC] vp9/encoder/vp9_encodeframe.c.o
    [CC] vp9/encoder/vp9_encodemb.c.o
    [CC] vp9/encoder/vp9_encodemv.c.o
    [CC] vp9/encoder/vp9_ethread.c.o
    [CC] vp9/encoder/vp9_extend.c.o
    [CC] vp9/encoder/vp9_firstpass.c.o
    [CC] vp9/encoder/vp9_frame_scale.c.o
    [CC] vp9/encoder/vp9_lookahead.c.o
    [CC] vp9/encoder/vp9_multi_thread.c.o
    [CC] vp9/encoder/vp9_mcomp.c.o
    [CC] vp9/encoder/vp9_encoder.c.o
    [CC] vp9/encoder/vp9_picklpf.c.o
    [CC] vp9/encoder/vp9_quantize.c.o
    [CC] vp9/encoder/vp9_ratectrl.c.o
    [CC] vp9/encoder/vp9_rd.c.o
    [CC] vp9/encoder/vp9_rdopt.c.o
    [CC] vp9/encoder/vp9_pickmode.c.o
    [CC] vp9/encoder/vp9_segmentation.c.o
    [CC] vp9/encoder/vp9_speed_features.c.o
    [CC] vp9/encoder/vp9_subexp.c.o
    [CC] vp9/encoder/vp9_svc_layercontext.c.o
    [CC] vp9/encoder/vp9_resize.c.o
    [CC] vp9/encoder/vp9_tokenize.c.o
    [CC] vp9/encoder/vp9_treewriter.c.o
    [CC] vp9/encoder/vp9_aq_variance.c.o
    [CC] vp9/encoder/vp9_aq_360.c.o
    [CC] vp9/encoder/vp9_aq_cyclicrefresh.c.o
    [CC] vp9/encoder/vp9_aq_complexity.c.o
    [CC] vp9/encoder/vp9_alt_ref_aq.c.o
    [CC] vp9/encoder/vp9_skin_detection.c.o
    [CC] vp9/encoder/vp9_noise_estimate.c.o
    [CC] vp9/encoder/vp9_ext_ratectrl.c.o
    [CC] vp9/encoder/vp9_temporal_filter.c.o
    [CC] vp9/encoder/vp9_tpl_model.c.o
    [CC] vp9/encoder/vp9_mbgraph.c.o
    [CC] vp9/vp9_dx_iface.c.o
    [CC] vp9/decoder/vp9_decodemv.c.o
    [CC] vp9/decoder/vp9_decodeframe.c.o
    [CC] vp9/decoder/vp9_detokenize.c.o
    [CC] vp9/decoder/vp9_decoder.c.o
    [CC] vp9/decoder/vp9_dsubexp.c.o
    [CC] vp9/decoder/vp9_job_queue.c.o
    [CC] vpx_config.c.o
    [CREATE] vpx.pc
    [CXX] vp9/ratectrl_rtc.cc.o
    [CXX] vp8/vp8_ratectrl_rtc.cc.o
    [AR] libvpxrc_g.a
    [STRIP] libvpxrc.a < libvpxrc_g.a
    [AR] libvpx_g.a
    [STRIP] libvpx.a < libvpx_g.a

libvpx/1.16.0: Package 'd93021ca1b0388001b5e47a93a6fad181eaf4da4' built
libvpx/1.16.0: Build folder /root/.conan2/p/b/libvp90f7f3ef9f940/b/build-release
libvpx/1.16.0: Generating the package
libvpx/1.16.0: Packaging in folder /root/.conan2/p/b/libvp90f7f3ef9f940/p
libvpx/1.16.0: Calling package()
libvpx/1.16.0: RUN: make install DESTDIR=/root/.conan2/p/b/libvp90f7f3ef9f940/p -j8
    [INSTALL] /root/.conan2/p/b/libvp90f7f3ef9f940/p/tmp_install/include/vpx/vp8.h
    [INSTALL] /root/.conan2/p/b/libvp90f7f3ef9f940/p/tmp_install/include/vpx/vp8cx.h
    [INSTALL] /root/.conan2/p/b/libvp90f7f3ef9f940/p/tmp_install/include/vpx/vpx_ext_ratectrl.h
    [INSTALL] /root/.conan2/p/b/libvp90f7f3ef9f940/p/tmp_install/include/vpx/vp8dx.h
    [INSTALL] /root/.conan2/p/b/libvp90f7f3ef9f940/p/tmp_install/include/vpx/vpx_codec.h
    [INSTALL] /root/.conan2/p/b/libvp90f7f3ef9f940/p/tmp_install/include/vpx/vpx_frame_buffer.h
    [INSTALL] /root/.conan2/p/b/libvp90f7f3ef9f940/p/tmp_install/include/vpx/vpx_image.h
    [INSTALL] /root/.conan2/p/b/libvp90f7f3ef9f940/p/tmp_install/include/vpx/vpx_integer.h
    [INSTALL] /root/.conan2/p/b/libvp90f7f3ef9f940/p/tmp_install/include/vpx/vpx_decoder.h
    [INSTALL] /root/.conan2/p/b/libvp90f7f3ef9f940/p/tmp_install/include/vpx/vpx_encoder.h
    [INSTALL] /root/.conan2/p/b/libvp90f7f3ef9f940/p/tmp_install/include/vpx/vpx_tpl.h
    [INSTALL] /root/.conan2/p/b/libvp90f7f3ef9f940/p/tmp_install/lib/libvpx.a
    [INSTALL] /root/.conan2/p/b/libvp90f7f3ef9f940/p/tmp_install/lib/pkgconfig/vpx.pc

libvpx/1.16.0: package(): Packaged 1 file: LICENSE
libvpx/1.16.0: package(): Packaged 11 '.h' files
libvpx/1.16.0: package(): Packaged 1 '.a' file: libvpx.a
libvpx/1.16.0: Created package revision 1053f8c9c8f58a28f0a3b3206366c75d
libvpx/1.16.0: Package 'd93021ca1b0388001b5e47a93a6fad181eaf4da4' created
libvpx/1.16.0: Full package reference: libvpx/1.16.0#83d0695fb94901b099e2f61e583cc9ca:d93021ca1b0388001b5e47a93a6fad181eaf4da4#1053f8c9c8f58a28f0a3b3206366c75d
libvpx/1.16.0: Package folder /root/.conan2/p/b/libvp90f7f3ef9f940/p

======== Launching test_package ========

======== Computing dependency graph ========
Graph root
    libvpx/1.16.0 (test package): /conan-center-index/recipes/libvpx/all/test_package/conanfile.py
Requirements
    libvpx/1.16.0#83d0695fb94901b099e2f61e583cc9ca - Cache

======== Computing necessary packages ========
Requirements
    libvpx/1.16.0#83d0695fb94901b099e2f61e583cc9ca:d93021ca1b0388001b5e47a93a6fad181eaf4da4#1053f8c9c8f58a28f0a3b3206366c75d - Cache

======== Installing packages ========
libvpx/1.16.0: Already installed! (1 of 1)

======== Testing the package ========
Removing previously existing 'test_package' build folder: /conan-center-index/recipes/libvpx/all/test_package/build/gcc-13-riscv64-gnu17-release
libvpx/1.16.0 (test package): Test package build: build/gcc-13-riscv64-gnu17-release
libvpx/1.16.0 (test package): Test package build folder: /conan-center-index/recipes/libvpx/all/test_package/build/gcc-13-riscv64-gnu17-release
libvpx/1.16.0 (test package): Writing generators to /conan-center-index/recipes/libvpx/all/test_package/build/gcc-13-riscv64-gnu17-release/generators
libvpx/1.16.0 (test package): Generator 'CMakeDeps' calling 'generate()'
libvpx/1.16.0 (test package): CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(libvpx)
    target_link_libraries(... libvpx::libvpx)
libvpx/1.16.0 (test package): Generator 'CMakeToolchain' calling 'generate()'
libvpx/1.16.0 (test package): CMakeToolchain generated: conan_toolchain.cmake
libvpx/1.16.0 (test package): CMakeToolchain generated: /conan-center-index/recipes/libvpx/all/test_package/build/gcc-13-riscv64-gnu17-release/generators/CMakePresets.json
libvpx/1.16.0 (test package): CMakeToolchain generated: /conan-center-index/recipes/libvpx/all/test_package/CMakeUserPresets.json
libvpx/1.16.0 (test package): Generator 'VirtualRunEnv' calling 'generate()'
libvpx/1.16.0 (test package): Generating aggregated env files
libvpx/1.16.0 (test package): Generated aggregated env files: ['conanrun.sh', 'conanbuild.sh']

======== Testing the package: Building ========
libvpx/1.16.0 (test package): Calling build()
libvpx/1.16.0 (test package): Running CMake.configure()
libvpx/1.16.0 (test package): RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/conan-center-index/recipes/libvpx/all/test_package" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/conan-center-index/recipes/libvpx/all/test_package"
-- Using Conan toolchain: /conan-center-index/recipes/libvpx/all/test_package/build/gcc-13-riscv64-gnu17-release/generators/conan_toolchain.cmake
-- Conan toolchain: C++ Standard 17 with extensions ON
-- The C compiler identification is GNU 13.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Conan: Target declared 'libvpx::libvpx'
-- Configuring done (1.3s)
-- Generating done (0.0s)
-- Build files have been written to: /conan-center-index/recipes/libvpx/all/test_package/build/gcc-13-riscv64-gnu17-release

libvpx/1.16.0 (test package): Running CMake.build()
libvpx/1.16.0 (test package): RUN: cmake --build "/conan-center-index/recipes/libvpx/all/test_package/build/gcc-13-riscv64-gnu17-release" -- -j8
[ 50%] Building C object CMakeFiles/test_package.dir/test_package.c.o
[100%] Linking C executable test_package
[100%] Built target test_package


======== Testing the package: Executing test ========
libvpx/1.16.0 (test package): Running test()
libvpx/1.16.0 (test package): RUN: ./test_package
vpx version v1.16.0

```

</details>


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
