### PR TITLE
keystone: Set CMake properties for keystone package

### DIFF
--- a/recipes/keystone/all/conanfile.py
+++ b/recipes/keystone/all/conanfile.py
@@ -93,6 +93,8 @@ class KeystoneConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "keystone")
+        self.cpp_info.set_property("cmake_target_name", "keystone::keystone")
         self.cpp_info.libs = ["keystone"]
         if is_msvc(self) and self.options.shared:
             self.cpp_info.bindirs = ["lib"]


### PR DESCRIPTION
### Summary
Changes to recipe:  **keystone/[0.9.2]**

#### Motivation
https://github.com/conan-io/conan-center-index/pull/28547#issuecomment-3933092414 Generate keystone artifacts for https://github.com/conan-io/conan-center-index/pull/28547

#### Details
Should finish dependency chain gathering for libmem PR. Alright it just skips gcc13 build and builds only for Win MSVC... so it would not help I guess.


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
