### PR TITLE
libpq/16: restore windows arm support

### DIFF
--- a/recipes/libpq/all/conanfile.py
+++ b/recipes/libpq/all/conanfile.py
@@ -166,7 +166,8 @@ class LibpqConan(ConanFile):
                 # Interim solution - recipes should move to using meson-based newer libpq
                 replace_in_file(self, solution_pm, "($output =~ /^\/favor:<.+AMD64/m) ? 'x64' : 'Win32';", "'ARM64';")
                 replace_in_file(self, msbuild_project_pm, "$self->{platform} eq 'Win32' ? 'MachineX86' : 'MachineX64';", "'MachineARM64';")
-                replace_in_file(self, msbuild_project_pm, "<RandomizedBaseAddress>false", "<RandomizedBaseAddress>true")
+                if Version(self.version) < '16':
+                    replace_in_file(self, msbuild_project_pm, "<RandomizedBaseAddress>false", "<RandomizedBaseAddress>true")
                 replace_in_file(self, os.path.join(self.source_folder, "src/port/pg_crc32c_sse42.c"), "nmmintrin.h", "intrin.h")
             if self.options.with_openssl:
                 openssl = self.dependencies["openssl"]


### PR DESCRIPTION
### Summary
Changes to recipe:  **libpq/16.***

#### Motivation
the build currently fails on windows arm, because libpq 16 has this change https://github.com/postgres/postgres/commit/36389a060ca6b44d6ccc67653da77562a1ac5bb4

#### Details
current failure
```
ERROR: libpq/16.13: Error in build() method, line 209
	self._patch_sources()
while calling '_patch_sources', line 169
	replace_in_file(self, msbuild_project_pm, "<RandomizedBaseAddress>false", "<RandomizedBaseAddress>true")
	ConanException: replace_in_file didn't find pattern '<RandomizedBaseAddress>false' in 'C:\Users\runner***\.conan2\p\b\libpqfb2921e0f248f\b\src\src\tools\msvc\MSBuildProject.pm' file.
```

the recipe is actually fixed by this change : 
https://github.com/ericLemanissier/cocorepo/actions/runs/23138938533/job/67210002299
https://github.com/ericLemanissier/cocorepo/actions/runs/23138938533/job/67210002368


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
