### PR TITLE
Fix `pq` requirement on `libpqxx`

### DIFF
--- a/recipes/libpqxx/all/conanfile.py
+++ b/recipes/libpqxx/all/conanfile.py
@@ -145,4 +145,4 @@ class LibpqxxConan(ConanFile):
 
         self.cpp_info.components["pqxx"].set_property("cmake_target_name", "libpqxx::pqxx")
         self.cpp_info.components["pqxx"].set_property("pkg_config_name", "libpqxx")
-        self.cpp_info.components["pqxx"].requires = ["libpq::libpq"]
+        self.cpp_info.components["pqxx"].requires = ["libpq::pq"]


### PR DESCRIPTION
### Summary
Changes to recipe:  **libpqxx/***

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Changes the requirement to *pq* component instead of the global component. This change doens't modify the behaviour of the recipe and fixes the requirement to libpq when using "PkgConfigDeps".

Fix: https://github.com/conan-io/conan-center-index/issues/29550

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
