### PR TITLE
[boost]: respect target triple config for cross compilation

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -859,7 +859,7 @@ class BoostConan(ConanFile):
 
     def build_requirements(self):
         if not self.options.header_only:
-            self.tool_requires("b2/[>=5.2 <6]")
+            self.tool_requires("b2/[>=5.4 <6]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version],
@@ -1603,6 +1603,11 @@ class BoostConan(ConanFile):
             sysroot = f'"{sysroot}"' if ' ' in sysroot else sysroot
             cppflags += f"--sysroot={sysroot} "
             ldflags += f"--sysroot={sysroot} "
+
+        # https://github.com/bfgroup/b2/pull/466
+        if "clang" in str(self.settings.compiler):
+            triple = self.conf.get("tools.gnu:host_triplet", "none")
+            contents += f'<triple>"{triple}" '
 
         if self._with_stacktrace_backtrace:
             backtrace_aggregated_cpp_info = self.dependencies["libbacktrace"].cpp_info.aggregated_components()


### PR DESCRIPTION
### Summary
Changes to recipe:  **boost/***

#### Motivation

Boost cannot be cross-compiled using clang without significant workarounds to the toolchain (ie setting up symlinks from `<arch>-pc-linux` to the actual configured target triple).

#### Details

b2 [added support to respect the target triple for clang](https://github.com/bfgroup/b2/pull/466) in 5.4.0 allowing clang to cross compile boost given an appropriately configured toolchain.

This PR adds the `<triple>` setting to `user-config.jam` if it has been set in the profile config section.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
