### PR TITLE
libvips: fix pdfium version check for Chromium versioning scheme

### DIFF
--- a/recipes/libvips/all/conanfile.py
+++ b/recipes/libvips/all/conanfile.py
@@ -8,6 +8,7 @@ from conan.tools.gnu import PkgConfigDeps
 from conan.tools.layout import basic_layout
 from conan.tools.meson import Meson, MesonToolchain
 from conan.tools.microsoft import check_min_vs, is_msvc, is_msvc_static_runtime
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.60.0 <2.0 || >=2.0.6"
@@ -288,6 +289,9 @@ class LibvipsConan(ConanFile):
         tc.generate()
 
         deps = PkgConfigDeps(self)
+        if self.options.with_pdfium:
+            pdfium_api_version = Version(self.dependencies["pdfium"].ref.version).patch
+            deps.set_property("pdfium", "system_package_version", pdfium_api_version)
         deps.generate()
 
     def _patch_sources(self):


### PR DESCRIPTION
### Summary
Changes to recipe: **libvips/8.16.0**

#### Motivation

When building libvips with `with_pdfium=True`, pdfium is **silently disabled** because `meson.build` checks `dependency('pdfium', version: '>=4200', ...)`. The CCI `pdfium/95.0.4629` recipe uses Chromium versioning — meson sees major version `95 < 4200` and rejects the dependency, even though the API version (`4629`) satisfies the constraint.

Fixes #29610

#### Details

Patch `meson.build` to:
1. Find pdfium without a version constraint
2. Split the version string on `.` and take the last component as the API version
3. Error if API version < 4200

This works for both versioning schemes:
- `95.0.4629` → last component `4629 >= 4200` ✓
- `4629` → last component `4629 >= 4200` ✓

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---