### PR TITLE
[imgui] add 1.92.6

### DIFF
--- a/recipes/imgui/all/conandata.yml
+++ b/recipes/imgui/all/conandata.yml
@@ -1,6 +1,13 @@
 # this package's recipe relies on version suffixes to handle imgui's docking branch.
 # Suffix: -docking for docking branch sources
 sources:
+  "1.92.6":
+    core:
+      url: "https://github.com/ocornut/imgui/archive/v1.92.6.tar.gz"
+      sha256: "5b17c01f69545bde732b14936d89ce0f508adb83e8b56fa82448371845172bc3"
+    testengine:
+      url: "https://github.com/ocornut/imgui_test_engine/archive/v1.92.6.tar.gz"
+      sha256: "5374ec2318933f9fc663d924529ea80e5fa40866e82fafc3872ae94a16fdbc7f"
   "1.92.5":
     core:
       url: "https://github.com/ocornut/imgui/archive/v1.92.5.tar.gz"

--- a/recipes/imgui/config.yml
+++ b/recipes/imgui/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.92.6":
+    folder: all
   "1.92.5":
     folder: all
   "1.92.5-docking":
@@ -27,4 +29,3 @@ versions:
     folder: all
   "1.85":
     folder: all
-


### PR DESCRIPTION
### Summary
Changes to recipe:  **imgui/1.92.6**

#### Motivation

Add [ImGui 1.92.6](https://github.com/ocornut/imgui/releases/tag/v1.92.6). This release has important fixes for working with the GLFW backend without X11.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
