### PR TITLE
reactiveplusplus: add version 2.2.3

### DIFF
--- a/recipes/reactiveplusplus/all/conandata.yml
+++ b/recipes/reactiveplusplus/all/conandata.yml
@@ -2,24 +2,9 @@ sources:
   "2.2.3":
     url: "https://github.com/victimsnino/ReactivePlusPlus/archive/refs/tags/v2.2.3.tar.gz"
     sha256: "d66507538e75f61569acbb4d5e26e18adf839791120688693d2fe8da955236ea"
-  "2.2.1":
-    url: "https://github.com/victimsnino/ReactivePlusPlus/archive/refs/tags/v2.2.1.tar.gz"
-    sha256: "4d44da273a8f7401b8ebf6973ae06246505e204e9c491b435f0e1b223d6841fe"
-  "2.2.0":
-    url: "https://github.com/victimsnino/ReactivePlusPlus/archive/refs/tags/v2.2.0.tar.gz"
-    sha256: "10b3969956ff05fa4ebd62245b616731d9c12fb5b57c4cecb2c4ee418303dbea"
   "2.1.1":
     url: "https://github.com/victimsnino/ReactivePlusPlus/archive/refs/tags/v2.1.1.tar.gz"
     sha256: "0b962478d7c973a1f74062ce7f8d24c2fdcd2733031b1f014e65d252d59ebe6a"
   "2.0.0":
     url: "https://github.com/victimsnino/ReactivePlusPlus/archive/v2.0.0.tar.gz"
     sha256: "8950fe579aea23be1a6affd4ec8845c78016454aaf875dbae6a52d10eeb6df02"
-  "0.2.3":
-    url: "https://github.com/victimsnino/ReactivePlusPlus/archive/v0.2.3.tar.gz"
-    sha256: "9542419f8d7da98126ba2c6ae08fab287b4b3798d89cf75ed9bed2a9e3ec1678"
-  "0.2.1":
-    url: "https://github.com/victimsnino/ReactivePlusPlus/archive/refs/tags/v0.2.1.tar.gz"
-    sha256: "c41f9a0b727d5bdbc92390b3f075bfa280fd4f6f2aa7db51428fc30023b518d0"
-  "0.1.2":
-    url: "https://github.com/victimsnino/ReactivePlusPlus/archive/refs/tags/v0.1.2.tar.gz"
-    sha256: "daa16d8258d811bfc6848829ea1afa6f4a72b68ad8978d55ea4e1cf809ae6d52"

--- a/recipes/reactiveplusplus/config.yml
+++ b/recipes/reactiveplusplus/config.yml
@@ -1,17 +1,7 @@
 versions:
   "2.2.3":
     folder: all
-  "2.2.1":
-    folder: all
-  "2.2.0":
-    folder: all
   "2.1.1":
     folder: all
   "2.0.0":
-    folder: all
-  "0.2.3":
-    folder: all
-  "0.2.1":
-    folder: all
-  "0.1.2":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe: **reactiveplusplus/2.2.3**

#### Motivation
New upstream release v2.2.3 is available.

#### Details
- Added version 2.2.3 to config.yml and conandata.yml
- Release notes: https://github.com/victimsnino/ReactivePlusPlus/releases/tag/v2.2.3

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!