### PR TITLE
libglvnd: use meson version range instead of pinned version

### DIFF
--- a/recipes/libglvnd/all/conanfile.py
+++ b/recipes/libglvnd/all/conanfile.py
@@ -59,7 +59,7 @@ class LibGlvndConan(ConanFile):
             raise ConanInvalidConfiguration(f"{self.name} is only compatible with Linux and FreeBSD")
 
     def build_requirements(self):
-        self.tool_requires("meson/1.4.0")
+        self.tool_requires("meson/[>=1.4.0 <2]")
         if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
             self.tool_requires("pkgconf/2.1.0")
 


### PR DESCRIPTION
### Summary
Changes to recipe: **libglvnd/***

#### Motivation

The build of `libglvnd` fails because `meson/1.4.0` is no longer available in CCI — only `meson/1.4.1` and later are.

This is the same class of issue addressed by #29579 (Fix wayland-protocols test package), which moved `meson/1.3.0` to a version range for the same reason.

#### Details

Replace the pinned `meson/1.4.0` with the version range `meson/[>=1.4.0 <2]`, consistent with the pattern used by other recipes that require meson 1.4.x (`cairo`, `dav1d`, `fontconfig`, `harfbuzz`, `libdrm`, `libsecret`, `libsystemd`, `pixman`, `wayland`), and aligned with the canonical template in `docs/package_templates/meson_package`.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details: build fails with `meson/1.4.0` not found; similar to #29579
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
