### PR TITLE
gobject-introspection: use PyEnv for setuptools

### DIFF
--- a/recipes/gobject-introspection/all/conandata.yml
+++ b/recipes/gobject-introspection/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.86.0":
+    url: "https://download.gnome.org/sources/gobject-introspection/1.86/gobject-introspection-1.86.0.tar.xz"
+    sha256: "920d1a3fcedeadc32acff95c2e203b319039dd4b4a08dd1a2dfd283d19c0b9ae"
   "1.78.1":
     url: "https://download.gnome.org/sources/gobject-introspection/1.78/gobject-introspection-1.78.1.tar.xz"
     sha256: "bd7babd99af7258e76819e45ba4a6bc399608fe762d83fde3cac033c50841bb4"

--- a/recipes/gobject-introspection/all/conandata.yml
+++ b/recipes/gobject-introspection/all/conandata.yml
@@ -2,9 +2,3 @@ sources:
   "1.86.0":
     url: "https://download.gnome.org/sources/gobject-introspection/1.86/gobject-introspection-1.86.0.tar.xz"
     sha256: "920d1a3fcedeadc32acff95c2e203b319039dd4b4a08dd1a2dfd283d19c0b9ae"
-  "1.78.1":
-    url: "https://download.gnome.org/sources/gobject-introspection/1.78/gobject-introspection-1.78.1.tar.xz"
-    sha256: "bd7babd99af7258e76819e45ba4a6bc399608fe762d83fde3cac033c50841bb4"
-  "1.72.0":
-    url: "https://download.gnome.org/sources/gobject-introspection/1.72/gobject-introspection-1.72.0.tar.xz"
-    sha256: "02fe8e590861d88f83060dd39cda5ccaa60b2da1d21d0f95499301b186beaabc"

--- a/recipes/gobject-introspection/all/conanfile.py
+++ b/recipes/gobject-introspection/all/conanfile.py
@@ -14,7 +14,7 @@ from conan.tools.scm import Version
 from conan.tools.system import PyEnv
 from conan import conan_version
 
-required_conan_version = ">=2.25"
+required_conan_version = ">=2.26"
 
 
 class GobjectIntrospectionConan(ConanFile):
@@ -100,12 +100,6 @@ class GobjectIntrospectionConan(ConanFile):
     def generate(self):
         env = VirtualBuildEnv(self)
         env.generate()
-        tc = MesonToolchain(self)
-        if cross_building(self):
-            tc.project_options["gi_cross_use_prebuilt_gi"] = "false"
-        tc.project_options["build_introspection_data"] = self.options.build_introspection_data
-        tc.project_options["datadir"] = "res"
-        tc.generate()
         deps = PkgConfigDeps(self)
         deps.generate()
         # INFO: g-ir-scanner uses PKG_CONFIG_PATH directly instead of pkg-config Meson module
@@ -121,6 +115,13 @@ class GobjectIntrospectionConan(ConanFile):
         else:
             pyenv.install(["setuptools~=82.0.0"])
         pyenv.generate()
+        tc = MesonToolchain(self)
+        if cross_building(self):
+            tc.project_options["gi_cross_use_prebuilt_gi"] = "false"
+        tc.project_options["build_introspection_data"] = self.options.build_introspection_data
+        tc.project_options["datadir"] = "res"
+        tc.project_options["python"] = pyenv.env_exe
+        tc.generate()
 
     def _patch_sources(self):
         # Disable tests

--- a/recipes/gobject-introspection/all/conanfile.py
+++ b/recipes/gobject-introspection/all/conanfile.py
@@ -11,9 +11,10 @@ from conan.tools.meson import MesonToolchain, Meson
 from conan.tools.env import Environment
 from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.scm import Version
+from conan.tools.system import PyEnv
 from conan import conan_version
 
-required_conan_version = ">=1.60.0 <2.0 || >=2.0.5"
+required_conan_version = ">=2.25"
 
 
 class GobjectIntrospectionConan(ConanFile):
@@ -111,6 +112,10 @@ class GobjectIntrospectionConan(ConanFile):
         env.define_path("PKG_CONFIG_PATH", self.generators_folder)
         envvars = env.vars(self)
         envvars.save_script("pkg_config_env")
+
+        pyenv = PyEnv(self)
+        pyenv.install(["setuptools~=82.0.0"])
+        pyenv.generate()
 
     def _patch_sources(self):
         # Disable tests

