### PR TITLE
[qt] Allow version ranges for Wayland dependency

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -337,6 +337,12 @@ class QtConan(ConanFile):
 
         if self.options.get_safe("qtwayland") and not self.options.get_safe("with_egl"):
             raise ConanInvalidConfiguration("qtwayland requires with_egl=True")
+        elif self.options.get_safe("qtwayland") and self.options.get_safe("with_egl"):
+            # INFO: The system EGL can be built using a different Wayland version, expecting different features not available
+            # in the version used to build the Conan package for Wayland, causing runtime errors.
+            # Usually consuming the latest Wayland package from Conan Center Index should work.
+            # See conan-io/conan-center-index#29476
+            self.output.warning("The system EGL may not work properly with Conan package for Wayland due ABI incompatibilities between the version used to build EGL.")
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -399,7 +405,7 @@ class QtConan(ConanFile):
         if self.options.with_zstd:
             self.requires("zstd/[>=1.5 <1.6]")
         if self.options.qtwayland:
-            self.requires("wayland/1.22.0")
+            self.requires("wayland/[>=1.22.0 <2]")
         if self.options.with_brotli:
             self.requires("brotli/1.1.0")
         if self.options.get_safe("qtwebengine") and self.settings.os == "Linux":
@@ -438,7 +444,7 @@ class QtConan(ConanFile):
                 self.tool_requires("flex/2.6.4")
 
         if self.options.qtwayland:
-            self.tool_requires("wayland/1.22.0")
+            self.tool_requires("wayland/<host_version>")
         if cross_building(self):
             self.tool_requires(f"qt/{self.version}")
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **qt/6.10.1**

#### Motivation

After a long investigation into the reported case #29555, it was found that the system Mesa EGL package was built using a newer version of Wayland (1.24.0), which resulted in an ABI incompatibility due to new features available and consumed by libEGL_mesa. When using Qt 6.x from Conan Center, it comes with Wayland 1.22.0, which does not contain such features, and a runtime error was produced.

fixes #29476
related to #29555

/cc @monkeber

#### Details

Originally reported using a Linux distro based on Arch Linux, which indicates fresh new versions, but also validated and reproduced the case by using Fedora 43 with Gnome Shell environment desktop. 

The found error is the same as the originally reported:

```
$ ./build/Release/testapp
qt.qpa.wayland: EGL not available
QRhiGles2: Failed to create temporary context
QRhiGles2: Failed to create context
Failed to create RHI (backend 2)
Failed to initialize graphics backend for OpenGL.
[1] (core dumped)  ./build/Release/testapp
```

When running the application with the environment variable `LD_DEBUG=libs`, we can track what happened: 

```
12076:	/lib64/libEGL_mesa.so.0: error: symbol lookup error: undefined symbol: wl_display_create_queue_with_name (fatal)
qt.qpa.wayland: EGL not available
     12076:	find library=libQt6Svg.so.6 [0]; searching
     12076:	 search path=/home/defumak/.conan2/p/b/qt2b518e33a7366/p/lib		(RUNPATH from file build/Release/testapp)
     12076:	  trying file=/home/defumak/.conan2/p/b/qt2b518e33a7366/p/lib/libQt6Svg.so.6
```

Full logs can be obtained at https://gist.github.com/uilianries/f1b3b1e7c4d5b2af37f3483828384e0e#file-wayland-1-22-0-L6464

The `libEGL_mesa` is looking for the Wayland symbol `wl_display_create_queue_with_name`, which is not available, causing our runtime error.

The Fedora 43 comes with Mesa 25.3.4 and will be built with Wayland >=1.11: https://src.fedoraproject.org/rpms/mesa/blob/rawhide/f/mesa.spec#_139. At the same time, Wayland 1.24.0 is used by Fedora 43: https://packages.fedoraproject.org/pkgs/wayland/wayland-devel/index.html.

On the other side, the Mesa project has a check on what is consumed from Wayland, based on a pre-build check, which validates `wl_display_create_queue_with_name` availability: https://gitlab.freedesktop.org/mesa/mesa/-/blob/mesa-25.3.4/meson.build?ref_type=tags#L2028. This feature was introduced into the upstream only after 1.22.0, in 2024: https://gitlab.freedesktop.org/wayland/wayland/-/merge_requests/355.

As a result, Mesa, when built using 1.24.0 in Fedora, has the define `HAVE_WL_CREATE_QUEUE_WITH_NAME` active and expects `wl_display_create_queue_with_name` be available when loading Wayland client library at runtime. However, Wayland 1.22.0 does not have that symbol available, causing the described error. In order fix the situation, we need to keep Qt aligned with the latest Wayland version available to make all features available for EGL. The [Wayland client is backward compatible](https://wayland.freedesktop.org/docs/html/ch04.html#sect-Protocol-Basic-Principles), so it should not break old EGL versions as well.

For extra simplification and exploration, the project https://github.com/uilianries/cci-issue-29476 was created to demonstrate the original issue without getting Qt involved.


### TODO: Pending validation with Qt 5.x


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
