### PR TITLE
Botan: bump latest version to 3.11.0

### DIFF
--- a/recipes/botan/all/conandata.yml
+++ b/recipes/botan/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "3.10.0":
-    url: "https://github.com/randombit/botan/archive/3.10.0.tar.gz"
-    sha256: "28a98475e05dc2052654397207b4a78e36e6309b662f7f2888feb78cc948cea6"
+  "3.11.0":
+    url: "https://github.com/randombit/botan/archive/3.11.0.tar.gz"
+    sha256: "a8c6428478f23c68792de1b6fbeac6169772e25e6b3dbb5a8b5dd4e393b01b54"
   "3.7.1+rscs1":
     # This is functionally equivalent to the vanilla Botan 3.7.1 release with two
     # backported patches to comply with the technical guidelines published by the

--- a/recipes/botan/config.yml
+++ b/recipes/botan/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "3.10.0":
+  "3.11.0":
     folder: all
   "3.7.1+rscs1":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **botan/3.11.0**

#### Details

New version. Release notes here: https://github.com/randombit/botan/blob/master/news.rst#version-3110-2026-03-15

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
