### PR TITLE
libxml2/*: Update to libiconv/1.18 to allow building on GCC 15

### DIFF
--- a/recipes/libxml2/all/conanfile.py
+++ b/recipes/libxml2/all/conanfile.py
@@ -101,7 +101,7 @@ class Libxml2Conan(ConanFile):
         if self.options.lzma:
             self.requires("xz_utils/5.4.5")
         if self.options.iconv:
-            self.requires("libiconv/1.17", transitive_headers=True, transitive_libs=True)
+            self.requires("libiconv/1.18", transitive_headers=True, transitive_libs=True)
         if self.options.icu:
             self.requires("icu/73.2")
 

--- a/recipes/libxml2/cmake/conanfile.py
+++ b/recipes/libxml2/cmake/conanfile.py
@@ -52,7 +52,7 @@ class Libxml2Conan(ConanFile):
 
     def requirements(self):
         if self.options.iconv:
-            self.requires("libiconv/1.17")
+            self.requires("libiconv/1.18")
         if self.options.get_safe("lzma"):
             self.requires("xz_utils/[>=5.4.5 <6]")
         if self.options.icu:


### PR DESCRIPTION
### Summary
Changes to recipe:  **libxml2/***

#### Motivation
Currently, libxml2 depends on libiconv/1.17, which [doesn't build on GCC15](https://github.com/conan-io/conan-center-index/issues/27265).

#### Details
Tested configurations:
```
conan create recipes/libxml2/all/conanfile.py --version 2.13.8 -b missing
```
```
conan create recipes/libxml2/cmake/conanfile.py --version 2.15.1 -b missing
```
```
juliangro@x299-workstation ~/g/conan-center-index (libxml2_gcc15)> conan profile show
Host profile:
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=gnu20
compiler.libcxx=libstdc++11
compiler.version=15
os=Linux
[tool_requires]
!cmake/*: cmake/[>=3 <4]
[conf]


Build profile:
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=gnu20
compiler.libcxx=libstdc++11
compiler.version=15
os=Linux
[tool_requires]
!cmake/*: cmake/[>=3 <4]
[conf]


juliangro@x299-workstation ~/g/conan-center-index (libxml2_gcc15)> 
```


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
