### PR TITLE
Remove upper limit on CMake version for abseil

### DIFF
--- a/recipes/abseil/all/conanfile.py
+++ b/recipes/abseil/all/conanfile.py
@@ -55,7 +55,7 @@ class AbseilConan(ConanFile):
     def build_requirements(self):
         # https://github.com/abseil/abseil-cpp/blob/20240722.0/CMakeLists.txt#L19
         if Version(self.version) >= "20240722.0":
-            self.tool_requires("cmake/[>=3.16 <4]")
+            self.tool_requires("cmake/[>=3.16]")
 
     def layout(self):
         cmake_layout(self, src_folder="src")


### PR DESCRIPTION
Remove upper limit on CMake version for abseil, because CMake 4 has 3.16 compatibility.

### Summary
Changes to recipe:  **abseil/20260107.1**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

I wanted this because CMake 3 does not support Visual Studio 2026.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
