### PR TITLE
jsrl: add recipe for version 1.0.1

### DIFF
--- a/recipes/jsrl/all/conandata.yml
+++ b/recipes/jsrl/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.0.2":
+    url: "https://github.com/adobe/jsrl/archive/refs/tags/1.0.2.tar.gz"
+    sha256: "478d28df3322acad7389410b953077e69e1179efcd388294729d338213a2f1d4"

--- a/recipes/jsrl/all/conandata.yml
+++ b/recipes/jsrl/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "1.0.2":
-    url: "https://github.com/adobe/jsrl/archive/refs/tags/1.0.2.tar.gz"
-    sha256: "478d28df3322acad7389410b953077e69e1179efcd388294729d338213a2f1d4"
+  "1.0.3":
+    url: "https://github.com/adobe/jsrl/archive/refs/tags/1.0.3.tar.gz"
+    sha256: "b0a2a799b208d3c46c15a026afc24ec6c116365ed379ac0434a7789469439cd6"

--- a/recipes/jsrl/all/conandata.yml
+++ b/recipes/jsrl/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "1.0.3":
-    url: "https://github.com/adobe/jsrl/archive/refs/tags/1.0.3.tar.gz"
-    sha256: "b0a2a799b208d3c46c15a026afc24ec6c116365ed379ac0434a7789469439cd6"
+  "1.0.4":
+    url: "https://github.com/adobe/jsrl/archive/refs/tags/1.0.4.tar.gz"
+    sha256: "6d530713ba00f8c762f55393c96c14a0d6eb9b6f8744aa87125e63af88ff1885"

--- a/recipes/jsrl/all/conanfile.py
+++ b/recipes/jsrl/all/conanfile.py
@@ -1,0 +1,62 @@
+from conan import ConanFile
+from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout
+from conan.tools.files import copy, get, rmdir
+from conan.tools.build import check_min_cppstd
+import os
+
+required_conan_version = ">=2.0.9"
+
+
+class JsrlConan(ConanFile):
+    name = "jsrl"
+    description = "Json Serialization and Reading Library - A modern C++ JSON library with UTF-8 correctness, immutability, and high-fidelity numbers"
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/adobe/jsrl"
+    topics = ("json", "parser")
+
+    package_type = "library"
+    settings = "os", "compiler", "build_type", "arch"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+    implements = ["auto_shared_fpic"]
+    languages = "C++"
+
+    def validate(self):
+        check_min_cppstd(self, 17)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.cache_variables["JSRL_BUILD_TESTS"] = False
+        tc.cache_variables["JSRL_INSTALL"] = True
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["jsrl"]
+        self.cpp_info.set_property("cmake_file_name", "jsrl")
+        self.cpp_info.set_property("cmake_target_name", "jsrl::jsrl")
+        self.cpp_info.set_property("pkg_config_name", "jsrl")

--- a/recipes/jsrl/all/conanfile.py
+++ b/recipes/jsrl/all/conanfile.py
@@ -57,6 +57,8 @@ class JsrlConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["jsrl"]
+        if not self.options.shared:
+            self.cpp_info.defines = ["JSRL_STATIC_DEFINE"]
         self.cpp_info.set_property("cmake_file_name", "jsrl")
         self.cpp_info.set_property("cmake_target_name", "jsrl::jsrl")
         self.cpp_info.set_property("pkg_config_name", "jsrl")

--- a/recipes/jsrl/all/test_package/conanfile.py
+++ b/recipes/jsrl/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+import os
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import can_run
+
+
+class JsrlTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def test(self):
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindirs[0], "test_jsrl")
+            self.run(cmd, env="conanrun")

--- a/recipes/jsrl/all/test_package/src/CMakeLists.txt
+++ b/recipes/jsrl/all/test_package/src/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.15)
+project(JsrlTest CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(jsrl REQUIRED CONFIG)
+
+add_executable(test_jsrl test_package.cpp)
+target_link_libraries(test_jsrl PRIVATE jsrl::jsrl)

--- a/recipes/jsrl/all/test_package/src/CMakeLists.txt
+++ b/recipes/jsrl/all/test_package/src/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 project(JsrlTest CXX)
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(jsrl REQUIRED CONFIG)
 

--- a/recipes/jsrl/all/test_package/src/test_package.cpp
+++ b/recipes/jsrl/all/test_package/src/test_package.cpp
@@ -1,0 +1,52 @@
+#include <jsrl/jsrl.hpp>
+#include <iostream>
+#include <sstream>
+
+// Basic test that verifies the jsrl library can be linked
+// and headers are accessible. Tests basic parse and access operations.
+
+int main() {
+    try {
+        // Test 1: Parse a simple JSON object
+        std::cout << "Test 1: Parsing simple JSON..." << std::endl;
+        std::istringstream iss(R"({"name": "test", "value": 42, "active": true})");
+        jsrl::Json json;
+        iss >> json;
+
+        // Test 2: Verify we can access the parsed data
+        std::cout << "Test 2: Accessing parsed data..." << std::endl;
+        if (!json.is_object()) {
+            std::cerr << "ERROR: Expected object type" << std::endl;
+            return 1;
+        }
+
+        std::string name = json["name"].as_string();
+        if (name != "test") {
+            std::cerr << "ERROR: Expected name='test', got '" << name << "'" << std::endl;
+            return 1;
+        }
+
+        long long value = json["value"].as_number_sint();
+        if (value != 42) {
+            std::cerr << "ERROR: Expected value=42, got " << value << std::endl;
+            return 1;
+        }
+
+        bool active = json["active"].as_bool();
+        if (!active) {
+            std::cerr << "ERROR: Expected active=true" << std::endl;
+            return 1;
+        }
+
+        std::cout << "\nAll tests passed!" << std::endl;
+        std::cout << "JSRL library test successful!" << std::endl;
+        return 0;
+
+    } catch (jsrl::Json::Error const& e) {
+        std::cerr << "ERROR: JSRL exception: " << e.what() << std::endl;
+        return 1;
+    } catch (std::exception const& e) {
+        std::cerr << "ERROR: Exception: " << e.what() << std::endl;
+        return 1;
+    }
+}

--- a/recipes/jsrl/config.yml
+++ b/recipes/jsrl/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.0.2":
+    folder: all

--- a/recipes/jsrl/config.yml
+++ b/recipes/jsrl/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.0.3":
+  "1.0.4":
     folder: all

--- a/recipes/jsrl/config.yml
+++ b/recipes/jsrl/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.0.2":
+  "1.0.3":
     folder: all


### PR DESCRIPTION
### Summary
Adding a recipe for version 1.0.1 of the JSRL json library

#### Motivation
The JSRL json library has recently been open sourced and I would like to make it available as a dependency through conan

#### Details
Initial addition of version 1.0.1 of the JSRL library. 
I've worked to make this align with the provided recipe template and best practices that have been provided.
I've tested this on macos(arm), and centos arm and amd configurations using a recent version of conan.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
