### PR TITLE
[qt] set lib property for plugins

### DIFF
--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -1075,7 +1075,12 @@ Prefix = ..""")
             assert componentname not in self.cpp_info.components, f"Plugin {pluginname} already present in self.cpp_info.components"
             self.cpp_info.components[componentname].set_property("cmake_target_name", f"Qt5::{pluginname}")
             self.cpp_info.components[componentname].set_property("cmake_target_aliases", [f"Qt::{pluginname}"])
-            if not self.options.shared:
+            if not (self.settings.os == "Windows" and bool(self.options.shared)):
+                # Can't populate this property for Shared builds on Windows as
+                # CMake `find_library` expects to find an import lib which doesn't exist for plugins.
+                # See eg:
+                # * https://discourse.cmake.org/t/find-library-wont-find-dlls/4050/4
+                # * https://github.com/conan-io/conan/issues/12654
                 self.cpp_info.components[componentname].libs = [libname + libsuffix]
             self.cpp_info.components[componentname].libdirs = [os.path.join("plugins", plugintype)]
             self.cpp_info.components[componentname].includedirs = []


### PR DESCRIPTION
### Summary
Changes to recipe:  **qt/5.x**

#### Motivation
When using the new [CMakeConfigDeps](https://docs.conan.io/2/reference/tools/cmake/cmakeconfigdeps.html#conan-tools-cmakeconfigdeps) generator, Qt plugins cannot be found by querying, for example,
 ```cmake
get_property(plugin_libs TARGET QXcbIntegrationPlugin PROPERTY IMPORTED_LOCATION)
```
as they do not have the `lib` property defined  when `shared=True` (which is typical for Qt), and they end up being
defined in the generated config files as `INTERFACE` libraries.

#### Details

the `lib` property for Qt plugins was only defined for `shared=False`. This PR defines it unconditionally.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
