### PR TITLE
cppcheck: add version 2.20.0

### DIFF
--- a/recipes/cppcheck/all/conandata.yml
+++ b/recipes/cppcheck/all/conandata.yml
@@ -2,27 +2,6 @@ sources:
   "2.20.0":
     url: "https://github.com/danmar/cppcheck/archive/2.20.0.tar.gz"
     sha256: "7be7992439339017edb551d8e7d2315f9bb57c402da50c2cee9cd0e2724600a1"
-  "2.19.1":
-    url: "https://github.com/danmar/cppcheck/archive/2.19.1.tar.gz"
-    sha256: "49bdf1d7826d60053575b78d3192d81d54970dbfb356590f7476de250b1a4234"
-  "2.18.3":
-    url: "https://github.com/danmar/cppcheck/archive/2.18.3.tar.gz"
-    sha256: "e37c94e190cdddc65682649b02b72939761585bddd8ada595f922e190a26a2be"
-  "2.17.1":
-    url: "https://github.com/danmar/cppcheck/archive/2.17.1.tar.gz"
-    sha256: "bfd681868248ec03855ca7c2aea7bcb1f39b8b18860d76aec805a92a967b966c"
-  "2.11.1":
-    url: "https://github.com/danmar/cppcheck/archive/2.11.1.tar.gz"
-    sha256: "fef6ef868d562d49136f158e1d0f7a38237e7e1c0a91d9189bdd465f1fe54316"
-  "2.10.3":
-    url: "https://github.com/danmar/cppcheck/archive/2.10.3.tar.gz"
-    sha256: "8aae5e116daeaaf5d19f3efa61b91c06f161cb97412a1d1af6e1e20686e48967"
-  "2.9.3":
-    url: "https://github.com/danmar/cppcheck/archive/2.9.3.tar.gz"
-    sha256: "46319ca73e33e4b2bd91981a76a0d4f184cd3f86b62dc18e8938eabacd3ad2e3"
-  "2.8.2":
-    url: "https://github.com/danmar/cppcheck/archive/2.8.2.tar.gz"
-    sha256: "30ba99ab54089c44b83f02e2453da046a7edff5237950d4A0eb1eba4afcb4f45"
 patches:
   "2.11.1":
     - patch_file: "patches/0003-pcre-debuglib-name.patch"

--- a/recipes/cppcheck/all/conandata.yml
+++ b/recipes/cppcheck/all/conandata.yml
@@ -11,4 +11,47 @@ sources:
   "2.17.1":
     url: "https://github.com/danmar/cppcheck/archive/2.17.1.tar.gz"
     sha256: "bfd681868248ec03855ca7c2aea7bcb1f39b8b18860d76aec805a92a967b966c"
- 
+  "2.11.1":
+    url: "https://github.com/danmar/cppcheck/archive/2.11.1.tar.gz"
+    sha256: "fef6ef868d562d49136f158e1d0f7a38237e7e1c0a91d9189bdd465f1fe54316"
+  "2.10.3":
+    url: "https://github.com/danmar/cppcheck/archive/2.10.3.tar.gz"
+    sha256: "8aae5e116daeaaf5d19f3efa61b91c06f161cb97412a1d1af6e1e20686e48967"
+  "2.9.3":
+    url: "https://github.com/danmar/cppcheck/archive/2.9.3.tar.gz"
+    sha256: "46319ca73e33e4b2bd91981a76a0d4f184cd3f86b62dc18e8938eabacd3ad2e3"
+  "2.8.2":
+    url: "https://github.com/danmar/cppcheck/archive/2.8.2.tar.gz"
+    sha256: "30ba99ab54089c44b83f02e2453da046a7edff5237950d4A0eb1eba4afcb4f45"
+patches:
+  "2.11.1":
+    - patch_file: "patches/0003-pcre-debuglib-name.patch"
+      patch_description: "Consider the Debug suffix for Windows"
+      patch_type: "portability"
+  "2.10.3":
+    - patch_file: "patches/0001-cli-remove-dmake-cmake-2.10.patch"
+      patch_description: "Remove dmake tool from target ALL"
+      patch_type: "portability"
+    - patch_file: "patches/0003-pcre-debuglib-name.patch"
+      patch_description: "Consider the Debug suffix for Windows"
+      patch_type: "portability"
+  "2.9.3":
+    - patch_file: "patches/0001-cli-remove-dmake-cmake.patch"
+      patch_description: "Remove dmake tool from target ALL"
+      patch_type: "portability"
+    - patch_file: "patches/0002-htmlreport-python3.patch"
+      patch_description: "Use Python 3 in Shebang Header"
+      patch_type: "portability"
+    - patch_file: "patches/0003-pcre-debuglib-name.patch"
+      patch_description: "Consider the Debug suffix for Windows"
+      patch_type: "portability"
+  "2.8.2":
+    - patch_file: "patches/0001-cli-remove-dmake-cmake-2.8.patch"
+      patch_description: "Remove dmake tool from target ALL"
+      patch_type: "portability"
+    - patch_file: "patches/0002-htmlreport-python3.patch"
+      patch_description: "Use Python 3 in Shebang Header"
+      patch_type: "portability"
+    - patch_file: "patches/0003-pcre-debuglib-name.patch"
+      patch_description: "Consider the Debug suffix for Windows"
+      patch_type: "portability"

