### PR TITLE
implot: Remove unusual source copying

### DIFF
--- a/recipes/implot/all/conanfile.py
+++ b/recipes/implot/all/conanfile.py
@@ -60,7 +60,6 @@ class ImplotConan(ConanFile):
 
     def package(self):
         copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
-        copy(self, pattern="implot*.cpp", dst=os.path.join(self.package_folder, "res", "src"), src=self.source_folder)
         cmake = CMake(self)
         cmake.install()
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **implot/0.17**

#### Motivation
As I wondered about this copying of the anyway compiled source files, I wanted to discuss here and suggest simplification of the recipe. See #29609

#### Details
I don't see the use of this additional copy. Either one uses the libraries or its source. Also I don't really understand the reason in #20681 as I don't see a use case? @technoyes are you around? It is compared there with #19877 but there it is about optional helper library functions, not about the actual code that is anyway build.

---
- [x Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
