### PR TITLE
tinyexif/1.0.4: Debug build contains incorrect library name

### DIFF
--- a/recipes/tinyexif/all/conanfile.py
+++ b/recipes/tinyexif/all/conanfile.py
@@ -68,8 +68,7 @@ class TinyEXIFConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
-        libpostfix = "d" if self.settings.build_type == "Debug" else ""
-        self.cpp_info.libs = [f"TinyEXIF{libpostfix}"]
+        self.cpp_info.libs = [f"TinyEXIF"]
 
         self.cpp_info.set_property("cmake_file_name", "TinyEXIF")
         self.cpp_info.set_property("cmake_target_name", "TinyEXIF::TinyEXIF")


### PR DESCRIPTION
### Summary
Changes to recipe:  **tinyexif/1.0.4**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
close: https://github.com/conan-io/conan-center-index/issues/29672

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
The new version removed the **CMAKE_DEBUG_POSTFIX**, but it wasn't change on the recipe. Causing an error when the library is build on debug mode.
https://github.com/cdcseacave/TinyEXIF/compare/6e56015f...1.0.4#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL78


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
