### PR TITLE
[libtorch] Use pyenv python interpreter

### DIFF
--- a/recipes/libtorch/all/conanfile.py
+++ b/recipes/libtorch/all/conanfile.py
@@ -219,12 +219,8 @@ class LibtorchRecipe(ConanFile):
         pyenv.generate()
         # PyEnv is set up to put the virtual env first in PATH
         # but CMake's default behaviour may prioritise other locations
-        # we need: "use the first python3 you find in PATH"
+        tc.cache_variables['Python_ROOT_DIR'] = pyenv.env_dir
         tc.cache_variables['Python_EXECUTABLE'] = pyenv.env_exe
-        tc.cache_variables['Python_FIND_UNVERSIONED_NAMES'] = 'FIRST'
-        tc.cache_variables['Python_FIND_STRATEGY'] = 'LOCATION'
-        tc.cache_variables['Python_FIND_VIRTUALENV'] = 'STANDARD'
-        tc.cache_variables['Python_FIND_REGISTRY'] = 'NEVER'
 
         tc.generate()
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **libtorch/2.9.1**

#### Motivation
Building libtorch is failing on Windows as it is not using the pyenv Python interpreter for building. The error is:

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Users\runneradmin\.conan2\p\b\libto555eb080a31c4\b\src\torchgen\gen.py", line 12, in <module>
    from typing_extensions import assert_never
ModuleNotFoundError: No module named 'typing_extensions'
CMake Error at cmake/Codegen.cmake:264 (message):
Failed to get generated_headers list
```

#### Details
Tested in the examples2 repo: https://github.com/conan-io/examples2/pull/220


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