--- a/recipes/gobject-introspection/all/conanfile.py
+++ b/recipes/gobject-introspection/all/conanfile.py
@@ -114,7 +114,11 @@ class GobjectIntrospectionConan(ConanFile):
         envvars.save_script("pkg_config_env")
 
         pyenv = PyEnv(self)
-        pyenv.install(["setuptools~=82.0.0"])
+        if(self.version < Version("1.81.2")):
+            # https://gitlab.gnome.org/GNOME/gobject-introspection/-/commit/a2139dba59eac283a7f543ed737f038deebddc19
+            pyenv.install(["setuptools<74.0.0"])
+        else:
+            pyenv.install(["setuptools~=82.0.0"])
         pyenv.generate()
 
     def _patch_sources(self):

--- a/recipes/gobject-introspection/all/conanfile.py
+++ b/recipes/gobject-introspection/all/conanfile.py
@@ -3,7 +3,7 @@ import os
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import cross_building
-from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
+from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import copy, get, replace_in_file, rm, rmdir
 from conan.tools.gnu import PkgConfigDeps
 from conan.tools.layout import basic_layout
@@ -100,9 +100,6 @@ class GobjectIntrospectionConan(ConanFile):
     def generate(self):
         env = VirtualBuildEnv(self)
         env.generate()
-        if not cross_building(self):
-            env = VirtualRunEnv(self)
-            env.generate(scope="build")
         tc = MesonToolchain(self)
         if cross_building(self):
             tc.project_options["gi_cross_use_prebuilt_gi"] = "false"

--- a/recipes/gobject-introspection/all/conanfile.py
+++ b/recipes/gobject-introspection/all/conanfile.py
@@ -100,13 +100,6 @@ class GobjectIntrospectionConan(ConanFile):
     def generate(self):
         env = VirtualBuildEnv(self)
         env.generate()
-        deps = PkgConfigDeps(self)
-        deps.generate()
-        # INFO: g-ir-scanner uses PKG_CONFIG_PATH directly instead of pkg-config Meson module
-        env = Environment()
-        env.define_path("PKG_CONFIG_PATH", self.generators_folder)
-        envvars = env.vars(self)
-        envvars.save_script("pkg_config_env")
 
         pyenv = PyEnv(self)
         if(self.version < Version("1.81.2")):
@@ -115,6 +108,7 @@ class GobjectIntrospectionConan(ConanFile):
         else:
             pyenv.install(["setuptools~=82.0.0"])
         pyenv.generate()
+
         tc = MesonToolchain(self)
         if cross_building(self):
             tc.project_options["gi_cross_use_prebuilt_gi"] = "false"
@@ -122,6 +116,14 @@ class GobjectIntrospectionConan(ConanFile):
         tc.project_options["datadir"] = "res"
         tc.project_options["python"] = pyenv.env_exe
         tc.generate()
+
+        deps = PkgConfigDeps(self)
+        deps.generate()
+        # INFO: g-ir-scanner uses PKG_CONFIG_PATH directly instead of pkg-config Meson module
+        env = Environment()
+        env.define_path("PKG_CONFIG_PATH", self.generators_folder)
+        envvars = env.vars(self)
+        envvars.save_script("pkg_config_env")
 
     def _patch_sources(self):
         # Disable tests

--- a/recipes/gobject-introspection/all/conanfile.py
+++ b/recipes/gobject-introspection/all/conanfile.py
@@ -57,7 +57,11 @@ class GobjectIntrospectionConan(ConanFile):
 
     def requirements(self):
         # https://gitlab.gnome.org/GNOME/gobject-introspection/-/blob/1.76.1/meson.build?ref_type=tags#L127-131
-        self.requires("glib/2.78.3", transitive_headers=True, transitive_libs=True)
+        if self.version < Version("1.82.0"):
+            self.requires("glib/[>=2.78.3 <3]", transitive_headers=True, transitive_libs=True)
+        else:
+            #https://gitlab.gnome.org/GNOME/gobject-introspection/-/commit/fc4b438253bf869f56153f80dc32f58bcf9e3b81
+            self.requires("glib/[>=2.82 <3]", transitive_headers=True, transitive_libs=True)
         # ffi.h is exposed by public header gobject-introspection-1.0/girffi.h
         self.requires("libffi/3.4.4", transitive_headers=True)
 

