### PR TITLE
pffft: add versions 1.0.0 and 1.1.0

### DIFF
--- a/recipes/pffft/all/conandata.yml
+++ b/recipes/pffft/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.1.0":
+    url: "https://github.com/marton78/pffft/archive/refs/tags/v1.1.0.tar.gz"
+    sha256: "ea0701a6bc256405b03975908a6a92d0ffecdd18579e8484b8d789c8bd561787"
   "1.0.0":
     url: "https://github.com/marton78/pffft/archive/refs/tags/v1.0.0.tar.gz"
     sha256: "6ea0465d215044d3b7c44a374f48f70c88965e75e97c0826157ac57e3cdc24ba"

--- a/recipes/pffft/all/conandata.yml
+++ b/recipes/pffft/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.0":
+    url: "https://github.com/marton78/pffft/archive/refs/tags/v1.0.0.tar.gz"
+    sha256: "6ea0465d215044d3b7c44a374f48f70c88965e75e97c0826157ac57e3cdc24ba"
   "cci.20210511":
     url: "https://bitbucket.org/jpommier/pffft/get/ed78751d751e.zip"
     sha256: "af4ac1f9e148348b492686491f2235b5b4dd210148fac29ceca6fb629e563b53"

--- a/recipes/pffft/all/conanfile.py
+++ b/recipes/pffft/all/conanfile.py
@@ -27,7 +27,6 @@ class PffftConan(ConanFile):
         "with_double": [True, False],
         "with_pffastconv": [True, False],
         "with_pfdsp": [True, False],
-        "with_simd": [True, False],
     }
     default_options = {
         "shared": False,
@@ -38,7 +37,6 @@ class PffftConan(ConanFile):
         "with_double": True,
         "with_pffastconv": False,
         "with_pfdsp": False,
-        "with_simd": True,
     }
 
     exports_sources = "CMakeLists.txt"
@@ -55,9 +53,6 @@ class PffftConan(ConanFile):
             del self.options.with_double
             del self.options.with_pffastconv
             del self.options.with_pfdsp
-            del self.options.with_simd
-        else:
-            del self.options.disable_simd
 
     def configure(self):
         if self.options.shared:
@@ -99,7 +94,7 @@ class PffftConan(ConanFile):
         else:
             tc.variables["PFFFT_USE_TYPE_FLOAT"] = self.options.with_float
             tc.variables["PFFFT_USE_TYPE_DOUBLE"] = self.options.with_double
-            tc.variables["PFFFT_USE_SIMD"] = self.options.with_simd
+            tc.variables["PFFFT_USE_SIMD"] = not self.options.disable_simd
             tc.variables["INSTALL_PFFFT"] = True
             tc.variables["INSTALL_PFFASTCONV"] = self.options.with_pffastconv
             tc.variables["INSTALL_PFDSP"] = self.options.with_pfdsp

--- a/recipes/pffft/all/conanfile.py
+++ b/recipes/pffft/all/conanfile.py
@@ -1,6 +1,8 @@
 from conan import ConanFile
-from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import get, load, save
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, load, save, rmdir
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.53.0"
@@ -10,7 +12,7 @@ class PffftConan(ConanFile):
     name = "pffft"
     description = "PFFFT, a pretty fast Fourier Transform."
     url = "https://github.com/conan-io/conan-center-index"
-    homepage = "https://bitbucket.org/jpommier/pffft/src/master/"
+    homepage = "https://github.com/marton78/pffft"
     topics = ("fft", "pffft")
     license = "BSD-like (FFTPACK license)"
 
@@ -20,24 +22,68 @@ class PffftConan(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "disable_simd": [True, False],
+        # v1.0+ options
+        "with_float": [True, False],
+        "with_double": [True, False],
+        "with_pffastconv": [True, False],
+        "with_pfdsp": [True, False],
+        "with_simd": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "disable_simd": False,
+        # v1.0+ defaults
+        "with_float": True,
+        "with_double": True,
+        "with_pffastconv": False,
+        "with_pfdsp": False,
+        "with_simd": True,
     }
 
     exports_sources = "CMakeLists.txt"
 
