### PR TITLE
libtirpc: add version 1.3.4

### DIFF
--- a/recipes/libtirpc/all/conandata.yml
+++ b/recipes/libtirpc/all/conandata.yml
@@ -1,0 +1,18 @@
+sources:
+  "1.3.4":
+    url: "https://downloads.sourceforge.net/libtirpc/libtirpc-1.3.4.tar.bz2"
+    sha256: "1e0b0c7231c5fa122e06c0609a76723664d068b0dba3b8219b63e6340b347860"
+patches:
+  "1.3.4":
+    - patch_file: "patches/1.3.4/ipv6.patch"
+      patch_description: "netconfig: remove tcp6, udp6 on --disable-ipv6.patch"
+      patch_type: "backport"
+      patch_source: "https://git.linux-nfs.org/?p=steved/libtirpc.git;a=commit;h=11d8d96e75e9260bed8566a6a366ff7dd8fde753"
+    - patch_file: "patches/1.3.4/0001-Update-declarations-to-allow-compile-with-gcc-15.patch"
+      patch_description: "Update declarations to allow compile with gcc-15"
+      patch_type: "backport"
+      patch_source: "https://git.linux-nfs.org/?p=steved/libtirpc.git;a=commit;h=d473f1e1f6ba80bfaee4daa058da159305167323"
+    - patch_file: "patches/1.3.4/0002-update-signal-and-key_call-declarations-to-allow-com.patch"
+      patch_description: "Update signal and key_call declarations to allow compile with gcc-15"
+      patch_type: "backport"
+      patch_source: "https://git.linux-nfs.org/?p=steved/libtirpc.git;a=commit;h=240ee6c774729c9c24812aa8912f1fcf8996b162"