--- a/recipes/gobject-introspection/all/conanfile.py
+++ b/recipes/gobject-introspection/all/conanfile.py
@@ -84,18 +84,16 @@ class GobjectIntrospectionConan(ConanFile):
         else:
             self.tool_requires("flex/2.6.4")
             self.tool_requires("bison/3.8.2")
-        self.tool_requires("glib/<host_version>")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
-        env = VirtualBuildEnv(self)
-        env.generate()
-
-        pyenv = PyEnv(self)
+        pyenv = PyEnv(self, py_version="3.12")
         pyenv.install(["setuptools~=82.0.0"])
         pyenv.generate()
+        env = VirtualBuildEnv(self)
+        env.generate()
 
         tc = MesonToolchain(self)
         if cross_building(self):
@@ -103,6 +101,8 @@ class GobjectIntrospectionConan(ConanFile):
         tc.project_options["build_introspection_data"] = self.options.build_introspection_data
         tc.project_options["datadir"] = "res"
         tc.project_options["python"] = pyenv.env_exe
+        if self.settings.os == "Linux":
+            tc.extra_ldflags.append("-Wl,--disable-new-dtags")
         tc.generate()
 
         deps = PkgConfigDeps(self)
@@ -110,6 +110,16 @@ class GobjectIntrospectionConan(ConanFile):
         # INFO: g-ir-scanner uses PKG_CONFIG_PATH directly instead of pkg-config Meson module
         env = Environment()
         env.define_path("PKG_CONFIG_PATH", self.generators_folder)
+        if self.settings.os == "Linux" and self.options.get_safe("build_introspection_data"):
+            launcher_path = os.path.join(self.generators_folder, "gi-cross-launcher.sh")
+            with open(launcher_path, "w") as f:
+                f.write(
+                    "#!/bin/sh\n"
+                    '. "$(dirname "$0")/conanrun.sh" >/dev/null\n'
+                    'exec "$@"\n'
+                )
+            os.chmod(launcher_path, 0o755)
+            env.define_path("GI_CROSS_LAUNCHER", launcher_path)
         envvars = env.vars(self)
         envvars.save_script("pkg_config_env")
 

--- a/recipes/gobject-introspection/all/conanfile.py
+++ b/recipes/gobject-introspection/all/conanfile.py
@@ -90,7 +90,7 @@ class GobjectIntrospectionConan(ConanFile):
 
     def generate(self):
         pyenv = PyEnv(self, py_version="3.10")
-        pyenv.install(["setuptools~=82.0.0"])
+        pyenv.install(["setuptools<81.0.0"]) # https://gitlab.gnome.org/GNOME/gobject-introspection/-/work_items/575
         pyenv.generate()
         env = VirtualBuildEnv(self)
         env.generate()

--- a/recipes/gobject-introspection/all/conanfile.py
+++ b/recipes/gobject-introspection/all/conanfile.py
@@ -89,7 +89,7 @@ class GobjectIntrospectionConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
-        pyenv = PyEnv(self, py_version="3.12")
+        pyenv = PyEnv(self, py_version="3.10")
         pyenv.install(["setuptools~=82.0.0"])
         pyenv.generate()
         env = VirtualBuildEnv(self)

--- a/recipes/gobject-introspection/all/conanfile.py
+++ b/recipes/gobject-introspection/all/conanfile.py
@@ -10,9 +10,7 @@ from conan.tools.layout import basic_layout
 from conan.tools.meson import MesonToolchain, Meson
 from conan.tools.env import Environment
 from conan.tools.apple import fix_apple_shared_install_name
-from conan.tools.scm import Version
 from conan.tools.system import PyEnv
-from conan import conan_version
 
 required_conan_version = ">=2.26"
 
@@ -36,7 +34,7 @@ class GobjectIntrospectionConan(ConanFile):
         "fPIC": True,
         "build_introspection_data": True,
     }
-    short_paths = True
+    languages = "C"
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -46,8 +44,6 @@ class GobjectIntrospectionConan(ConanFile):
             self.options.build_introspection_data = False
 
     def configure(self):