+    @property
+    def _is_legacy(self):
+        return Version(self.version) < "1.0"
+
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+        if self._is_legacy:
+            del self.options.with_float
+            del self.options.with_double
+            del self.options.with_pffastconv
+            del self.options.with_pfdsp
+            del self.options.with_simd
+        else:
+            del self.options.disable_simd
 
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
-        self.settings.rm_safe("compiler.cppstd")
-        self.settings.rm_safe("compiler.libcxx")
+        if self._is_legacy:
+            self.settings.rm_safe("compiler.cppstd")
+            self.settings.rm_safe("compiler.libcxx")
+        elif not self.options.get_safe("with_pfdsp"):
+            # Pure C library when pfdsp is not built
+            self.settings.rm_safe("compiler.cppstd")
+            self.settings.rm_safe("compiler.libcxx")
+
+    def validate(self):
+        if not self._is_legacy:
+            if not self.options.with_float and not self.options.with_double:
+                raise ConanInvalidConfiguration(
+                    f"{self.ref}: at least one of 'with_float' or 'with_double' must be enabled"
+                )
+            if self.options.with_pffastconv and not self.options.with_float:
+                raise ConanInvalidConfiguration(
+                    f"{self.ref}: 'with_pffastconv' requires 'with_float' to be enabled"
+                )
+            if self.options.with_pfdsp and not self.options.with_float:
+                raise ConanInvalidConfiguration(
+                    f"{self.ref}: 'with_pfdsp' requires 'with_float' to be enabled"
+                )
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -47,23 +93,77 @@ class PffftConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["PFFFT_SRC_DIR"] = self.source_folder.replace("\\", "/")
-        tc.variables["DISABLE_SIMD"] = self.options.disable_simd
+        if self._is_legacy:
+            tc.variables["PFFFT_SRC_DIR"] = self.source_folder.replace("\\", "/")
+            tc.variables["DISABLE_SIMD"] = self.options.disable_simd
+        else:
+            tc.variables["PFFFT_USE_TYPE_FLOAT"] = self.options.with_float
+            tc.variables["PFFFT_USE_TYPE_DOUBLE"] = self.options.with_double
+            tc.variables["PFFFT_USE_SIMD"] = self.options.with_simd
+            tc.variables["INSTALL_PFFFT"] = True
+            tc.variables["INSTALL_PFFASTCONV"] = self.options.with_pffastconv
+            tc.variables["INSTALL_PFDSP"] = self.options.with_pfdsp
+            tc.variables["PFFFT_BUILD_TESTS"] = False
+            tc.variables["PFFFT_BUILD_BENCHMARKS"] = False
+            tc.variables["PFFFT_BUILD_EXAMPLES"] = False
         tc.generate()
+        if not self._is_legacy:
+            deps = CMakeDeps(self)
+            deps.generate()
 
     def build(self):
         cmake = CMake(self)
-        cmake.configure(build_script_folder=os.path.join(self.source_folder, os.pardir))
+        if self._is_legacy:
+            cmake.configure(build_script_folder=os.path.join(self.source_folder, os.pardir))
+        else:
+            cmake.configure()
         cmake.build()
 
     def package(self):