--- a/recipes/cppcheck/all/conandata.yml
+++ b/recipes/cppcheck/all/conandata.yml
@@ -8,74 +8,7 @@ sources:
   "2.18.3":
     url: "https://github.com/danmar/cppcheck/archive/2.18.3.tar.gz"
     sha256: "e37c94e190cdddc65682649b02b72939761585bddd8ada595f922e190a26a2be"
-  "2.18.0":
-    url: "https://github.com/danmar/cppcheck/archive/2.18.0.tar.gz"
-    sha256: "dc74e300ac59f2ef9f9c05c21d48ae4c8dd1ce17f08914dd30c738ff482e748f"
   "2.17.1":
     url: "https://github.com/danmar/cppcheck/archive/2.17.1.tar.gz"
     sha256: "bfd681868248ec03855ca7c2aea7bcb1f39b8b18860d76aec805a92a967b966c"
-  "2.17.0":
-    url: "https://github.com/danmar/cppcheck/archive/2.17.0.tar.gz"
-    sha256: "5a639adf8d5f2520a280eb0f0fc25605cd8a3d4336a27f4a3e3e0f0c0c9789da"
-  "2.16.2":
-    url: "https://github.com/danmar/cppcheck/archive/2.16.2.tar.gz"
-    sha256: "521b996cb56b0c30f89e022abcb50aef85d7219cb7a7162fa81fe40fe6394206"
-  "2.16.0":
-    url: "https://github.com/danmar/cppcheck/archive/2.16.0.tar.gz"
-    sha256: "f1a97c8cef5ee9d0abb57e9244549d4fe18d4ecac80cf82e250d1fc5f38b1501"
-  "2.15.0":
-    url: "https://github.com/danmar/cppcheck/archive/2.15.0.tar.gz"
-    sha256: "98bcc40ac8062635b492fb096d7815376a176ae26749d6c708083f4637f7c0bb"
-  "2.14.2":
-    url: "https://github.com/danmar/cppcheck/archive/2.14.2.tar.gz"
-    sha256: "9c3acea5f489336bd83a8ea33917a9a04a80c56d874bf270287e7de27acf2d00"
-  "2.13.4":
-    url: "https://github.com/danmar/cppcheck/archive/2.13.4.tar.gz"
-    sha256: "d6ea064ebab76c6aa000795440479767d8d814dd29405918df4c1bbfcd6cb86c"
-  "2.12.1":
-    url: "https://github.com/danmar/cppcheck/archive/2.12.1.tar.gz"
-    sha256: "2a3d4ba1179419612183ab3d6aed6d3b18be75e98cd6f138ea8e2020905dced2"
-  "2.11.1":
-    url: "https://github.com/danmar/cppcheck/archive/2.11.1.tar.gz"
-    sha256: "fef6ef868d562d49136f158e1d0f7a38237e7e1c0a91d9189bdd465f1fe54316"
-  "2.10.3":
-    url: "https://github.com/danmar/cppcheck/archive/2.10.3.tar.gz"
-    sha256: "8aae5e116daeaaf5d19f3efa61b91c06f161cb97412a1d1af6e1e20686e48967"
-  "2.9.3":
-    url: "https://github.com/danmar/cppcheck/archive/2.9.3.tar.gz"
-    sha256: "46319ca73e33e4b2bd91981a76a0d4f184cd3f86b62dc18e8938eabacd3ad2e3"
-  "2.8.2":
-    url: "https://github.com/danmar/cppcheck/archive/2.8.2.tar.gz"
-    sha256: "30ba99ab54089c44b83f02e2453da046a7edff5237950d4A0eb1eba4afcb4f45"
-patches:
-  "2.11.1":
-    - patch_file: "patches/0003-pcre-debuglib-name.patch"
-      patch_description: "Consider the Debug suffix for Windows"
-      patch_type: "portability"
-  "2.10.3":
-    - patch_file: "patches/0001-cli-remove-dmake-cmake-2.10.patch"
-      patch_description: "Remove dmake tool from target ALL"
-      patch_type: "portability"
-    - patch_file: "patches/0003-pcre-debuglib-name.patch"
-      patch_description: "Consider the Debug suffix for Windows"
-      patch_type: "portability"
-  "2.9.3":
-    - patch_file: "patches/0001-cli-remove-dmake-cmake.patch"
-      patch_description: "Remove dmake tool from target ALL"
-      patch_type: "portability"
-    - patch_file: "patches/0002-htmlreport-python3.patch"
-      patch_description: "Use Python 3 in Shebang Header"
-      patch_type: "portability"
-    - patch_file: "patches/0003-pcre-debuglib-name.patch"
-      patch_description: "Consider the Debug suffix for Windows"
-      patch_type: "portability"
-  "2.8.2":
-    - patch_file: "patches/0001-cli-remove-dmake-cmake-2.8.patch"
-      patch_description: "Remove dmake tool from target ALL"
-      patch_type: "portability"
-    - patch_file: "patches/0002-htmlreport-python3.patch"
-      patch_description: "Use Python 3 in Shebang Header"
-      patch_type: "portability"
-    - patch_file: "patches/0003-pcre-debuglib-name.patch"
-      patch_description: "Consider the Debug suffix for Windows"
-      patch_type: "portability"
+ 

