### PR TITLE
Fix wayland-protocols test package

### DIFF
--- a/recipes/wayland-protocols/all/test_package/conanfile.py
+++ b/recipes/wayland-protocols/all/test_package/conanfile.py
@@ -17,13 +17,13 @@ class TestPackageConan(ConanFile):
 
     def requirements(self):
         self.requires(self.tested_reference_str)
-        self.requires("wayland/1.22.0")
+        self.requires("wayland/[>=1.22.0]")
 
     def build_requirements(self):
-        self.tool_requires("meson/1.3.0")
+        self.tool_requires("meson/[>=1.3.0]")
         if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
-            self.tool_requires("pkgconf/2.1.0")
-        self.tool_requires("wayland/1.22.0")
+            self.tool_requires("pkgconf/[>=2.1.0]")
+        self.tool_requires("wayland/<host_version>")
 
     def layout(self):
         basic_layout(self)


### PR DESCRIPTION
Fixes the test_package of wayland-protocols for the current state of package versions on CCI.

### Summary
Changes to **test_package** recipe of:  **wayland-protocols/***

#### Motivation

- Makes the test package pass if only the current state of the recipes of master are exported (so no server involved).
- The test package requires `wayland/1.22.0`, but should also be able to test with newer `wayland` versions.
- It tool_requires `meson/1.3.0` which is no longer listed in master. Thus, a built against the current state of CCI recipes fails unnecessarily. 


#### Details
Very simple change. 
- Use version ranges in the [build_]requirements
- Use <host_version> for wayland in the build_requirements

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
