### PR TITLE
openjph: 0.26.3

### DIFF
--- a/recipes/openjph/all/conandata.yml
+++ b/recipes/openjph/all/conandata.yml
@@ -1,9 +1,9 @@
 sources:
-  "0.25.3":
-    url: "https://github.com/aous72/OpenJPH/archive/0.25.3.tar.gz"
-    sha256: "815b0d345daf3bbad72f3930d4f6c831643dcb2b734d8bb44d871d68db12f4d2"
+  "0.26.3":
+    url: "https://github.com/aous72/OpenJPH/archive/0.26.3.tar.gz"
+    sha256: "29de006da7f1e8cf0cd7c3ec424cf29103e465052c00b5a5f0ccb7e1f917bb3f"
 patches:
-  "0.25.3":
-    - patch_file: "patches/0.25.3-cmake-cxx-standard-pic.patch"
+  "0.26.3":
+    - patch_file: "patches/0.26.3-cmake-cxx-standard-pic.patch"
       patch_description: "Remove setting of CXX standard to a fixed value overriding the toolchain provided by Conan and PIC hardcoded option"
       patch_type: "conan"

--- a/recipes/openjph/all/patches/0.26.3-cmake-cxx-standard-pic.patch
+++ b/recipes/openjph/all/patches/0.26.3-cmake-cxx-standard-pic.patch
@@ -9,5 +9,5 @@ index ea19aea..132a619 100644
 -set_target_properties(openjph PROPERTIES POSITION_INDEPENDENT_CODE ON)
 +#set_target_properties(openjph PROPERTIES POSITION_INDEPENDENT_CODE ON)
  target_compile_definitions(openjph PUBLIC _FILE_OFFSET_BITS=64)
- target_include_directories(openjph PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/common> $<INSTALL_INTERFACE:include>)
+ target_include_directories(openjph PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/openjph> $<INSTALL_INTERFACE:include>)
  

--- a/recipes/openjph/config.yml
+++ b/recipes/openjph/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.25.3":
+  "0.26.3":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **openjph/0.26.3**

#### Motivation
Bugfixes in https://github.com/aous72/OpenJPH/pull/244 and https://github.com/aous72/OpenJPH/pull/245 to catch some erroneous data input to prevent running into invalid decoding.

#### Details
* No large build changes, main intention of build related changes is users using it via add_subdirectory: https://github.com/aous72/OpenJPH/compare/0.25.3...0.26.3

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
