### PR TITLE
meson: add version 1.10.1

### DIFF
--- a/recipes/meson/all/conandata.yml
+++ b/recipes/meson/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "1.10.0":
-    url: "https://github.com/mesonbuild/meson/archive/1.10.0.tar.gz"
-    sha256: "cad50c9484cbc3d4e5a45b1c2662d079be9a848aaa4cef02de7dbec412b0eede"
+  "1.10.1":
+    url: "https://github.com/mesonbuild/meson/archive/1.10.1.tar.gz"
+    sha256: "3d4768a76fc63dc4c562edc7892de17b54dfaa7309d148e805b0d763bc085e00"
   "1.9.1":
     url: "https://github.com/mesonbuild/meson/archive/1.9.1.tar.gz"
     sha256: "febaa8f7c1916521c53eb5fd11c0641b5eb4741c2c6e9b42c288ed62d9e4fd2c"

--- a/recipes/meson/config.yml
+++ b/recipes/meson/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "1.10.0":
+  "1.10.1":
     folder: all
   "1.9.1":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **meson/[1.10.1]**

#### Motivation
1.10.1 has some bug fixes especially with the new `build_subdir` argument.
https://github.com/mesonbuild/meson/compare/1.10.0...1.10.1

#### Details
Just a version bump

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
