### PR TITLE
libxml2: Add version 2.15.2

### DIFF
--- a/recipes/libxml2/cmake/conandata.yml
+++ b/recipes/libxml2/cmake/conandata.yml
@@ -2,12 +2,6 @@ sources:
   "2.15.2":
     url: "https://download.gnome.org/sources/libxml2/2.15/libxml2-2.15.2.tar.xz"
     sha256: "c8b9bc81f8b590c33af8cc6c336dbff2f53409973588a351c95f1c621b13d09d"
-  "2.15.1":
-    url: "https://download.gnome.org/sources/libxml2/2.15/libxml2-2.15.1.tar.xz"
-    sha256: "c008bac08fd5c7b4a87f7b8a71f283fa581d80d80ff8d2efd3b26224c39bc54c"
-  "2.15.0":
-    url: "https://download.gnome.org/sources/libxml2/2.15/libxml2-2.15.0.tar.xz"
-    sha256: "5abc766497c5b1d6d99231f662e30c99402a90d03b06c67b62d6c1179dedd561"
   "2.14.5":
     url: "https://download.gnome.org/sources/libxml2/2.14/libxml2-2.14.5.tar.xz"
     sha256: "03d006f3537616833c16c53addcdc32a0eb20e55443cba4038307e3fa7d8d44b"

--- a/recipes/libxml2/config.yml
+++ b/recipes/libxml2/config.yml
@@ -1,10 +1,6 @@
 versions:
   "2.15.2":
     folder: cmake
-  "2.15.1":
-    folder: cmake
-  "2.15.0":
-    folder: cmake
   "2.14.5":
     folder: cmake
   "2.13.8":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libxml2**

#### Motivation
New upstream release <https://gitlab.gnome.org/GNOME/libxml2/-/blob/v2.15.2/NEWS>

<img width="901" height="968" alt="image" src="https://github.com/user-attachments/assets/1c6eb307-858b-4f1f-9d15-23d11f1c09cf" />


#### Details
Version bump


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
