### PR TITLE
giflib: fix source URLs

### DIFF
--- a/recipes/giflib/5.1.x/conandata.yml
+++ b/recipes/giflib/5.1.x/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "5.1.4":
-    url: "https://downloads.sourceforge.net/project/giflib/giflib-5.1.4.tar.gz"
+    url: "https://downloads.sourceforge.net/project/giflib/giflib-5.x/giflib-5.1.4.tar.gz"
     sha256: "34a7377ba834397db019e8eb122e551a49c98f49df75ec3fcc92b9a794a4f6d1"

--- a/recipes/giflib/5.2.x/conandata.yml
+++ b/recipes/giflib/5.2.x/conandata.yml
@@ -1,9 +1,9 @@
 sources:
   "5.2.2":
-    url: "https://downloads.sourceforge.net/project/giflib/giflib-5.2.2.tar.gz"
+    url: "https://downloads.sourceforge.net/project/giflib/giflib-5.x/giflib-5.2.2.tar.gz"
     sha256: "be7ffbd057cadebe2aa144542fd90c6838c6a083b5e8a9048b8ee3b66b29d5fb"
   "5.2.1":
-    url: "https://downloads.sourceforge.net/project/giflib/giflib-5.2.1.tar.gz"
+    url: "https://downloads.sourceforge.net/project/giflib/giflib-5.x/giflib-5.2.1.tar.gz"
     sha256: "31da5562f44c5f15d63340a09a4fd62b48c45620cd302f77a6d9acf0077879bd"
 patches:
   "5.2.2":


### PR DESCRIPTION
### Summary
Changes to recipe: **giflib/all**

#### Motivation
The SourceForge download layout for `giflib` changed after a new release and a restructuring of the project files. The archives for the affected versions are now located under the `giflib-5.x/` subfolder, while the recipe still points to the old paths. As a result, source retrieval for these versions fails.

#### Details
Updated the source URLs in the following files to use the current SourceForge location under `giflib-5.x/`:

- `recipes/giflib/5.1.x/conandata.yml`
- `recipes/giflib/5.2.x/conandata.yml`

Affected versions:
- `5.1.4`
- `5.2.1`
- `5.2.2`

SourceForge files page:
- `https://sourceforge.net/projects/giflib/files/`

Only the source download paths were changed. Filenames, checksums, and recipe behavior remain unchanged.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!