### PR TITLE
libjxl: Add version 0.11.2 and clean up old versions

### DIFF
--- a/recipes/libjxl/all/conandata.yml
+++ b/recipes/libjxl/all/conandata.yml
@@ -1,13 +1,7 @@
 sources:
+  "0.11.2":
+    url: "https://github.com/libjxl/libjxl/archive/v0.11.2.tar.gz"
+    sha256: "ab38928f7f6248e2a98cc184956021acb927b16a0dee71b4d260dc040a4320ea"
   "0.11.1":
     url: "https://github.com/libjxl/libjxl/archive/v0.11.1.tar.gz"
     sha256: "1492dfef8dd6c3036446ac3b340005d92ab92f7d48ee3271b5dac1d36945d3d9"
-  "0.10.3":
-    url: "https://github.com/libjxl/libjxl/archive/v0.10.3.zip"
-    sha256: "a9e2103f61ab79f5561b506ad03fcba33207263284b1a796eba3ca826ab0a75f"
-  "0.10.2":
-    url: "https://github.com/libjxl/libjxl/archive/v0.10.2.zip"
-    sha256: "910ab4245eebe0fba801a057f5fbc4fe96dad7c9979880bb49ad3e2623a911a2"
-  "0.8.2":
-    url: "https://github.com/libjxl/libjxl/archive/v0.8.2.zip"
-    sha256: "1f2ccc06f07c4f6cf4aa6c7763ba0598f12a7544d597f02beb07f615eb08ccf0"

--- a/recipes/libjxl/config.yml
+++ b/recipes/libjxl/config.yml
@@ -1,9 +1,5 @@
 versions:
+  "0.11.2":
+    folder: all
   "0.11.1":
-    folder: all
-  "0.10.3":
-    folder: all
-  "0.10.2":
-    folder: all
-  "0.8.2":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **libjxl/0.11.2**

#### Motivation
* Add new version with (security related) bugfixes (2 CVEs, one finding from Project Zero).
* Cleanup old versions. Only 0.11.1 is still used by quite a few projects, all older versions still published aren't used anymore.

#### Details
* https://github.com/libjxl/libjxl/releases/tag/v0.11.2
* https://github.com/libjxl/libjxl/compare/v0.11.1...v0.11.2

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
