### PR TITLE
libcurl: update to 8.19.0

### DIFF
--- a/recipes/libcurl/all/conandata.yml
+++ b/recipes/libcurl/all/conandata.yml
@@ -1,6 +1,6 @@
 sources:
-  "8.18.0":
+  "8.19.0":
     url:
-      - "https://curl.se/download/curl-8.18.0.tar.xz"
-      - "https://github.com/curl/curl/releases/download/curl-8_18_0/curl-8.18.0.tar.xz"
-    sha256: "40df79166e74aa20149365e11ee4c798a46ad57c34e4f68fd13100e2c9a91946"
+      - "https://curl.se/download/curl-8.19.0.tar.xz"
+      - "https://github.com/curl/curl/releases/download/curl-8_19_0/curl-8.19.0.tar.xz"
+    sha256: "4eb41489790d19e190d7ac7e18e82857cdd68af8f4e66b292ced562d333f11df"

--- a/recipes/libcurl/config.yml
+++ b/recipes/libcurl/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "8.18.0":
+  "8.19.0":
     folder: all


### PR DESCRIPTION
Update libcurl to 8.19.0

Closes #29761

### Summary
Changes to recipe:  **libcurl/8.19.0**

#### Motivation

Patches two high CVEs in curl 8.18.0. See #29761 for details.

#### Details
I simply bumped the version in `config.yml` and `conandata.yml` and adapted the SHA256 digest./

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