-        self.settings.rm_safe("compiler.libcxx")
-        self.settings.rm_safe("compiler.cppstd")
         if self.options.get_safe("build_introspection_data"):
             # INFO: g-ir-scanner looks for dynamic glib and gobject libraries when running
             self.options["glib"].shared = True
@@ -56,12 +52,8 @@ class GobjectIntrospectionConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        # https://gitlab.gnome.org/GNOME/gobject-introspection/-/blob/1.76.1/meson.build?ref_type=tags#L127-131
-        if self.version < Version("1.82.0"):
-            self.requires("glib/[>=2.78.3 <3]", transitive_headers=True, transitive_libs=True)
-        else:
-            #https://gitlab.gnome.org/GNOME/gobject-introspection/-/commit/fc4b438253bf869f56153f80dc32f58bcf9e3b81
-            self.requires("glib/[>=2.82 <3]", transitive_headers=True, transitive_libs=True)
+        #https://gitlab.gnome.org/GNOME/gobject-introspection/-/commit/fc4b438253bf869f56153f80dc32f58bcf9e3b81
+        self.requires("glib/[>=2.82 <3]", transitive_headers=True, transitive_libs=True)
         # ffi.h is exposed by public header gobject-introspection-1.0/girffi.h
         self.requires("libffi/3.4.4", transitive_headers=True)
 
@@ -102,11 +94,7 @@ class GobjectIntrospectionConan(ConanFile):
         env.generate()
 
         pyenv = PyEnv(self)
-        if(self.version < Version("1.81.2")):
-            # https://gitlab.gnome.org/GNOME/gobject-introspection/-/commit/a2139dba59eac283a7f543ed737f038deebddc19
-            pyenv.install(["setuptools<74.0.0"])
-        else:
-            pyenv.install(["setuptools~=82.0.0"])
+        pyenv.install(["setuptools~=82.0.0"])
         pyenv.generate()
 
         tc = MesonToolchain(self)
@@ -134,25 +122,11 @@ class GobjectIntrospectionConan(ConanFile):
         replace_in_file(self, os.path.join(self.source_folder, "tools", "g-ir-tool-template.in"),
                         "os.path.join(filedir, '..', 'share')",
                         "os.path.join(filedir, '..', 'res')")
-        if Version(conan_version) < "2":
-            # INFO: Conan 1.x generates PkgConfigDeps with libdir1 and includedir1 variables only for glib due its modules
-            replace_in_file(self, os.path.join(self.source_folder, "gir", "meson.build"),
-                            "glib_dep.get_variable(pkgconfig: 'libdir')",
-                            "glib_dep.get_variable(pkgconfig: 'libdir1')")
-            replace_in_file(self, os.path.join(self.source_folder, "gir", "meson.build"),
-                            "join_paths(glib_dep.get_variable(pkgconfig: 'includedir'), 'glib-2.0')",
-                            "join_paths(glib_dep.get_variable(pkgconfig: 'includedir1'), 'glib-2.0')")
-            # gir/meson.build expects the gio-unix-2.0 includedir to be passed as a build flag.
-            # Patch this for glib from Conan.
-            replace_in_file(self, os.path.join(self.source_folder, "gir", "meson.build"),
-                            "join_paths(giounix_dep.get_variable(pkgconfig: 'includedir'), 'gio-unix-2.0')",
-                            "giounix_dep.get_variable(pkgconfig: 'includedir1')")
-        else:
-            # gir/meson.build expects the gio-unix-2.0 includedir to be passed as a build flag.
-            # Patch this for glib from Conan.
-            replace_in_file(self, os.path.join(self.source_folder, "gir", "meson.build"),
-                            "join_paths(giounix_dep.get_variable(pkgconfig: 'includedir'), 'gio-unix-2.0')",
-                            "giounix_dep.get_variable(pkgconfig: 'includedir')")
+        # gir/meson.build expects the gio-unix-2.0 includedir to be passed as a build flag.
+        # Patch this for glib from Conan.
+        replace_in_file(self, os.path.join(self.source_folder, "gir", "meson.build"),
+                        "join_paths(giounix_dep.get_variable(pkgconfig: 'includedir'), 'gio-unix-2.0')",
+                        "giounix_dep.get_variable(pkgconfig: 'includedir')")
 
     def build(self):
         self._patch_sources()

