### PR TITLE
sdl: explicitly disable opengl if not supported

### DIFF
--- a/recipes/sdl/3.x/conanfile.py
+++ b/recipes/sdl/3.x/conanfile.py
@@ -259,10 +259,8 @@ class SDLConan(ConanFile):
         for subsystem in _subsystems:
             tc.cache_variables[f"SDL_{subsystem[0].upper()}"] = self.options.get_safe(subsystem[0])
 
-        if self._supports_opengl:
-            tc.cache_variables["SDL_OPENGL"] = True
-        if self._supports_opengles:
-            tc.cache_variables["SDL_OPENGLES"] = True
+        tc.cache_variables["SDL_OPENGL"] = bool(self._supports_opengl)
+        tc.cache_variables["SDL_OPENGLES"] = bool(self._supports_opengles)
 
         if self.options.hidapi:
             tc.cache_variables["SDL_HIDAPI_LIBUSB"] = self.options.get_safe("libusb")

--- a/recipes/sdl/3.x/test_package/CMakeLists.txt
+++ b/recipes/sdl/3.x/test_package/CMakeLists.txt
@@ -5,4 +5,3 @@ find_package(SDL3 REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} SDL3::SDL3)
-


### PR DESCRIPTION
### Summary
Changes to recipe:  **sdl/3.4.0**

#### Motivation

When building SDL with conan with opengles disabled, conan does not explicitly disable opengles for sdl's build. sdl's build then enables opengles as its is detecting it is building for ios, while we are not adding the linker flag for the required opengles library. (edited)

#### Details

If opengl is not disabled by the user, disable it explicitly instead of leaving it unset.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
