### PR TITLE
paho-mqtt-c: add recipe for version 1.3.16

### DIFF
--- a/recipes/paho-mqtt-c/all/conandata.yml
+++ b/recipes/paho-mqtt-c/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.3.16":
+    url: "https://github.com/eclipse/paho.mqtt.c/archive/v1.3.16.tar.gz"
+    sha256: "8b960f51edc7e03507637d987882bc486d8f4be6e79431bf99e2763344fd14c5"
   "1.3.13":
     url: "https://github.com/eclipse/paho.mqtt.c/archive/v1.3.13.tar.gz"
     sha256: "47c77e95609812da82feee30db435c3b7c720d4fd3147d466ead126e657b6d9c"

--- a/recipes/paho-mqtt-c/all/conanfile.py
+++ b/recipes/paho-mqtt-c/all/conanfile.py
@@ -80,9 +80,14 @@ class PahoMqttcConan(ConanFile):
 
     def _patch_source(self):
         apply_conandata_patches(self)
-        replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
-                        "SET(CMAKE_MODULE_PATH \"${CMAKE_SOURCE_DIR}/cmake/modules\")",
-                        "LIST(APPEND CMAKE_MODULE_PATH \"${CMAKE_SOURCE_DIR}/cmake/modules\")")
+        if Version(self.version) < "1.3.14": # pylint: disable=conan-condition-evals-to-constant
+            replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
+                            "SET(CMAKE_MODULE_PATH \"${CMAKE_SOURCE_DIR}/cmake/modules\")",
+                            "LIST(APPEND CMAKE_MODULE_PATH \"${CMAKE_SOURCE_DIR}/cmake/modules\")")
+        elif Version(self.version) < "1.3.17": # pylint: disable=conan-condition-evals-to-constant
+            replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
+                            "set(CMAKE_MODULE_PATH \"${PROJECT_SOURCE_DIR}/cmake/modules\")",
+                            "list(APPEND CMAKE_MODULE_PATH \"${PROJECT_SOURCE_DIR}/cmake/modules\")")
         if not self.options.get_safe("fPIC", True):
             replace_in_file(self, os.path.join(self.source_folder, "src", "CMakeLists.txt"), "POSITION_INDEPENDENT_CODE ON", "")
 

--- a/recipes/paho-mqtt-c/config.yml
+++ b/recipes/paho-mqtt-c/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.3.16":
+    folder: "all"
   "1.3.13":
     folder: "all"
   "1.3.12":


### PR DESCRIPTION
### Summary
Changes to recipe:  **paho-mqtt-c/1.3.16**

#### Motivation
To add newer versions of this library.

#### Details
Adds a new versions of paho.mqtt.c library which supports the latest gcc.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
