### PR TITLE
[stb] Add option for precompiled image

### DIFF
--- a/recipes/stb/all/CMakeLists.txt
+++ b/recipes/stb/all/CMakeLists.txt
@@ -1,9 +1,13 @@
 cmake_minimum_required(VERSION 3.18)
 project(stb LANGUAGES CXX)
 
-add_library(${PROJECT_NAME})
-target_include_directories(${PROJECT_NAME} PRIVATE "${CMAKE_SOURCE_DIR}")
-
+set(STB_SOURCES "")
 if(STB_IMAGE)
-    target_sources(${PROJECT_NAME} PRIVATE "stb_image.cpp")
+    list(APPEND STB_SOURCES "stb_image.cpp")
 endif()
+
+if(STB_SOURCES)
+    add_library(${PROJECT_NAME} ${STB_SOURCES})
+    target_include_directories(${PROJECT_NAME} PRIVATE "${CMAKE_SOURCE_DIR}")
+endif()
+

--- a/recipes/stb/all/CMakeLists.txt
+++ b/recipes/stb/all/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.18)
+project(stb LANGUAGES CXX)
+
+add_library(${PROJECT_NAME})
+target_include_directories(${PROJECT_NAME} PRIVATE "${CMAKE_SOURCE_DIR}")
+
+if(STB_IMAGE)
+    target_sources(${PROJECT_NAME} PRIVATE "stb_image.cpp")
+endif()

--- a/recipes/stb/all/conanfile.py
+++ b/recipes/stb/all/conanfile.py
@@ -1,4 +1,5 @@
 from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir
 from conan.tools.layout import basic_layout
 from conan.tools.scm import Version
@@ -19,10 +20,12 @@ class StbConan(ConanFile):
     no_copy_source = True
     options = {
         "with_deprecated": [True, False],
+        "image": [True, False],
     }
 
     default_options = {
         "with_deprecated": True,
+        "image": False,
     }
 
     @property
@@ -34,6 +37,10 @@ class StbConan(ConanFile):
     def config_options(self):
         if Version(self._version) < "20210713":
             del self.options.with_deprecated
+
+    def export_sources(self):
+        copy(self, pattern="CMakeLists.txt", src=self.recipe_folder, dst=os.path.join(self.export_sources_folder, "src"))
+        copy(self, pattern="stb_image.cpp", src=self.recipe_folder, dst=os.path.join(self.export_sources_folder, "src"))
 
     def layout(self):
         basic_layout(self, src_folder="src")
@@ -51,6 +58,20 @@ class StbConan(ConanFile):
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        if self.options.image:
+            tc.variables["STB_IMAGE"] = "ON"
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
     def package(self):
         copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
         copy(self, "*.h", src=self.source_folder, dst=os.path.join(self.package_folder, "include"))
@@ -61,10 +82,11 @@ class StbConan(ConanFile):
         if self.options.get_safe("with_deprecated"):
             copy(self, "*.h", src=os.path.join(self.source_folder, "deprecated"), dst=os.path.join(self.package_folder, "include"))
             copy(self, "stb_image.c", src=os.path.join(self.source_folder, "deprecated"), dst=os.path.join(self.package_folder, "include"))
+        copy(self, "libstb.a", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"))
 
     def package_info(self):
         self.cpp_info.bindirs = []
-        self.cpp_info.libdirs = []
+        self.cpp_info.libs = ["stb"]
         self.cpp_info.defines.append("STB_TEXTEDIT_KEYTYPE=unsigned")
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("m")

--- a/recipes/stb/all/conanfile.py
+++ b/recipes/stb/all/conanfile.py
@@ -49,20 +49,6 @@ class StbConan(ConanFile):
     def layout(self):
         basic_layout(self, src_folder="src")
 
-    def package_id(self):
-        # this option adds a precompiled static library
-        if self.options.image:
-            return
-
-        # Can't call self.info.clear() because options contribute to package id
-        self.info.settings.clear()
-        self.info.requires.clear()
-        try:
-            # conan v2 specific
-            self.info.conf.clear()
-        except AttributeError:
-            pass
-
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 

--- a/recipes/stb/all/conanfile.py
+++ b/recipes/stb/all/conanfile.py
@@ -15,7 +15,7 @@ class StbConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/nothings/stb"
     topics = ("stb", "single-file", "header-only")
-    package_type = "header-library"
+    package_type = "static-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
     options = {
@@ -50,6 +50,10 @@ class StbConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def package_id(self):
+        # this option adds a precompiled static library
+        if self.options.image:
+            return
+
         # Can't call self.info.clear() because options contribute to package id
         self.info.settings.clear()
         self.info.requires.clear()

--- a/recipes/stb/all/conanfile.py
+++ b/recipes/stb/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, get, rmdir
+from conan.tools.files import copy, get, rmdir, rm
 from conan.tools.layout import basic_layout
 from conan.tools.scm import Version
 import os
@@ -33,6 +33,10 @@ class StbConan(ConanFile):
         # HACK: Used to circumvent the incompatibility
         #       of the format cci.YYYYMMDD in tools.Version
         return str(self.version)[4:]
+
+    @property
+    def _build_library(self):
+        return self.options.image
 
     def config_options(self):
         if Version(self._version) < "20210713":
@@ -82,11 +86,13 @@ class StbConan(ConanFile):
         if self.options.get_safe("with_deprecated"):
             copy(self, "*.h", src=os.path.join(self.source_folder, "deprecated"), dst=os.path.join(self.package_folder, "include"))
             copy(self, "stb_image.c", src=os.path.join(self.source_folder, "deprecated"), dst=os.path.join(self.package_folder, "include"))
-        copy(self, "libstb.a", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"))
+        copy(self, "lib*.a", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"))
+        if not self.options.image:
+            rm(self, pattern="stb_image.h", folder=os.path.join(self.package_folder, "include"))
 
     def package_info(self):
         self.cpp_info.bindirs = []
-        self.cpp_info.libs = ["stb"]
+        self.cpp_info.libs = ["stb"] if self._build_library else []
         self.cpp_info.defines.append("STB_TEXTEDIT_KEYTYPE=unsigned")
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("m")

--- a/recipes/stb/all/stb_image.cpp
+++ b/recipes/stb/all/stb_image.cpp
@@ -1,0 +1,2 @@
+#define STB_IMAGE_IMPLEMENTATION
+#include "stb_image.h"


### PR DESCRIPTION
The current recipe results in a link error by default. Then, you have to read the docs of stb to realize, that you have to compile the implementation yourself with a custom `#define STB_IMAGE_IMPLEMENTATION`. I want this to be handled by my package manager.

The issue was mentioned a while ago in https://github.com/conan-io/conan-center-index/issues/8398

Considerations:
* Should the various pieces like `stb_image` and `stb_truetype` be individual options? -> I think yes
* Should everything be included by default? -> I think no
* Should the individual `stb_image.h` header be removed if the option is not set? -> I think yes. Missing headers is a more familiar prompt to check dependency options, than a link error.
