### PR TITLE
implot: Add version 0.17 and clean up old versions & recipe

### DIFF
--- a/recipes/implot/all/conandata.yml
+++ b/recipes/implot/all/conandata.yml
@@ -1,19 +1,4 @@
 sources:
-  "0.16":
-    url: "https://github.com/epezent/implot/archive/v0.16.tar.gz"
-    sha256: "961df327d8a756304d1b0a67316eebdb1111d13d559f0d3415114ec0eb30abd1"
-  "0.15":
-    url: "https://github.com/epezent/implot/archive/v0.15.tar.gz"
-    sha256: "4c20f22fbfbe4ad055f3d344581918d62cde72070b233dad75419a4334f82146"
-  "0.14":
-    url: "https://github.com/epezent/implot/archive/v0.14.tar.gz"
-    sha256: "1613af3e6554c0a74de20c6e60e9bce5ce35c2d4f9e1aa5ff963f7fe2d48af88"
-  "0.13":
-    url: "https://github.com/epezent/implot/archive/v0.13.tar.gz"
-    sha256: "acc8b012b6761c9b7ce1599a35fd861ac6dafb01368b1e938c90a3f654bd7589"
-  "0.12":
-    url: "https://github.com/epezent/implot/archive/v0.12.tar.gz"
-    sha256: "f8bc3b9b58dbabe3a0c0a2ebb8307d8e850012685332a85be36fcc4d4450be56"
-  "0.11":
-    url: "https://github.com/epezent/implot/archive/v0.11.tar.gz"
-    sha256: "1ec4c8501f70901132a9f14409c956b508a8ea3fe457e8518325b156dceada00"
+  "0.17":
+    url: "https://github.com/epezent/implot/archive/v0.17.tar.gz"
+    sha256: "0aa3ff4fb97e553608e6758e77980eedf01745628fe6c025e647f941ae674127"

--- a/recipes/implot/config.yml
+++ b/recipes/implot/config.yml
@@ -1,13 +1,3 @@
 versions:
-  "0.16":
-    folder: "all"
-  "0.15":
-    folder: "all"
-  "0.14":
-    folder: "all"
-  "0.13":
-    folder: "all"
-  "0.12":
-    folder: "all"
-  "0.11":
+  "0.17":
     folder: "all"


### PR DESCRIPTION
### Summary
Changes to recipe:  **implot/0.17**

#### Motivation
Wanted to play around with implot. The older versions are too old as the imgui API is quite fluid, so not building v0.16 or older with imgui < 1.92(.5). The recipe feels a bit too complex for my taste with all the version dependent switches and as we only keep the most recent version(s) for many recipes, I'd suggest we remove the older versions.

#### Details

One thing I saw in the recipe, is a packaging of all implot*.cpp files which I don't get:
```
copy(self, pattern="implot*.cpp", dst=os.path.join(self.package_folder, "res", "src"), src=self.source_folder)
```

Don't understand why those files are copied, they are all compiled anyway. Should we remove this maybe?

* https://github.com/epezent/implot/releases/tag/v0.17
* https://github.com/epezent/implot/compare/v0.16...v0.17 but as the CMake is part of the recipe here, there is no build change. No new or removed file from the build, so I don't see any build related change.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
