### PR TITLE
marchingcubecpp: add new recipe for 0.0.0.cci.20260215

### DIFF
--- a/recipes/marchingcubecpp/all/conandata.yml
+++ b/recipes/marchingcubecpp/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.0.0.cci.20260224":
+    url: "https://github.com/aparis69/MarchingCubeCpp/archive/0e980cc9ed2309ace816622e7877a51330b54aec.tar.gz"
+    sha256: "b813ec6459f5e0e66ac67c2e61b5ad3f477bfda1f1443faf0f11b6c87f9532ec"

--- a/recipes/marchingcubecpp/all/conanfile.py
+++ b/recipes/marchingcubecpp/all/conanfile.py
@@ -1,0 +1,33 @@
+from conan import ConanFile
+from conan.tools.files import get, copy
+from conan.tools.layout import basic_layout
+import os
+
+required_conan_version = ">=2.4"
+
+
+class MarchingCubeCppConan(ConanFile):
+    name = "marchingcubecpp"
+    description = "A public domain/MIT header-only marching cube implementation in C++."
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/aparis69/MarchingCubeCpp"
+    topics = ("graphics", "marching-cube", "header-only")
+    package_type = "header-library"
+    implements = ["auto_header_only"]
+    no_copy_source = True
+    settings = "os", "arch", "compiler", "build_type"
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, "MC.h",  src=self.source_folder,  dst=os.path.join(self.package_folder, "include"))
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/marchingcubecpp/all/test_package/CMakeLists.txt
+++ b/recipes/marchingcubecpp/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(MarchingCubeCpp REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE marchingcubecpp::marchingcubecpp)

--- a/recipes/marchingcubecpp/all/test_package/conanfile.py
+++ b/recipes/marchingcubecpp/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/marchingcubecpp/all/test_package/test_package.cpp
+++ b/recipes/marchingcubecpp/all/test_package/test_package.cpp
@@ -1,0 +1,12 @@
+#define MC_IMPLEM_ENABLE
+#include <MC.h>
+
+#include <iostream>
+
+int main() {
+
+  MC::MC_FLOAT f = 0;
+  std::cout << "f: " << f << std::endl;
+
+  return 0;
+}

--- a/recipes/marchingcubecpp/config.yml
+++ b/recipes/marchingcubecpp/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.0.0.cci.20260224":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **marchingcubecpp/0.0.0.cci.20260224**

#### Motivation
Add new recipe for MarchingCubeCpp 0.0.0.cci.20260224.
MarchingCubeCpp is a lightweight, header-only C++ implementation of the Marching Cubes algorithm.
This library used in computer vision, 3d graphics, and robotics.

#### Details
- Add new recipe from https://github.com/aparis69/MarchingCubeCpp
- Using version `0.0.0.cci.20260224` based on the latest commit (Feb 24, 2026).

Tested locally with `conan create . --version=0.0.0.cci.20260224` on
- Linux: GCC 15.2.1 (x64)
- Windows: MSVC 19.50.35723 (x64)
- macOS: Apple Clang 17.0.0 (clang-1700.6.3.2) (arm64)


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!