### PR TITLE
libccd: Fix build with CMake 4

### DIFF
--- a/recipes/libccd/all/conanfile.py
+++ b/recipes/libccd/all/conanfile.py
@@ -49,6 +49,7 @@ class LibccdConan(ConanFile):
         tc.variables["BUILD_DOCUMENTATION"] = False
         tc.variables["ENABLE_DOUBLE_PRECISION"] = self.options.enable_double_precision
         tc.variables["CCD_HIDE_ALL_SYMBOLS"] = not self.options.shared
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5"  # CMake 4 support
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **libccd/[2.1]**

#### Motivation
Currently libccd cannot be built with cmake4.

#### Details
- Set CMAKE_POLICY_VERSION_MINIMUM to 3.5

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