--- a/recipes/gobject-introspection/all/conanfile.py
+++ b/recipes/gobject-introspection/all/conanfile.py
@@ -167,9 +167,3 @@ class GobjectIntrospectionConan(ConanFile):
         )
         self.buildenv_info.define_path("GI_GIR_PATH", os.path.join(self.package_folder, "res", "gir-1.0"))
         self.buildenv_info.define_path("GI_TYPELIB_PATH", os.path.join(self.package_folder, "lib", "girepository-1.0"))
-
-        # TODO: remove in conan v2
-        bin_path = os.path.join(self.package_folder, "bin")
-        self.env_info.PATH.append(bin_path)
-        self.env_info.GI_GIR_PATH = os.path.join(self.package_folder, "res", "gir-1.0")
-        self.env_info.GI_TYPELIB_PATH = os.path.join(self.package_folder, "lib", "girepository-1.0")

--- a/recipes/gobject-introspection/all/test_package/conanfile.py
+++ b/recipes/gobject-introspection/all/test_package/conanfile.py
@@ -5,6 +5,8 @@ from conan.tools.build import can_run
 from conan.tools.cmake import cmake_layout, CMake, CMakeToolchain
 from conan.tools.files import save, load
 from conan.tools.apple import is_apple_os
+from conan.tools.scm import Version
+from conan.tools.system import PyEnv
 
 
 class TestPackageConan(ConanFile):
@@ -26,6 +28,14 @@ class TestPackageConan(ConanFile):
         save(self, os.path.join(self.build_folder, "gobject_introspection_data"), str(introspection_data))
         save(self, os.path.join(self.build_folder, "gobject_introspection_bin"),
               self.dependencies["gobject-introspection"].cpp_info.bindirs[0])
+        
+        pyenv = PyEnv(self)
+        if(self.dependencies["gobject-introspection"].ref.version < Version("1.81.2")):
+            # https://gitlab.gnome.org/GNOME/gobject-introspection/-/commit/a2139dba59eac283a7f543ed737f038deebddc19
+            pyenv.install(["setuptools<74.0.0"])
+        else:
+            pyenv.install(["setuptools~=82.0.0"])
+        pyenv.generate()
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/gobject-introspection/all/test_package/conanfile.py
+++ b/recipes/gobject-introspection/all/test_package/conanfile.py
@@ -5,7 +5,6 @@ from conan.tools.build import can_run
 from conan.tools.cmake import cmake_layout, CMake, CMakeToolchain
 from conan.tools.files import save, load
 from conan.tools.apple import is_apple_os
-from conan.tools.scm import Version
 from conan.tools.system import PyEnv
 
 
@@ -30,11 +29,7 @@ class TestPackageConan(ConanFile):
               self.dependencies["gobject-introspection"].cpp_info.bindirs[0])
         
         pyenv = PyEnv(self)
-        if(self.dependencies["gobject-introspection"].ref.version < Version("1.81.2")):
-            # https://gitlab.gnome.org/GNOME/gobject-introspection/-/commit/a2139dba59eac283a7f543ed737f038deebddc19
-            pyenv.install(["setuptools<74.0.0"])
-        else:
-            pyenv.install(["setuptools~=82.0.0"])
+        pyenv.install(["setuptools~=82.0.0"])
         pyenv.generate()
 
     def build(self):

--- a/recipes/gobject-introspection/config.yml
+++ b/recipes/gobject-introspection/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.86.0":
+    folder: all
   "1.78.1":
     folder: all
   "1.72.0":

--- a/recipes/gobject-introspection/config.yml
+++ b/recipes/gobject-introspection/config.yml
@@ -1,7 +1,3 @@
 versions:
   "1.86.0":
     folder: all
-  "1.78.1":
-    folder: all
-  "1.72.0":
-    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **gobject-introspection/***
Until https://gitlab.gnome.org/GNOME/gobject-introspection/-/issues/395 is fixed, gobject-introspection use distutils, so it requires setuptools to be installed since python 3.12
Thankfully, conan now has PyEnv which unlocks this kind of situation

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

#### Details
current failure for [1.78.1](https://github.com/eirikb/proof-of-conan/actions/runs/22179973973/job/64138465861#step:12:1916) and [1.72.0](https://github.com/eirikb/proof-of-conan/actions/runs/22179973973/job/64138465928)

This PR fixes linux windows and macos : https://github.com/eirikb/proof-of-conan/actions/runs/22300946929

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