--- a/recipes/libtirpc/all/conanfile.py
+++ b/recipes/libtirpc/all/conanfile.py
@@ -1,0 +1,130 @@
+from conan import ConanFile, Version
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import fix_apple_shared_install_name
+from conan.tools.build import cross_building, check_min_cstd
+from conan.tools.env import Environment, VirtualRunEnv
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rm, rmdir
+from conan.tools.gnu import Autotools, AutotoolsDeps, AutotoolsToolchain, PkgConfigDeps
+from conan.tools.layout import basic_layout
+from conan.tools.microsoft import is_msvc, unix_path
+import os
+
+required_conan_version = ">=2.0.9"
+
+class LibtirpcConan(ConanFile):
+    name = "libtirpc"
+    description = "Libtirpc is a port of Sun's Transport-Independent RPC library to Linux. It's being developed by the Bull GNU/Linux NFSv4 project."
+
+    license = "BSD-3-Clause"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://sourceforge.net/projects/libtirpc/"
+    topics = ("libtirpc", "tirpc", "sun-rpc", "onc-rpc", "nfs", "rpc", "rpcgen")
+
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "with_ipv6": [True, False],
+        "with_gssapi": [True, False]
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "with_ipv6": False,
+        "with_gssapi": False
+    }
+    implements = ["auto_shared_fpic"]
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def requirements(self):
+        if self.options.with_gssapi:
+            self.requires(f"krb5/1.21.2")
+
+    def validate(self):
+        if "cstd" in self.settings.compiler:
+            check_min_cstd(self, 99)
+
+
+    def build_requirements(self):
+        self.tool_requires("libtool/2.4.7")
+        if self.settings_build.os == "Windows":
+            self.win_bash = True
+            if not self.conf.get("tools.microsoft.bash:path", check_type=str):
+                self.tool_requires("msys2/cci.latest")
+        if is_msvc(self):
+            self.tool_requires("automake/1.9.4")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
+
+    def generate(self):
+        if not cross_building(self):
+            VirtualRunEnv(self).generate(scope="build")
+        tc = AutotoolsToolchain(self)
+
+        def enable_disable(v):
+            return "enable" if v else "disable"
+
+        tc.configure_args.extend([
+            f"--enable-tools=no",
+            "--enable-manpages=no",
+            f"--{enable_disable(self.options.with_ipv6)}-ipv6",
+            f"--{enable_disable(self.options.with_gssapi)}-gssapi"
+        ])
+        tc.generate()
+        tc = PkgConfigDeps(self)
+        tc.generate()
+        deps = AutotoolsDeps(self)
+        deps.generate()
+
+        if is_msvc(self):
+            env = Environment()
+            automake_conf = self.dependencies.build["automake"].conf_info
+            compile_wrapper = unix_path(self, automake_conf.get("user.automake:compile-wrapper", check_type=str))
+            ar_wrapper = unix_path(self, automake_conf.get("user.automake:lib-wrapper", check_type=str))
+            env.define("CC", f"{compile_wrapper} cl -nologo")
+            env.define("CXX", f"{compile_wrapper} cl -nologo")
+            env.define("LD", "link -nologo")
+            env.define("AR", f"{ar_wrapper} lib")
+            env.define("NM", "dumpbin -symbols")
+            env.define("OBJDUMP", ":")
+            env.define("RANLIB", ":")
+            env.define("STRIP", ":")
+            env.vars(self).save_script("conanbuild_msvc")
+
+    def build(self):
+        autotools = Autotools(self)
+        autotools.autoreconf()
+        autotools.configure()
+        autotools.make()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        autotools = Autotools(self)
+        autotools.install()
+
+        rm(self, "*.la", os.path.join(self.package_folder, "lib"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+
+        copy(self, "*", os.path.join(self.package_folder, "include", "tirpc"), os.path.join(self.package_folder, "include"))
+        rmdir(self, os.path.join(self.package_folder, "include", "tirpc"))
+
+        fix_apple_shared_install_name(self)
+
+    def package_info(self):
+        self.cpp_info.names["cmake_find_package"] = "libtirpc"
+        self.cpp_info.names["cmake_find_package_multi"] = "libtirpc"
+        self.cpp_info.libs = ["tirpc"]
+
+        self.cpp_info.set_property("pkg_config_name", "libtirpc")
+
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.extend(["dl", "m", "pthread"])

--- a/recipes/libtirpc/all/patches/1.3.4/0001-Update-declarations-to-allow-compile-with-gcc-15.patch
+++ b/recipes/libtirpc/all/patches/1.3.4/0001-Update-declarations-to-allow-compile-with-gcc-15.patch
@@ -1,0 +1,64 @@
+From b526c0a90953f47d4cbf7ef01e9ac13e9e76904a Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Thu, 12 Dec 2024 04:16:02 -0500
+Subject: [PATCH 1/2] Update declarations to allow compile with gcc-15
+
+This patch fixes some of the compile errors with gcc 15-20241117.
+
+In addition the follow declarations need to be fixed:
+  sed -n 75,77p libtirpc-1.3.6/src/key_call.c
+  cryptkeyres *(*__key_encryptsession_pk_LOCAL)() = 0;
+  cryptkeyres *(*__key_decryptsession_pk_LOCAL)() = 0;
+  des_block *(*__key_gendes_LOCAL)() = 0;
+
+Upstream-Status: Backport [https://git.linux-nfs.org/?p=steved/libtirpc.git;a=commit;h=d473f1e1f6ba80bfaee4daa058da159305167323]
+Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>
+Signed-off-by: Steve Dickson <steved@redhat.com>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/auth_none.c     | 2 +-
+ src/getpublickey.c  | 2 +-
+ src/svc_auth_none.c | 4 ++--
+ 3 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/auth_none.c b/src/auth_none.c
+index 0b0bbd1..aca6e71 100644
+--- a/src/auth_none.c
++++ b/src/auth_none.c
+@@ -62,7 +62,7 @@ static bool_t authnone_validate (AUTH *, struct opaque_auth *);
+ static bool_t authnone_refresh (AUTH *, void *);
+ static void authnone_destroy (AUTH *);
+ 
+-extern bool_t xdr_opaque_auth();
++extern bool_t xdr_opaque_auth(XDR *, struct opaque_auth *);
+ 
+ static struct auth_ops *authnone_ops();
+ 
+diff --git a/src/getpublickey.c b/src/getpublickey.c
+index be37a24..4e96c7c 100644
+--- a/src/getpublickey.c
++++ b/src/getpublickey.c
+@@ -52,7 +52,7 @@
+ /*
+  * Hack to let ypserv/rpc.nisd use AUTH_DES.
+  */
+-int (*__getpublickey_LOCAL)() = 0;
++int (*__getpublickey_LOCAL)(const char *, char *) = 0;
+ 
+ /*
+  * Get somebody's public key
+diff --git a/src/svc_auth_none.c b/src/svc_auth_none.c
+index 887e809..5ca98e9 100644
+--- a/src/svc_auth_none.c
++++ b/src/svc_auth_none.c
+@@ -37,8 +37,8 @@
+ 
+ #include <rpc/rpc.h>
+ 
+-static bool_t	svcauth_none_destroy();
+-static bool_t   svcauth_none_wrap();
++static bool_t	svcauth_none_destroy(SVCAUTH *);
++static bool_t   svcauth_none_wrap(SVCAUTH *, XDR *, bool_t (*)(XDR *, ...), char *);
+ 
+ struct svc_auth_ops svc_auth_none_ops = {
+ 	svcauth_none_wrap,

--- a/recipes/libtirpc/all/patches/1.3.4/0002-update-signal-and-key_call-declarations-to-allow-com.patch
+++ b/recipes/libtirpc/all/patches/1.3.4/0002-update-signal-and-key_call-declarations-to-allow-com.patch
@@ -1,0 +1,60 @@
+From 55452e6ae71869880f8c85d5dba9aa24d7147d8b Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Thu, 2 Jan 2025 08:46:24 -0500
+Subject: [PATCH 2/2] update signal and key_call declarations to allow compile
+ with gcc-15
+
+Follow up patch addressing the following declarations:
+  sed -n 75,77p libtirpc-1.3.6/src/key_call.c
+  cryptkeyres *(*__key_encryptsession_pk_LOCAL)() = 0;
+  cryptkeyres *(*__key_decryptsession_pk_LOCAL)() = 0;
+  des_block *(*__key_gendes_LOCAL)() = 0;
+
+Upstream-Status: Backport [https://git.linux-nfs.org/?p=steved/libtirpc.git;a=commit;h=240ee6c774729c9c24812aa8912f1fcf8996b162]
+Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>
+Signed-off-by: Steve Dickson <steved@redhat.com>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/auth_time.c | 4 ++--
+ src/key_call.c  | 6 +++---
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/src/auth_time.c b/src/auth_time.c
+index 936dd76..c21b1df 100644
+--- a/src/auth_time.c
++++ b/src/auth_time.c
+@@ -248,7 +248,7 @@ __rpc_get_time_offset(td, srv, thost, uaddr, netid)
+ 	char			ut[64], ipuaddr[64];
+ 	endpoint		teps[32];
+ 	nis_server		tsrv;
+-	void			(*oldsig)() = NULL; /* old alarm handler */
++	void			(*oldsig)(int) = NULL; /* old alarm handler */
+ 	struct sockaddr_in	sin;
+ 	int			s = RPC_ANYSOCK;
+ 	socklen_t len;
+@@ -417,7 +417,7 @@ __rpc_get_time_offset(td, srv, thost, uaddr, netid)
+ 		} else {
+ 			int res;
+ 
+-			oldsig = (void (*)())signal(SIGALRM, alarm_hndler);
++			oldsig = (void (*)(int))signal(SIGALRM, alarm_hndler);
+ 			saw_alarm = 0; /* global tracking the alarm */
+ 			alarm(20); /* only wait 20 seconds */
+ 			res = connect(s, (struct sockaddr *)&sin, sizeof(sin));
+diff --git a/src/key_call.c b/src/key_call.c
+index 9f4b1d2..43f990e 100644
+--- a/src/key_call.c
++++ b/src/key_call.c
+@@ -72,9 +72,9 @@
+  * implementations of these functions, and to call those in key_call().
+  */
+ 
+-cryptkeyres *(*__key_encryptsession_pk_LOCAL)() = 0;
+-cryptkeyres *(*__key_decryptsession_pk_LOCAL)() = 0;
+-des_block *(*__key_gendes_LOCAL)() = 0;
++cryptkeyres *(*__key_encryptsession_pk_LOCAL)(uid_t, char *) = 0;
++cryptkeyres *(*__key_decryptsession_pk_LOCAL)(uid_t, char *) = 0;
++des_block *(*__key_gendes_LOCAL)(uid_t, char *) = 0;
+ 
+ static int key_call( u_long, xdrproc_t, void *, xdrproc_t, void *);
+ 

--- a/recipes/libtirpc/all/patches/1.3.4/ipv6.patch
+++ b/recipes/libtirpc/all/patches/1.3.4/ipv6.patch
@@ -1,0 +1,52 @@
+From 077bbd32e8b7474dc5f153997732e1e6aec7fad6 Mon Sep 17 00:00:00 2001
+Message-Id: <077bbd32e8b7474dc5f153997732e1e6aec7fad6.1697120796.git.joerg.sommer@navimatix.de>
+From: =?UTF-8?q?J=C3=B6rg=20Sommer?= <joerg.sommer@navimatix.de>
+Date: Thu, 12 Oct 2023 16:22:59 +0200
+Subject: [PATCH] netconfig: remove tcp6, udp6 on --disable-ipv6
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+If the configuration for IPv6 is disabled, the netconfig should not contain
+settings for tcp6 and udp6.
+
+The test for the configure option didn't work, because it check the wrong
+variable.
+
+Signed-off-by: Jörg Sommer <joerg.sommer@navimatix.de>
+Upstream-Status: Submitted [libtirpc-devel@lists.sourceforge.net]
+Upstream-Status: Submitted [linux-nfs@vger.kernel.org]
+---
+ configure.ac    | 2 +-
+ doc/Makefile.am | 5 +++++
+ 2 files changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index fe6c517..b687f8d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -64,7 +64,7 @@ fi
+ AC_ARG_ENABLE(ipv6,
+ 	[AC_HELP_STRING([--disable-ipv6], [Disable IPv6 support @<:@default=no@:>@])],
+ 	[],[enable_ipv6=yes])
+-AM_CONDITIONAL(INET6, test "x$disable_ipv6" != xno)
++AM_CONDITIONAL(INET6, test "x$enable_ipv6" != xno)
+ if test "x$enable_ipv6" != xno; then
+ 	AC_DEFINE(INET6, 1, [Define to 1 if IPv6 is available])
+ fi
+diff --git a/doc/Makefile.am b/doc/Makefile.am
+index d42ab90..b9678f6 100644
+--- a/doc/Makefile.am
++++ b/doc/Makefile.am
+@@ -2,3 +2,8 @@ dist_sysconf_DATA	= netconfig bindresvport.blacklist
+ 
+ CLEANFILES	       = cscope.* *~
+ DISTCLEANFILES	       = Makefile.in
++
++if ! INET6
++install-exec-hook:
++	$(SED) -i '/^tcp6\|^udp6/d' "$(DESTDIR)$(sysconfdir)"/netconfig
++endif
+-- 
+2.34.1
+

--- a/recipes/libtirpc/all/test_package/CMakeLists.txt
+++ b/recipes/libtirpc/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES C)
+
+find_package(libtirpc REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE libtirpc::libtirpc)

--- a/recipes/libtirpc/all/test_package/conanfile.py
+++ b/recipes/libtirpc/all/test_package/conanfile.py
@@ -1,0 +1,29 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build_requirements(self):
+        # only if we have to call autoreconf
+        self.tool_requires("cmake/[>=3.15]")
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/libtirpc/all/test_package/test_package.c
+++ b/recipes/libtirpc/all/test_package/test_package.c
@@ -1,0 +1,32 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <rpc/rpc.h>
+#include <rpc/rpc_com.h>
+
+
+int main(void) {
+    char buf[RPC_MAXDATASIZE];
+
+    XDR xdr_in;
+    xdrmem_create(&xdr_in, buf, sizeof(buf), XDR_ENCODE);
+
+    char* data_in = "Hello World!";
+    if (!xdr_string(&xdr_in, &data_in, strlen(data_in))) {
+        return EXIT_FAILURE;
+    }
+
+    XDR xdr_out;
+    xdrmem_create(&xdr_out, buf, sizeof(buf), XDR_DECODE);
+
+    char* data_out = NULL;
+    if (!xdr_string(&xdr_out, &data_out, sizeof(buf))) {
+        return EXIT_FAILURE + 1;
+    }
+
+    if (strcmp(data_in, data_out) != 0) {
+        return EXIT_FAILURE + 2;
+    }
+    return EXIT_SUCCESS;
+}

--- a/recipes/libtirpc/config.yml
+++ b/recipes/libtirpc/config.yml
@@ -1,0 +1,4 @@
+versions:
+  # Newer versions at the top
+  "1.3.4":
+    folder: all


### PR DESCRIPTION
### Summary
Adding recipe:  **libtirpc/1.3.4**

#### Motivation

I am providing the recipe I was using for a few months in a  private project and since I noticed the request #20718 for adding the version 1.3.4 to the recipe index a  few days ago, I want  to help it move forward.

#### Details

So far, this recipe was tested and used with the following **settings** and **options** only:

**settings:**
```ini
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=15
os=Linux
```

**options:**
```ini
[options]
```

```ini
[options]
&:with_ipv6=True
```

```ini
[options]
&:shared=True
```

```ini
[options]
&:shared=True
&:with_ipv6=True
```

```ini
[options]
&:fPIC=True
&:shared=True
```

```ini
[options]
&:fPIC=True
&:shared=True
&:with_ipv6=True
```

Regarding the two extra options of the recipe:
* `with_ipv6`:  :heavy_check_mark:   works fine
* `with_gssapi`: :x:  causes some `conflicting types ...` errors upon building the `krb5` dependency from the conan index

Other OSes aside from Linux were not tested, so testing for the following OSes is still open:
- [ ] Windows
- [ ] MacOS
- [ ] FreeBSD

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
