### PR TITLE
onnxruntime: fix the windows compiler.cppstd=20 and cuda builds

### DIFF
--- a/recipes/onnxruntime/all/cmake/onnxruntime_external_deps.cmake
+++ b/recipes/onnxruntime/all/cmake/onnxruntime_external_deps.cmake
@@ -88,6 +88,21 @@ if (onnxruntime_USE_XNNPACK)
   endif()
 endif()
 
+
+if (onnxruntime_USE_CUDA)
+  find_package(CUDAToolkit REQUIRED)
+
+  # cuDNN is not needed for minimal CUDA builds (e.g., TensorRT-only builds)
+  if(NOT onnxruntime_CUDA_MINIMAL)
+    if(onnxruntime_CUDNN_HOME)
+      file(TO_CMAKE_PATH ${onnxruntime_CUDNN_HOME} onnxruntime_CUDNN_HOME)
+      set(CUDNN_PATH ${onnxruntime_CUDNN_HOME})
+    endif()
+
+    include(cuDNN)
+  endif()
+endif()
+
 if (onnxruntime_USE_MIMALLOC)
   find_package(mimalloc REQUIRED CONFIG)
   add_definitions(-DUSE_MIMALLOC)

--- a/recipes/onnxruntime/all/conandata.yml
+++ b/recipes/onnxruntime/all/conandata.yml
@@ -5,3 +5,4 @@ sources:
 patches:
   "1.24.4":
     - patch_file: "patches/fix-cutlass-cuda-provider.patch"
+    - patch_file: "patches/fix-cuda-architectures.patch"

--- a/recipes/onnxruntime/all/conandata.yml
+++ b/recipes/onnxruntime/all/conandata.yml
@@ -6,3 +6,4 @@ patches:
   "1.24.4":
     - patch_file: "patches/fix-cutlass-cuda-provider.patch"
     - patch_file: "patches/fix-cuda-architectures.patch"
+    - patch_file: "patches/fix-logging-ortchar.patch"

--- a/recipes/onnxruntime/all/conanfile.py
+++ b/recipes/onnxruntime/all/conanfile.py
@@ -104,7 +104,9 @@ class OnnxRuntimeConan(ConanFile):
         tc.variables["onnxruntime_USE_FULL_PROTOBUF"] = not self.dependencies["protobuf"].options.lite
         tc.variables["onnxruntime_USE_XNNPACK"] = self.options.with_xnnpack
 
+        # use onnxruntime_CUDA_MINIMAL, as cudnn requires unpackaged https://github.com/NVIDIA/cudnn-frontend
         tc.variables["onnxruntime_USE_CUDA"] = self.options.with_cuda
+        tc.variables["onnxruntime_CUDA_MINIMAL"] = True
         tc.variables["onnxruntime_BUILD_UNIT_TESTS"] = False
         tc.variables["onnxruntime_DISABLE_CONTRIB_OPS"] = False
         tc.variables["onnxruntime_USE_FLASH_ATTENTION"] = False

--- a/recipes/onnxruntime/all/patches/fix-cuda-architectures.patch
+++ b/recipes/onnxruntime/all/patches/fix-cuda-architectures.patch
@@ -1,0 +1,23 @@
+diff --git a/cmake/external/cuda_configuration.cmake b/cmake/external/cuda_configuration.cmake
+index 00f7d81eda..5d3b129ced 100644
+--- a/cmake/external/cuda_configuration.cmake
++++ b/cmake/external/cuda_configuration.cmake
+@@ -126,13 +126,13 @@ macro(setup_cuda_architectures)
+       # Support for Jetson/Tegra ARM devices
+       set(CMAKE_CUDA_ARCHITECTURES "53;62;72;87") # TX1/Nano, TX2, Xavier, Orin
+     else()
+-      if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 12)
+-        # 37, 50 still work in CUDA 11 but are marked deprecated and will be removed in future CUDA version.
+-        set(CMAKE_CUDA_ARCHITECTURES "37;50;52;60;70;75;80;86;89")
+-      elseif(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 12.8)
++      if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 12.8)
+         set(CMAKE_CUDA_ARCHITECTURES "52;60;70;75;80;86;89;90")
+-      else()
++      elseif(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 13.0)
+         set(CMAKE_CUDA_ARCHITECTURES "60;70;75;80;86;89;90;100;120")
++      else()
++        # 13.x drops support for 60 and 70
++        set(CMAKE_CUDA_ARCHITECTURES "75;80;86;89;90;100;120")
+       endif()
+     endif()
+   endif()

--- a/recipes/onnxruntime/all/patches/fix-logging-ortchar.patch
+++ b/recipes/onnxruntime/all/patches/fix-logging-ortchar.patch
@@ -1,0 +1,12 @@
+diff --git a/onnxruntime/core/session/utils.cc b/onnxruntime/core/session/utils.cc
+--- a/onnxruntime/core/session/utils.cc
++++ b/onnxruntime/core/session/utils.cc
+@@ -549,7 +549,7 @@
+                                                             true,
+                                                             ProviderLibraryPathType::Absolute);
+   bool is_provider_bridge = provider_library->Load() == Status::OK();  // library has GetProvider
+-  LOGS_DEFAULT(INFO) << "Loading EP library: " << library_path
++  LOGS_DEFAULT(INFO) << "Loading EP library: " << resolved_library_path.generic_string()
+                      << (is_provider_bridge ? " as a provider bridge" : " as a plugin");
+
+   // create EpLibraryPlugin to ensure CreateEpFactories and ReleaseEpFactory are available


### PR DESCRIPTION
### Summary
Changes to recipe:  **onnxruntime/1.24.4**

#### Details

- Fixes the windows build using Visual Studio 2022 and compiler.cppstd=20
- Fix build issue with log macro and wchar_t
- Fix build issues with cuda > 13


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
