### PR TITLE
Add TinyEXIF 1.0.4

### DIFF
--- a/recipes/tinyexif/all/conandata.yml
+++ b/recipes/tinyexif/all/conandata.yml
@@ -2,9 +2,3 @@ sources:
   "1.0.4":
     url: "https://github.com/cdcseacave/TinyEXIF/archive/refs/tags/1.0.4.tar.gz"
     "sha256": "6484dec27c8d86bd33edf3eb7c132044728a4ca3a239411104038158721bd395"
-  "cci.20210411":
-    url: "https://github.com/cdcseacave/TinyEXIF/archive/6e56015f56ee0f387f1b8c76e50eb35ac60372da.tar.gz"
-    sha256: "54031072382dbe9cc08ca18b40e39a6c2b248e83bd6263b29c70a4a8aa8affe7"
-  "1.0.2":
-    url: "https://github.com/cdcseacave/TinyEXIF/archive/refs/tags/1.0.2.tar.gz"
-    sha256: "427e02c38ee29d87bc82d08545d9f9a68c603af16e0b35f6807a4a8e63c14b86"

--- a/recipes/tinyexif/config.yml
+++ b/recipes/tinyexif/config.yml
@@ -1,7 +1,3 @@
 versions:
   "1.0.4":
     folder: all
-  "cci.20210411":
-    folder: all
-  "1.0.2":
-    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **tinyexif/1.0.4**

#### Motivation
Add up-to-date version of tinyexif. Most importantly, the updated version of this library is now compatible with CMake 4.0.

#### Details
No special changes, just added a new source tarball and checksum.

### Maintainers edit

* Do not publish revisions for older versions
* Updated license -> MIT
* Minor clean up and remove useless CMake variables

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
