### PR TITLE
glog: use version range for libunwind dependency

### DIFF
--- a/recipes/folly/all/conanfile.py
+++ b/recipes/folly/all/conanfile.py
@@ -83,7 +83,7 @@ class FollyConan(ConanFile):
         self.requires("xz_utils/[>=5.4.5 <6]")
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.requires("libiberty/9.1.0")
-            self.requires("libunwind/1.8.0")
+            self.requires("libunwind/[>=1.8.0 <2]")
         if self.settings.os == "Linux":
             self.requires("liburing/2.6")
         # INFO: Folly does not support fmt 11 on MSVC: https://github.com/facebook/folly/issues/2250

--- a/recipes/folly/all/conanfile.py
+++ b/recipes/folly/all/conanfile.py
@@ -69,7 +69,7 @@ class FollyConan(ConanFile):
         self.requires("boost/1.85.0", transitive_headers=True, transitive_libs=True)
         self.requires("bzip2/1.0.8")
         self.requires("double-conversion/3.3.0", transitive_headers=True, transitive_libs=True)
-        self.requires("gflags/2.2.2")
+        self.requires("gflags/[>=2.2.2 <3]")
         self.requires("glog/0.7.1", transitive_headers=True, transitive_libs=True)
         self.requires("libevent/2.1.12", transitive_headers=True, transitive_libs=True)
         self.requires("openssl/[>=1.1 <4]")

--- a/recipes/glog/all/conanfile.py
+++ b/recipes/glog/all/conanfile.py
@@ -54,7 +54,7 @@ class GlogConan(ConanFile):
             self.requires("gflags/[>=2.2.2 <3]", transitive_headers=True, transitive_libs=True)
         # 0.4.0 requires libunwind unconditionally
         if self.options.get_safe("with_unwind"):
-            self.requires("libunwind/1.8.0", transitive_headers=True, transitive_libs=True)
+            self.requires("libunwind/[>=1.8.0 <2]", transitive_headers=True, transitive_libs=True)
 
     def validate(self):
         if Version(self.version) < "0.7.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **glog/all**

#### Motivation
I suggest to use version range for libunwind dependency so that consumer can update libunwind to latest version in their end-user recipe.
Similar change was already merged for gperftools here: https://github.com/conan-io/conan-center-index/pull/28467

#### Details
Currently we have the following additional recipes also depending on libunwind. How do you want to proceed with them? Do you want me to include them to this PR as well?
```
backward-cpp/all/conanfile.py:                self.requires("libunwind/1.7.2", transitive_headers=True)
cpptrace/all/conanfile.py:            self.requires("libunwind/1.8.0", transitive_libs=True)
folly/all/conanfile.py:            self.requires("libunwind/1.8.0")
libmysqlclient/all/conanfile.py:            self.requires("libunwind/1.7.2")
pdal/all/conanfile.py:            self.requires("libunwind/1.6.2")
sdl/all/conanfile.py:                self.requires("libunwind/1.8.0")
tracy/all/conanfile.py:            self.requires("libunwind/1.8.1", transitive_headers=True, transitive_libs=True)
wt/all/conanfile.py:            self.requires("libunwind/1.7.2")
```


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
