### PR TITLE
libtorch: Avoid hardcoding venv path

### DIFF
--- a/recipes/libtorch/all/conanfile.py
+++ b/recipes/libtorch/all/conanfile.py
@@ -214,8 +214,13 @@ class LibtorchRecipe(ConanFile):
         tc.cache_variables["USE_NNPACK"] = self.options.get_safe("with_nnpack")
         tc.cache_variables["USE_NUMA"] = self.options.get_safe("with_numa")
 
+        # PyEnv/PipEnv is set up to put the virtual env first in PATH
+        # but CMake's default behaviour may prioritise other locations
+        # we need: "use the first python3 you find in PATH"
         tc.cache_variables['Python_FIND_UNVERSIONED_NAMES'] = 'FIRST'
         tc.cache_variables['Python_FIND_STRATEGY'] = 'LOCATION'
+        tc.cache_variables['Python_FIND_VIRTUALENV'] = 'STANDARD'
+        tc.cache_variables['Python_FIND_REGISTRY'] = 'NEVER'
 
         tc.generate()
 


### PR DESCRIPTION
### Summary
Changes to recipe: **libtorch/2.9.1**

#### Motivation

The recipe hardcoded the PipEnv venv path for CMake. After Conan 2.25 switched to PyEnv (venv name `conan_pyenv`), the toolchain pointed to a non-existent dir and CMake failed with "Could NOT find Python". Broke [examples2](https://github.com/conan-io/examples2) CI ([run](https://github.com/conan-io/examples2/actions/runs/21847035045)).

#### Details

- Generate `VirtualBuildEnv` first, then PipEnv last. PipEnv’s PATH then takes precedence when CMake runs, so CMake finds the venv interpreter without any Python-related cache variables. 

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
