### PR TITLE
args-parser: bump version to 6.3.5

### DIFF
--- a/recipes/args-parser/all/conandata.yml
+++ b/recipes/args-parser/all/conandata.yml
@@ -2,33 +2,10 @@ sources:
   "6.3.5":
     url: "https://github.com/igormironchik/args-parser/archive/refs/tags/6.3.5.tar.gz"
     sha256: "e6eaebece03224e69c91ab540a3f0b349b1ccf5952db5a9a5760ff0bcf8567f6"
-  "6.3.4":
-    url: "https://github.com/igormironchik/args-parser/archive/refs/tags/6.3.4.tar.gz"
-    sha256: "874be94baac622e16045b958539e91347f18fc0803356fb500757c0060222aa2"
-  "6.3.3":
-    url: "https://github.com/igormironchik/args-parser/archive/refs/tags/6.3.3.tar.gz"
-    sha256: "67867d7ab624a8c2f391230c54c37830e6127f7f5c716ff634165f674d876b64"
-  "6.3.2":
-    url: "https://github.com/igormironchik/args-parser/archive/refs/tags/6.3.2.tar.gz"
-    sha256: "cd89549a9f5b5cfd16db2f8b9c93fd164cea334147c58890d5322365789e05e5"
-  "6.3.1":
-    url: "https://github.com/igormironchik/args-parser/archive/refs/tags/6.3.1.tar.gz"
-    sha256: "7509639553708baf03aca57cfb0c9e5824b705782b69ebb71de5e4f1c6ad18ab"
-  "6.3.0":
-    url: "https://github.com/igormironchik/args-parser/archive/refs/tags/6.3.0.tar.gz"
-    sha256: "a21d1ad1b4648f3fff0fe898514040312c7eae17b6347cb9aa1da5c74d9815f0"
   "6.2.0.1":
     url: "https://github.com/igormironchik/args-parser/archive/refs/tags/6.2.0.1.tar.gz"
     sha256: "9fd34a717f9dbaf1ebbce35645f71ce1f5079ced8d6b77a240911bd580914ecd"
-  "6.2.0.0":
-    url: "https://github.com/igormironchik/args-parser/archive/refs/tags/6.2.0.0.tar.gz"
-    sha256: "77aa15ad637e48ddbf7dca1311519ad53d73fee6395989f7922754da59138915"
   "6.1.1.0":
     url: "https://github.com/igormironchik/args-parser/archive/refs/tags/6.1.1.0.tar.gz"
     sha256: "41135cb79034f8f8940fc0bd0346059446df98a8df47ca461af8757e9cb3e33b"
-  "6.1.0.0":
-    url: "https://github.com/igormironchik/args-parser/archive/refs/tags/6.1.0.0.tar.gz"
-    sha256: "f6fadc1458e8821160a287a7dd096e94a36f968ba9719fa2a7ce8cec6bfb6969"
-  "6.0.1.0":
-    url: "https://github.com/igormironchik/args-parser/archive/refs/tags/6.0.1.0.tar.gz"
-    sha256: "d3569ee05f89d361f28fcca32e5ff782578e55aeea5559ebf1f394a689e2ae26"
+

--- a/recipes/args-parser/config.yml
+++ b/recipes/args-parser/config.yml
@@ -1,23 +1,7 @@
 versions:
   "6.3.5":
     folder: all
-  "6.3.4":
-    folder: all
-  "6.3.3":
-    folder: all
-  "6.3.2":
-    folder: all
-  "6.3.1":
-    folder: all
-  "6.3.0":
-    folder: all
   "6.2.0.1":
     folder: all
-  "6.2.0.0":
-    folder: all
   "6.1.1.0":
-    folder: all
-  "6.1.0.0":
-    folder: all
-  "6.0.1.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **args-parser/[6.3.5]**

#### Motivation
No bugs was fixed, but added a few nice things.

#### Details
* Default value of argument prints in the help now.
* Possibility to make paragraphs in description of an argument.
* Too long word splits if it doesn't fit in.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
