### PR TITLE
tinyfsm: add recipe for version 0.3.3

### DIFF
--- a/recipes/tinyfsm/all/conandata.yml
+++ b/recipes/tinyfsm/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.3.3":
+    url: "https://github.com/digint/tinyfsm/archive/refs/tags/v0.3.3.tar.gz"
+    sha256: "99aaad53ddb9b9b3fbb535a6983e9c86a0b8c8ef112181cddcb6f3857b440d09"

--- a/recipes/tinyfsm/all/conanfile.py
+++ b/recipes/tinyfsm/all/conanfile.py
@@ -31,9 +31,6 @@ class TinyfsmConan(ConanFile):
     def validate(self):
         check_min_cppstd(self, 11)
 
-    def build(self):
-        pass
-
     def package(self):
         copy(self, pattern="COPYING", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
         copy(

--- a/recipes/tinyfsm/all/conanfile.py
+++ b/recipes/tinyfsm/all/conanfile.py
@@ -1,0 +1,48 @@
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+import os
+
+
+required_conan_version = ">=2.4"
+
+
+class TinyfsmConan(ConanFile):
+    name = "tinyfsm"
+    description = "A simple C++ finite state machine library"
+    license = "MIT"
+    homepage = "https://github.com/digint/tinyfsm"
+    url = "https://github.com/conan-io/conan-center-index"
+    topics = ("fsm", "finite-state-machine", "state-machine", "header-only")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        check_min_cppstd(self, 11)
+
+    def build(self):
+        pass
+
+    def package(self):
+        copy(self, pattern="COPYING", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        copy(
+            self,
+            pattern="*.hpp",
+            dst=os.path.join(self.package_folder, "include"),
+            src=os.path.join(self.source_folder, "include"),
+        )
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/tinyfsm/all/test_package/CMakeLists.txt
+++ b/recipes/tinyfsm/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package CXX)
+
+find_package(tinyfsm REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE tinyfsm::tinyfsm)

--- a/recipes/tinyfsm/all/test_package/conanfile.py
+++ b/recipes/tinyfsm/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TinyfsmTestConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/tinyfsm/all/test_package/conanfile.py
+++ b/recipes/tinyfsm/all/test_package/conanfile.py
@@ -7,7 +7,6 @@ import os
 class TinyfsmTestConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeDeps", "CMakeToolchain"
-    test_type = "explicit"
 
     def requirements(self):
         self.requires(self.tested_reference_str)

--- a/recipes/tinyfsm/all/test_package/test_package.cpp
+++ b/recipes/tinyfsm/all/test_package/test_package.cpp
@@ -1,0 +1,34 @@
+#include <tinyfsm.hpp>
+#include <iostream>
+
+struct ToggleEvent : tinyfsm::Event {};
+
+class TestFsm : public tinyfsm::Fsm<TestFsm>
+{
+public:
+    void react(ToggleEvent const &) {
+        std::cout << "Event received" << std::endl;
+    }
+
+    virtual void entry() {
+        std::cout << "State entered" << std::endl;
+    }
+};
+
+// Initialize state
+using fsm_handle = TestFsm;
+FSM_INITIAL_STATE(TestFsm, TestFsm)
+
+int main()
+{
+    std::cout << "Testing tinyfsm package..." << std::endl;
+
+    // Start the state machine
+    fsm_handle::start();
+
+    // Send an event
+    fsm_handle::dispatch(ToggleEvent());
+
+    std::cout << "tinyfsm package test completed successfully!" << std::endl;
+    return 0;
+}

--- a/recipes/tinyfsm/config.yml
+++ b/recipes/tinyfsm/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.3.3":
+    folder: all


### PR DESCRIPTION
### Summary
Addinge recipe:  **tinyfsm/0.3.3**

#### Motivation
This PR adds the recipe for the sockpp library version 1.0.0, which was not previously available in Conan Center Index.
Related issue: https://github.com/conan-io/conan-center-index/issues/29627

#### Details
Details
- Added recipes/tinyfsm/all/conanfile.py with Conan 2.x compliance.
- Added recipes/tinyfsm/all/conandata.yml for source retrieval.
- Added recipes/tinyfsm/all/test_package to verify the package.
- Tested locally with Conan 2.x and GCC 11 on Linux.


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
