### PR TITLE
msys2: update base tarball from 2023-10-26 to 2025-12-13

### DIFF
--- a/recipes/msys2/all/conandata.yml
+++ b/recipes/msys2/all/conandata.yml
@@ -1,7 +1,6 @@
 sources:
   "cci.latest":
     url:
-      - "https://github.com/msys2/msys2-installer/releases/download/2023-10-26/msys2-base-x86_64-20231026.tar.xz"
-      - "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20231026.tar.xz"
-      - "https://sourceforge.net/projects/msys2/files/Base/x86_64/msys2-base-x86_64-20231026.tar.xz"
-    sha256: "fa75120560563a311241c05882016978bd35612692c7f0d39815a27837bff27d"
+      - "https://github.com/msys2/msys2-installer/releases/download/2025-12-13/msys2-base-x86_64-20251213.tar.xz"
+      - "http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20251213.tar.xz"
+    sha256: "999f63c2fc7525af5cd41b55e9ea704471a4f9d0278a257fff3b0d1183c441b9"


### PR DESCRIPTION
### Summary
Changes to recipe: **msys2/cci.latest**

#### Motivation
The current base tarball (`msys2-base-x86_64-20231026.tar.xz`) is over 2 years old and contains a broken `gpgme` that cannot verify current MSYS2 repository signatures. All `msys2/cci.latest` builds fail with:

```
GPGME error: Invalid crypto engine
database is invalid (invalid or corrupted database (PGP signature))
```

#### Details
- Updated base tarball: `20231026` → `20251213`
- Removed SourceForge mirror (returns 404 for all versions — MSYS2 no longer publishes there)
- Kept GitHub and repo.msys2.org mirrors

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!