### PR TITLE
openexr: Add bugfix version 3.4.7

### DIFF
--- a/recipes/openexr/3.x/conandata.yml
+++ b/recipes/openexr/3.x/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "3.4.6":
-    url: "https://github.com/AcademySoftwareFoundation/openexr/releases/download/v3.4.6/openexr-3.4.6.tar.gz"
-    sha256: "7ef434e434a9ee0e60c2faa952ea1386d251eb98803e8f0924a2a2cdd9e352bf"
+  "3.4.7":
+    url: "https://github.com/AcademySoftwareFoundation/openexr/releases/download/v3.4.7/openexr-3.4.7.tar.gz"
+    sha256: "3744624362dbe6d13985fc73cd67d1ccaa8d0dea97318d27a6dfd5804cdefef5"
   "3.3.8":
     url: "https://github.com/AcademySoftwareFoundation/openexr/releases/download/v3.3.8/openexr-3.3.8.tar.gz"
     sha256: "87e4237e2a7f8fa1e42fb099ff84a7a99c71afe4eb472a0f3963f24f1069f06e"

--- a/recipes/openexr/config.yml
+++ b/recipes/openexr/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "3.4.6":
+  "3.4.7":
     folder: "3.x"
   "3.3.8":
     folder: "3.x"


### PR DESCRIPTION
### Summary
Changes to recipe:  **openexr/3.4.7**

#### Motivation
Bugfix release fixing a buffer overflow and two build fixes (regarding glibc 2.43 and Windows symbol visibility.

#### Details
* https://github.com/AcademySoftwareFoundation/openexr/releases/tag/v3.4.7
* https://github.com/AcademySoftwareFoundation/openexr/compare/v3.4.6..v3.4.7

No build system related changes.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
