### PR TITLE
[gnu-config] Fix error in `git fetch` at `conan source`

### DIFF
--- a/recipes/gnu-config/all/conanfile.py
+++ b/recipes/gnu-config/all/conanfile.py
@@ -28,7 +28,8 @@ class GnuConfigConan(ConanFile):
 
     def source(self):
         git = Git(self)
-        git.fetch_commit(**self.conan_data["sources"][self.version])
+        git.clone(url=self.conan_data["sources"][self.version]["url"], target=".")
+        git.checkout(commit=self.conan_data["sources"][self.version]["commit"])
         apply_conandata_patches(self)
 
     def build(self):


### PR DESCRIPTION
Not able to fetch the specified commit due to 'error: Server does not allow request for unadvertised object 191bcb948f7191c36eefe634336f5fc5c0c4c2be'. Fix the issue by first cloning the repository and then check-out the commit.