### PR TITLE
cnats: expand version range for protobuf-c dependency

### DIFF
--- a/recipes/cnats/all/conanfile.py
+++ b/recipes/cnats/all/conanfile.py
@@ -53,7 +53,7 @@ class PackageConan(ConanFile):
             self.requires("libsodium/[~1.0.20]")
         # FIXME: C3I Jenkins does not have protobuf-c static x shared deps for now
         if self.options.enable_streaming:
-            self.requires("protobuf-c/[>=1.4.1 <1.6.0]")
+            self.requires("protobuf-c/[>=1.4.1 <2]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
### Summary
Changes to recipe:  **cnats/all**

#### Motivation

~protobuf-c latest version 1.5.2 does not work with cnats~
protobuf-c latest version 1.5.2 should be allowed with cnats, instead of pinning to `protobuf-c/1.4.1`

#### Details

Expand protobuf-c to accept a range

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
