### PR TITLE
drogon: providing the path to drogon_ctl

### DIFF
--- a/recipes/drogon/all/conanfile.py
+++ b/recipes/drogon/all/conanfile.py
@@ -163,3 +163,8 @@ class DrogonConan(ConanFile):
 
         self.cpp_info.set_property("cmake_file_name", "Drogon")
         self.cpp_info.set_property("cmake_target_name", "Drogon::Drogon")
+
+        if self.options.with_ctl:
+            bin_dir = os.path.join(self.package_folder, "bin")
+            self.buildenv_info.prepend_path("PATH", bin_dir)
+            self.runenv_info.prepend_path("PATH", bin_dir)


### PR DESCRIPTION
### Summary
Changes to recipe:  **drogon/[1.9.12]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
DrogonUtilities.cmake is included automatically, but the function drogon_create_views() cannot find the command drogon_ctl

```
add_custom_command(OUTPUT ${ARGV2}/${outputFile}.h ${ARGV2}/${outputFile}.cc
                         COMMAND drogon_ctl
                                 ARGS
                                 create
                                 view
                                 ${inFile}
                                 ${p2ns}
                                 -o
                                 ${ARGV2}
                                 ${ns}
                         DEPENDS ${cspFile}
                         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                         VERBATIM)
```

Conan creates drogon_ctl, but this function has no path to drogon_ctl

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [] If this is a bug fix, please link related issue or provide bug details
- [] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
