### PR TITLE
m4: add libiconv as requirement

### DIFF
--- a/recipes/m4/all/conanfile.py
+++ b/recipes/m4/all/conanfile.py
@@ -31,6 +31,9 @@ class M4Conan(ConanFile):
     def package_id(self):
         del self.info.settings.compiler
 
+    def requirements(self):
+        self.requires("libiconv/1.18")
+
     def build_requirements(self):
         if self.settings_build.os == "Windows":
             self.win_bash = True
@@ -45,6 +48,7 @@ class M4Conan(ConanFile):
         env.generate()
 
         tc = AutotoolsToolchain(self)
+        tc.configure_args.append(f"--with-libiconv-prefix={self.dependencies['libiconv'].package_folder}")
         if is_msvc(self):
             tc.extra_cflags.append("-FS")
             # Avoid a `Assertion Failed Dialog Box` during configure with build_type=Debug


### PR DESCRIPTION
### Summary
Changes to recipe:  **m4/***

#### Motivation
same as https://github.com/conan-io/conan-center-index/issues/29187 and https://github.com/conan-io/conan-center-index/pull/29190

#### Details
see https://github.com/ericLemanissier/cocorepo/actions/runs/22184115304/job/64153046897#step:8:3283
```
dyld[32892]: Symbol not found: _iconv
  Referenced from: <1EB6B4D8-1ED5-36EA-9652-2D5B5BF8A57F> /Users/runner/.conan2/p/b/m400a41e34e2467/p/bin/m4
  Expected in:     <53202BA6-58C4-3A8E-8E41-E96CF926FCBC> /Users/runner/.conan2/p/libic02cc726b6b192/p/lib/libiconv.2.dylib
```

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
