### PR TITLE
cpp-httplib: Add missing anl library linking

### DIFF
--- a/recipes/cpp-httplib/all/conanfile.py
+++ b/recipes/cpp-httplib/all/conanfile.py
@@ -79,7 +79,7 @@ class CpphttplibConan(ConanFile):
         if self.options.get_safe("with_zstd"):
             self.cpp_info.defines.append("CPPHTTPLIB_ZSTD_SUPPORT")
         if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.system_libs = ["pthread"]
+            self.cpp_info.system_libs = ["pthread", "anl"]
         elif self.settings.os == "Windows":
             self.cpp_info.system_libs = ["crypt32", "cryptui", "ws2_32"]
         elif self.settings.os == "Macos":


### PR DESCRIPTION
### Summary
Changes to recipe:  **cpp-httplib**

#### Motivation
`cpp-httplib` uses `gai_suspend`, `gai_error`, `gai_cancel` functions, which requires `anl` linking on the systems where `anl` is not part of `libc`.

#### Details
add `anl` to `system_libs` on `Linux` and `FreeBSD`.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
