### PR TITLE
Add craw library recipe

### DIFF
--- a/recipes/craw/all/conanfile.py
+++ b/recipes/craw/all/conanfile.py
@@ -1,0 +1,47 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.files import get, copy
+import os
+
+
+class CrawConan(ConanFile):
+    name = "craw"
+    description = "C Reddit API wrapper"
+    license = "MIT"
+    url = "https://github.com/YOUR_USERNAME/craw"
+    homepage = "https://github.com/YOUR_USERNAME/craw"
+    topics = ("reddit", "api", "c")
+
+    package_type = "library"
+
+    settings = "os", "arch", "compiler", "build_type"
+
+    options = {"shared": [True, False]}
+    default_options = {"shared": False}
+
+    exports_sources = "CMakeLists.txt", "src/*", "include/*"
+
+    generators = "CMakeToolchain", "CMakeDeps"
+
+    requires = (
+        "libcurl/8.18.0"
+        "cjson/1.7.17",
+    )
+
+    def layout(self):
+        cmake_layout(self)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["craw"]

--- a/recipes/craw/config.yml
+++ b/recipes/craw/config.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.0":
+    url: "https://github.com/SomeTroller77/CRAW/archive/refs/tags/v1.0.tar.gz"
+    sha256: "469871e89e1f4171f005d3d7ac14c82e394e12688b82e0a7a2c92e20c1e724be"


### PR DESCRIPTION
Add recipe for CRAW, a lightweight C Reddit API wrapper.

Package Details

Name: CRAW

Version: 1.0

License: MIT

Homepage: https://github.com/SomeTroller77/CRAW

Description

CRAW is a lightweight C library for interacting with the Reddit API.
It provides functionality for authentication and retrieving Reddit data through a simple and modular C interface.

Features

OAuth authentication

Subreddit post retrieval

Comment retrieval

Modular and lightweight C API

Dependencies

cJSON

libcurl

Build System

CMake

Tested Platforms

Linux (GCC)

Notes

The project provides CMake install targets.

The library exports a modern CMake target for linking