### PR TITLE
redis-plus-plus: use version range for hiredis dependency

### DIFF
--- a/recipes/redis-plus-plus/all/conanfile.py
+++ b/recipes/redis-plus-plus/all/conanfile.py
@@ -39,7 +39,7 @@ class RedisPlusPlusConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("hiredis/1.2.0", transitive_headers=True, transitive_libs=True)
+        self.requires("hiredis/[>=1.2.0 <2]", transitive_headers=True, transitive_libs=True)
         if self.options.build_async:
             self.requires("libuv/[>=1 <2]")
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **redis-plus-plus/1.3.15**

#### Motivation
I would like to kindly suggest to use version range `hiredis/[>=1.2.0 <2]` for hiredis dependency.
Currently in my project I need to set an override like this:
```
    def requirements(self):
        self.requires('hiredis/1.3.0', override=True)
```
While this works it should not be necessary.

#### Details
Cite from redis-plus-plus Readme.md:

> The minimum version requirement for hiredis is v0.12.1. However, [the latest stable release](https://github.com/redis/hiredis/releases) of hiredis is always recommended.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