-        header = load(self, os.path.join(self.source_folder, "pffft.h"))
-        license_content = header[: header.find("*/", 1)]
-        save(self, os.path.join(self.package_folder, "licenses", "LICENSE"), license_content)
+        if self._is_legacy:
+            header = load(self, os.path.join(self.source_folder, "pffft.h"))
+            license_content = header[: header.find("*/", 1)]
+            save(self, os.path.join(self.package_folder, "licenses", "LICENSE"), license_content)
+        else:
+            copy(self, "LICENSE.txt", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
         cmake = CMake(self)
         cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
-        self.cpp_info.libs = ["pffft"]
-        if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.system_libs.append("m")
+        if self._is_legacy:
+            self.cpp_info.libs = ["pffft"]
+            if self.settings.os in ["Linux", "FreeBSD"]:
+                self.cpp_info.system_libs.append("m")
+        else:
+            self.cpp_info.set_property("cmake_file_name", "pffft")
+
+            self.cpp_info.components["pffft"].set_property(
+                "cmake_target_name", "PFFFT::PFFFT"
+            )
+            self.cpp_info.components["pffft"].libs = ["pffft"]
+            # Expose both include/ (for #include <pffft/pffft.h>) and
+            # include/pffft/ (for #include <pffft.h> legacy compat)
+            self.cpp_info.components["pffft"].includedirs = [
+                "include", os.path.join("include", "pffft")
+            ]
+            if self.settings.os != "Windows":
+                self.cpp_info.components["pffft"].system_libs.append("m")
+
+            if self.options.with_pffastconv:
+                self.cpp_info.components["pffastconv"].set_property(
+                    "cmake_target_name", "PFFFT::PFFASTCONV"
+                )
+                self.cpp_info.components["pffastconv"].libs = ["pffastconv"]
+                self.cpp_info.components["pffastconv"].requires = ["pffft"]
+                if self.settings.os != "Windows":
+                    self.cpp_info.components["pffastconv"].system_libs.append("m")
+
+            if self.options.with_pfdsp:
+                self.cpp_info.components["pfdsp"].set_property(
+                    "cmake_target_name", "PFFFT::PFDSP"
+                )
+                self.cpp_info.components["pfdsp"].libs = ["pfdsp"]
+                if self.settings.os != "Windows":
+                    self.cpp_info.components["pfdsp"].system_libs.append("m")

--- a/recipes/pffft/all/test_package/CMakeLists.txt
+++ b/recipes/pffft/all/test_package/CMakeLists.txt
@@ -4,4 +4,4 @@ project(test_package LANGUAGES C)
 find_package(pffft REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_link_libraries(${PROJECT_NAME} PRIVATE pffft::pffft)
+target_link_libraries(${PROJECT_NAME} PRIVATE PFFFT::PFFFT)

--- a/recipes/pffft/config.yml
+++ b/recipes/pffft/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.0.0":
+    folder: all
   "cci.20210511":
     folder: all
   "cci.20201015":

--- a/recipes/pffft/config.yml
+++ b/recipes/pffft/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.1.0":
+    folder: all
   "1.0.0":
     folder: all
   "cci.20210511":


### PR DESCRIPTION
## Summary
- Add pffft 1.0.0 and 1.1.0 from the [marton78/pffft](https://github.com/marton78/pffft) fork
- New version features reorganized project layout, proper CMake install with export targets, float/double precision toggle, additional libraries (pffastconv, pfdsp), and shared library support
- New Conan options for v1.0+: `with_float`, `with_double`, `with_pffastconv`, `with_pfdsp`
- Legacy `cci.*` versions are unchanged

## Changes
- `config.yml`: added versions `1.0.0` and `1.1.0`
- `conandata.yml`: added source URL and sha256 for `1.0.0` and `1.1.0`
- `conanfile.py`: version-branched recipe (`_is_legacy` property) — v1.0+ uses the project's native CMake directly (no wrapper needed), defines components for pffft/pffastconv/pfdsp with correct target names and system_libs
- `test_package/CMakeLists.txt`: use `PFFFT::PFFFT` target name (matches upstream CMake exports)

## Test plan
- [ ] CI builds pass across all configurations
- [ ] Legacy `cci.*` versions still build correctly
- [ ] v1.0.0 builds with default options
- [ ] v1.0.0 builds with `with_pffastconv=True`, `with_pfdsp=True`
- [ ] v1.0.0 builds with `with_float=False` (double-only)
- [ ] v1.1.0 builds with default options
- [ ] v1.1.0 builds with `with_pffastconv=True`, `with_pfdsp=True`
- [ ] v1.1.0 builds with `with_float=False` (double-only)
