### PR TITLE
libfabric: add version 2.2.0

### DIFF
--- a/recipes/libfabric/all/conandata.yml
+++ b/recipes/libfabric/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "1.21.0":
     url: "https://github.com/ofiwg/libfabric/releases/download/v1.21.0/libfabric-1.21.0.tar.bz2"
     sha256: "0c1b7b830d9147f661e5d7f359250b85b5a9885c330464cd3b5e5d35b86551c7"
+  "2.2.0":
+    url: "https://github.com/ofiwg/libfabric/releases/download/v2.2.0/libfabric-2.2.0.tar.bz2"
+    sha256: "ff6d05240b4a9753bb3d1eaf962f5a06205038df5142374a6ef40f931bb55ecc"

--- a/recipes/libfabric/all/conanfile.py
+++ b/recipes/libfabric/all/conanfile.py
@@ -3,6 +3,7 @@ import os
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import is_apple_os, fix_apple_shared_install_name
+from conan.tools.env import Environment
 from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
 from conan.tools.files import copy, get, rm, rmdir
 from conan.tools.gnu import Autotools, AutotoolsToolchain, AutotoolsDeps
@@ -157,7 +158,7 @@ class LibfabricConan(ConanFile):
         tc.configure_args.append("--with-synapseai=no")
         tc.configure_args.append("--with-uring=no")  # TODO
         tc.configure_args.append("--with-ze=no")
-        tc.configure_args.append("-enable-psm=no")
+        tc.configure_args.append("--enable-psm=no")
         tc.configure_args.append("--enable-psm2=no")
         tc.configure_args.append("--enable-psm3=no")
         tc.configure_args.append("--enable-xpmem=no")
@@ -173,9 +174,12 @@ class LibfabricConan(ConanFile):
         VirtualRunEnv(self).generate(scope="build")
 
     def build(self):
+        env = Environment()
+        env.define("lt_cv_deplibs_check_method", "pass_all")
         autotools = Autotools(self)
-        autotools.configure()
-        autotools.make()
+        with env.vars(self).apply():
+            autotools.configure()
+            autotools.make()
 
     def package(self):
         copy(self, "COPYING", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)

--- a/recipes/libfabric/config.yml
+++ b/recipes/libfabric/config.yml
@@ -1,3 +1,5 @@
 versions:
   "1.21.0":
     folder: all
+  "2.2.0":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **lib/2.2.0**

#### Motivation
Add new release version 2.2.0 of libfabric which add some fixes and breaking changes.

Changelog : https://github.com/ofiwg/libfabric/releases/tag/v2.2.0

#### Details
* Add 2.2.0 sources in conandata.yaml
* Add 2.2.0 recipes in config.yml
* Harden recipe for shared library builds: set `lt_cv_deplibs_check_method=pass_all` to avoid libtool dependency probe failures in minimal CI environments
* Fix typo in configure argument: `-enable-psm` → `--enable-psm`

close #29747 

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
