### PR TITLE
Bumped sqlite3 version, stop publishing revisions for some older versions

### DIFF
--- a/recipes/behaviortree.cpp/all/conanfile.py
+++ b/recipes/behaviortree.cpp/all/conanfile.py
@@ -55,7 +55,7 @@ class BehaviorTreeCPPConan(ConanFile):
         if self.options.enable_groot_interface:
             self.requires("cppzmq/4.11.0")
         if self.options.enable_sqlite_logging:
-            self.requires("sqlite3/3.50.4")
+            self.requires("sqlite3/[>=3.50.4 <4]")
         if self.options.with_tools:
             self.requires("zeromq/4.3.5")
 

--- a/recipes/sqlite3/all/conandata.yml
+++ b/recipes/sqlite3/all/conandata.yml
@@ -2,15 +2,6 @@ sources:
   "3.51.3":
     url: "https://sqlite.org/2026/sqlite-amalgamation-3510300.zip"
     sha256: "acb1e6f5d832484bf6d32b681e858c38add8b2acdfd42ac5df24b8afb46552b4"
-  "3.50.4":
-    url: "https://sqlite.org/2025/sqlite-amalgamation-3500400.zip"
-    sha256: "1d3049dd0f830a025a53105fc79fd2ab9431aea99e137809d064d8ee8356b032"
-  "3.49.2":
-    url: "https://sqlite.org/2025/sqlite-amalgamation-3490200.zip"
-    sha256: "921fc725517a694df7df38a2a3dfede6684024b5788d9de464187c612afb5918"
-  "3.45.3":
-    url: "https://sqlite.org/2024/sqlite-amalgamation-3450300.zip"
-    sha256: "ea170e73e447703e8359308ca2e4366a3ae0c4304a8665896f068c736781c651"
   "3.44.2":
     url: "https://sqlite.org/2023/sqlite-amalgamation-3440200.zip"
     sha256: "833be89b53b3be8b40a2e3d5fedb635080e3edb204957244f3d6987c2bb2345f"

--- a/recipes/sqlite3/config.yml
+++ b/recipes/sqlite3/config.yml
@@ -1,11 +1,5 @@
 versions:
   "3.51.3":
     folder: all
-  "3.50.4":
-    folder: all
-  "3.49.2":
-    folder: all
-  "3.45.3":
-    folder: all
   "3.44.2":
     folder: all


### PR DESCRIPTION
### Summary

* Bumped version from `3.51.0` to `3.51.3`.
* Stop publishing revisions for some older versions.
* Using version range for `behaviortree.cpp` recipe

Closes: https://github.com/conan-io/conan-center-index/issues/29794

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
