### PR TITLE
imgui: Add 1.92.6 and clean-up some older versions

### DIFF
--- a/recipes/imgui/all/conandata.yml
+++ b/recipes/imgui/all/conandata.yml
@@ -15,6 +15,20 @@ sources:
     testengine:
       url: "https://github.com/ocornut/imgui_test_engine/archive/v1.92.6.tar.gz"
       sha256: "5374ec2318933f9fc663d924529ea80e5fa40866e82fafc3872ae94a16fdbc7f"
+  "1.92.2b":
+    core:
+      url: "https://github.com/ocornut/imgui/archive/v1.92.2b.tar.gz"
+      sha256: "da3d453cce74e0fb3d67f8d798a2a8d04fcaf0b33ce0e0131d0695dfc4f64191"
+    testengine:
+      url: "https://github.com/ocornut/imgui_test_engine/archive/v1.92.2.tar.gz"
+      sha256: "5914327269b2dd9ad66bead3be8577f99f5f572d196bbe4028f6812cf0356adb"
+  "1.92.2b-docking":
+    core:
+      url: "https://github.com/ocornut/imgui/archive/v1.92.2b-docking.tar.gz"
+      sha256: "f6ad86e6f938fdda4d5e362b9a9b39158963dd3257fdc9902efc148c0c0c39f9"
+    testengine:
+      url: "https://github.com/ocornut/imgui_test_engine/archive/v1.92.2.tar.gz"
+      sha256: "5914327269b2dd9ad66bead3be8577f99f5f572d196bbe4028f6812cf0356adb"
   "1.91.8":
     core:
       url: "https://github.com/ocornut/imgui/archive/v1.91.8.tar.gz"
@@ -51,6 +65,22 @@ sources:
     testengine:
       url: "https://github.com/ocornut/imgui_test_engine/archive/v1.90.5.tar.gz"
       sha256: "79339246d8c919c5926df0a7bee99be585ebaf67cdaba89a0ac314b1f7846f92"
+  "1.88":
+    core:
+      url: "https://github.com/ocornut/imgui/archive/v1.88.tar.gz"
+      sha256: "9f14c788aee15b777051e48f868c5d4d959bd679fc5050e3d2a29de80d8fd32e"
+  "1.87":
+    core:
+      url: "https://github.com/ocornut/imgui/archive/v1.87.tar.gz"
+      sha256: "b54ceb35bda38766e36b87c25edf7a1cd8fd2cb8c485b245aedca6fb85645a20"
+  "1.86":
+    core:
+      url: "https://github.com/ocornut/imgui/archive/v1.86.tar.gz"
+      sha256: "6ba6ae8425a19bc52c5e067702c48b70e4403cd339cba02073a462730a63e825"
+  "1.85":
+    core:
+      url: "https://github.com/ocornut/imgui/archive/v1.85.tar.gz"
+      sha256: "7ed49d1f4573004fa725a70642aaddd3e06bb57fcfe1c1a49ac6574a3e895a77"
 patches:
   "1.92.4":
     - patch_file: "patches/1.92.4-0001-static-linking-bugfix-backport.patch"

--- a/recipes/imgui/config.yml
+++ b/recipes/imgui/config.yml
@@ -3,6 +3,10 @@ versions:
     folder: all
   "1.92.6-docking":
     folder: all
+  "1.92.2b":
+    folder: all
+  "1.92.2b-docking":
+    folder: all
   "1.91.8":
     folder: all
   "1.91.8-docking":
@@ -14,4 +18,12 @@ versions:
   "1.90.5":
     folder: all
   "1.90.5-docking":
+    folder: all
+  "1.88":
+    folder: all
+  "1.87":
+    folder: all
+  "1.86":
+    folder: all
+  "1.85":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **imgui/1.92.6**

#### Motivation
As usual, number of accumulated changes since the last release. Especially it looks like high res font handling has been optimized which I'm looking forward to.

Also removing some older versions to clean up the version matrix a bit. We have a number of recipes still using very old versions. (1.88.0 which I propose to remove is roughly 4 years out (June 22) with imgui being very actively developed.) Going to look at least into updating & cleaning up implot which I wanted to integrate anyway after this is in.

#### Details
* https://github.com/ocornut/imgui/releases/tag/v1.92.6
* https://github.com/ocornut/imgui/compare/v1.92.5...v1.92.6

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