--- a/recipes/cppcheck/all/conandata.yml
+++ b/recipes/cppcheck/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.20.0":
+    url: "https://github.com/danmar/cppcheck/archive/2.20.0.tar.gz"
+    sha256: "7be7992439339017edb551d8e7d2315f9bb57c402da50c2cee9cd0e2724600a1"
   "2.19.1":
     url: "https://github.com/danmar/cppcheck/archive/2.19.1.tar.gz"
     sha256: "49bdf1d7826d60053575b78d3192d81d54970dbfb356590f7476de250b1a4234"

--- a/recipes/cppcheck/all/conanfile.py
+++ b/recipes/cppcheck/all/conanfile.py
@@ -32,6 +32,10 @@ class CppcheckConan(ConanFile):
     def requirements(self):
         if self.options.get_safe("have_rules"):
             self.requires("pcre/8.45")
+    
+    def build_requirements(self):
+        if Version(self.version) >= "2.20":
+            self.tool_requires("cmake/[>=3.22]")
 
     def package_id(self):
         del self.info.settings.compiler
@@ -39,6 +43,7 @@ class CppcheckConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -56,7 +61,6 @@ class CppcheckConan(ConanFile):
         deps.generate()
 
     def build(self):
-        apply_conandata_patches(self)
         cmake = CMake(self)
         cmake.configure()
         cmake.build()

--- a/recipes/cppcheck/all/conanfile.py
+++ b/recipes/cppcheck/all/conanfile.py
@@ -1,7 +1,6 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get
-from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=2.1"
@@ -30,12 +29,11 @@ class CppcheckConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        if self.options.get_safe("have_rules"):
+        if self.options.have_rules:
             self.requires("pcre/8.45")
     
     def build_requirements(self):
-        if Version(self.version) >= "2.20":
-            self.tool_requires("cmake/[>=3.22]")
+        self.tool_requires("cmake/[>=3.22]")
 
     def package_id(self):
         del self.info.settings.compiler
@@ -47,14 +45,11 @@ class CppcheckConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["HAVE_RULES"] = self.options.get_safe("have_rules", False)
+        tc.variables["HAVE_RULES"] = self.options.have_rules
         tc.variables["USE_MATCHCOMPILER"] = "Auto"
         tc.variables["ENABLE_OSS_FUZZ"] = False
-        if Version(self.version) >= "2.11.0":
-            tc.variables["DISABLE_DMAKE"] = True
+        tc.variables["DISABLE_DMAKE"] = True
         tc.variables["FILESDIR"] = "bin"
-        if Version(self.version) < "2.14.0":
-            tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
 
         deps = CMakeDeps(self)

--- a/recipes/cppcheck/config.yml
+++ b/recipes/cppcheck/config.yml
@@ -7,3 +7,11 @@ versions:
     folder: all
   "2.17.1":
     folder: all
+  "2.11.1":
+    folder: all
+  "2.10.3":
+    folder: all
+  "2.9.3":
+    folder: all
+  "2.8.2":
+    folder: all

--- a/recipes/cppcheck/config.yml
+++ b/recipes/cppcheck/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.20.0":
+    folder: all
   "2.19.1":
     folder: all
   "2.18.3":

--- a/recipes/cppcheck/config.yml
+++ b/recipes/cppcheck/config.yml
@@ -1,17 +1,3 @@
 versions:
   "2.20.0":
     folder: all
-  "2.19.1":
-    folder: all
-  "2.18.3":
-    folder: all
-  "2.17.1":
-    folder: all
-  "2.11.1":
-    folder: all
-  "2.10.3":
-    folder: all
-  "2.9.3":
-    folder: all
-  "2.8.2":
-    folder: all

--- a/recipes/cppcheck/config.yml
+++ b/recipes/cppcheck/config.yml
@@ -5,29 +5,5 @@ versions:
     folder: all
   "2.18.3":
     folder: all
-  "2.18.0":
-    folder: all
   "2.17.1":
-    folder: all
-  "2.17.0":
-    folder: all
-  "2.16.2":
-    folder: all
-  "2.16.0":
-    folder: all
-  "2.15.0":
-    folder: all
-  "2.14.2":
-    folder: all
-  "2.13.4":
-    folder: all
-  "2.12.1":
-    folder: all
-  "2.11.1":
-    folder: all
-  "2.10.3":
-    folder: all
-  "2.9.3":
-    folder: all
-  "2.8.2":
     folder: all


### PR DESCRIPTION
### Summary

Add recipe for cppcheck version 2.20.0

#### Motivation

To have access to the latest version of the cppcheck tool for better C++ code analysis in people C++ project in general.

### Details

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
