### PR TITLE
Fix gcc recipe to include lib64 runtime library path for non-x86_64 arch

### DIFF
--- a/recipes/gcc/all/conanfile.py
+++ b/recipes/gcc/all/conanfile.py
@@ -182,6 +182,16 @@ class GccConan(ConanFile):
         self.output.info("Creating RANLIB env var with: " + ranlib)
         self.buildenv_info.define("RANLIB", ranlib)
 
+        # Add GCC runtime library paths (libstdc++, libgcc_s) to run and build environments.
+        # On non-x86_64 platforms (e.g. aarch64) GCC installs shared runtime libs into lib64/
+        # rather than the lib/ that Conan auto-detects, so we must register it explicitly.
+        for libdir_name in ("lib64", "lib"):
+            libdir = os.path.join(self.package_folder, libdir_name)
+            if os.path.exists(os.path.join(libdir, "libstdc++.so")):
+                self.runenv_info.prepend_path("LD_LIBRARY_PATH", libdir)
+                self.buildenv_info.prepend_path("LD_LIBRARY_PATH", libdir)
+                break
+
         # TODO: Remove after conan 2.0 is released
         self.env_info.CC = cc
         self.env_info.CXX = cxx


### PR DESCRIPTION
Add GCC runtime library paths to environment variables for non-x86_64 platforms.


### Summary
Changes to recipe:  **lib/[version]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
