### PR TITLE
kickcat: add version v2.5

### DIFF
--- a/recipes/kickcat/all/conandata.yml
+++ b/recipes/kickcat/all/conandata.yml
@@ -1,10 +1,5 @@
 sources:
-  "v2.0-rc1":
-    url: "https://github.com/leducp/KickCAT/archive/refs/tags/v2.0-rc1.zip"
-    sha256: "3feec08fd2718d286a041cb83266479840f7739c1203b4450375ea1f59f234c8"
-  "v2-alpha4":
-    url: "https://github.com/leducp/KickCAT/archive/refs/tags/v2-alpha4.zip"
-    sha256: "483a374f77808cb35823652eb37c5ab864a3f12a1c3a957d3315c319ca0ec528"
-  "v2-alpha3":
-    url: "https://github.com/leducp/KickCAT/archive/refs/tags/v2-alpha3.zip"
-    sha256: "dadd8518c3232162b7455fdcd837578120ece5a42c3bc2701147a68cbee60da4"
+  "v2.5":
+    url: "https://github.com/leducp/KickCAT/archive/refs/tags/v2.5.zip"
+    sha256: "838fa44cd86feddfdfb836d3f70eeaff377001caf20696efc942b729cb1f6bc6"
+

--- a/recipes/kickcat/all/conanfile.py
+++ b/recipes/kickcat/all/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
-from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout
+from conan.tools.cmake import CMakeToolchain, CMakeDeps, CMake, cmake_layout
 from conan.tools.files import get, copy
 from conan.tools.scm import Version
 import os
@@ -18,8 +18,8 @@ class KickCATRecipe(ConanFile):
     topics = ("ethercat")
     package_type = "library"
     settings = "os", "compiler", "build_type", "arch"
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": False, "fPIC": True}
+    options = {"shared": [True, False], "fPIC": [True, False], "with_esi_parser": [True, False]}
+    default_options = {"shared": False, "fPIC": True, "with_esi_parser": False}
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -35,7 +35,7 @@ class KickCATRecipe(ConanFile):
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, 17)
 
-        if self.settings.os != "Linux":
+        if self.settings.os not in ["Linux", "baremetal"]:
             raise ConanInvalidConfiguration(
                 f"{self.ref} is not supported on {self.settings.os}.")
 
@@ -46,14 +46,20 @@ class KickCATRecipe(ConanFile):
         if self.settings.compiler == 'gcc' and Version(self.settings.compiler.version) < "7":
             raise ConanInvalidConfiguration("Building requires GCC >= 7")
 
+    def requirements(self):
+        if self.options.with_esi_parser:
+            self.requires("tinyxml2/10.0.0")
+
     def generate(self):
         tc = CMakeToolchain(self)
+        tc.cache_variables["ENABLE_ESI_PARSER"] = bool(self.options.with_esi_parser)
         tc.cache_variables["BUILD_UNIT_TESTS"] = "OFF"
         tc.cache_variables["BUILD_EXAMPLES"] = "OFF"
         tc.cache_variables["BUILD_SIMULATION"] = "OFF"
         tc.cache_variables["BUILD_TOOLS"] = "OFF"
-        tc.cache_variables["DEBUG"] = "OFF"
         tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
 
     def build(self):
         cmake = CMake(self)
@@ -61,8 +67,11 @@ class KickCATRecipe(ConanFile):
         cmake.build()
 
     def package(self):
-        copy(self, "*.h", os.path.join(self.source_folder, "include"),
-             os.path.join(self.package_folder, "include"))
+        src_folders = ["lib/include", "lib/slave/include", "lib/slave/driver/include", "lib/master/include"]
+        for folder in src_folders:
+            copy(self, "*.h", os.path.join(self.source_folder, folder),
+                os.path.join(self.package_folder, "include"))
+
         copy(self, "*.a", self.build_folder,
              os.path.join(self.package_folder, "lib"), keep_path=False)
         copy(self, "*.so", self.build_folder,

--- a/recipes/kickcat/config.yml
+++ b/recipes/kickcat/config.yml
@@ -1,7 +1,3 @@
 versions:
-  "v2.0-rc1":
-    folder: all
-  "v2-alpha4":
-    folder: all
-  "v2-alpha3":
+  "v2.5":
     folder: all


### PR DESCRIPTION
### Summary
kickcat/v2.5: Add new recipe version

#### Motivation
Add support for KickCAT v2.5 in Conan Center Index so the latest upstream release can be consumed through Conan.

#### Details
- Added recipe for kickcat/2.5
- Updated source URL and checksum for the v2.5 release
- Verified the package builds successfully with a recent Conan version
- Update recipe logic

The option is to disable `ENABLE_ESI_PARSER`, which is enabled by default. This was the behavior the library previously had if it found `tinyxml2`, although it wasn’t defined in the recipe. The option helps build a simpler package and maintain behavior closer to what the recipe has done so far. The option has been tested, and the logs are included here: 
[with_esi_parser_log.txt](https://github.com/user-attachments/files/27441624/with_esi_parser_log.txt)
[Comparing v2.1-rc1...v2.5 · leducp/KickCAT](https://github.com/leducp/KickCAT/compare/v2.1-rc1...v2.5#diff-cf8a66a569e01d1af94486f614f7de9a94daa9f8fdf9e50c5fe9d4bd59902e37R1) 

Support for “baremetal” comes from the Conan recipe of upstream and is an option that should always have been accepted, since the library is focused on embedded systems.
[KickCAT/README.md at master · leducp/KickCAT](https://github.com/leducp/KickCAT/blob/master/README.md?plain=1#L21)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
