### PR TITLE
Qt advanced docking system 4.5.0

### DIFF
--- a/recipes/qt-advanced-docking-system/all/conandata.yml
+++ b/recipes/qt-advanced-docking-system/all/conandata.yml
@@ -5,5 +5,3 @@ sources:
 patches:
   "4.5.0":
     - patch_file: "patches/fix-versioning-no-git.patch"
-      patch_description: "Versioning.cmake unconditionally overwrites PROJECT_VERSION_* with empty strings when git is unavailable (e.g. tarball builds), causing malformed Windows RC files. Only update version variables when git returns a valid tag."
-      patch_type: "bugfix"

--- a/recipes/qt-advanced-docking-system/all/conandata.yml
+++ b/recipes/qt-advanced-docking-system/all/conandata.yml
@@ -2,3 +2,8 @@ sources:
   "4.5.0":
     url: "https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/archive/refs/tags/4.5.0.tar.gz"
     sha256: "a438810b9749684232fa29721857bb700167006f44407ab4dd51f5c90d171f09"
+patches:
+  "4.5.0":
+    - patch_file: "patches/fix-versioning-no-git.patch"
+      patch_description: "Versioning.cmake unconditionally overwrites PROJECT_VERSION_* with empty strings when git is unavailable (e.g. tarball builds), causing malformed Windows RC files. Only update version variables when git returns a valid tag."
+      patch_type: "bugfix"

--- a/recipes/qt-advanced-docking-system/all/conandata.yml
+++ b/recipes/qt-advanced-docking-system/all/conandata.yml
@@ -2,6 +2,3 @@ sources:
   "4.5.0":
     url: "https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/archive/refs/tags/4.5.0.tar.gz"
     sha256: "a438810b9749684232fa29721857bb700167006f44407ab4dd51f5c90d171f09"
-  "4.3.1":
-    url: "https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/archive/refs/tags/4.3.1.tar.gz"
-    sha256: "d7c244d9accaa78766e90124c0ce6054327b78625dae8ba2cfe22fc29dfba37d"

--- a/recipes/qt-advanced-docking-system/all/conandata.yml
+++ b/recipes/qt-advanced-docking-system/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.5.0":
+    url: "https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/archive/refs/tags/4.5.0.tar.gz"
+    sha256: "a438810b9749684232fa29721857bb700167006f44407ab4dd51f5c90d171f09"
   "4.3.1":
     url: "https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/archive/refs/tags/4.3.1.tar.gz"
     sha256: "d7c244d9accaa78766e90124c0ce6054327b78625dae8ba2cfe22fc29dfba37d"

--- a/recipes/qt-advanced-docking-system/all/conanfile.py
+++ b/recipes/qt-advanced-docking-system/all/conanfile.py
@@ -22,6 +22,15 @@ class QtADS(ConanFile):
     homepage = "https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System"
     topics = ("qt", "gui")
 
+    # Note: This recipe supports platform_requires for system Qt on Linux.
+    # However, version 4.3.1 requires Qt private headers and is NOT compatible
+    # with platform_requires. Versions 4.4.1+ work with platform_requires.
+    # Use platform_requires in your profile like:
+    #   [platform_requires]
+    #   qt/6.10.1
+    #   [platform_tool_requires]
+    #   qt/6.10.1
+
     package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
@@ -36,6 +45,11 @@ class QtADS(ConanFile):
 
     @property
     def _qt_major(self):
+        # Handle platform_requires case where Qt is not in dependencies
+        if "qt" not in self.dependencies:
+            # When Qt is from system (platform_requires), default to Qt6
+            # This is a reasonable assumption for modern systems
+            return 6
         return Version(self.dependencies["qt"].ref.version).major
 
     @property
@@ -53,7 +67,7 @@ class QtADS(ConanFile):
 
     def build_requirements(self):
         self.tool_requires("qt/<host_version>")
-        self.tool_requires("cmake/[>=3.27 <4]") # to be able to use CMAKE_AUTOMOC_EXECUTABLE
+        self.tool_requires("cmake/[>=3.27 <5]") # to be able to use CMAKE_AUTOMOC_EXECUTABLE
 
     def validate(self):
         check_min_cppstd(self, self._min_cppstd)
@@ -66,14 +80,23 @@ class QtADS(ConanFile):
         tc.cache_variables["ADS_VERSION"] = self.version
         tc.cache_variables["BUILD_EXAMPLES"] = "OFF"
         tc.cache_variables["BUILD_STATIC"] = not self.options.shared
-        # https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/blob/a16d17a8bf375127847ac8f40af1ebcdb841b13c/src/CMakeLists.txt#L12
-        # TODO: the upstream Qt recipe should expose this variable
-        qt_version = str(self.dependencies["qt"].ref.version)
-        qt_include_root = self.dependencies["qt"].cpp_info.includedirs[0]
-        tc.cache_variables[f"Qt{self._qt_major}Gui_PRIVATE_INCLUDE_DIRS"] = os.path.join(qt_include_root, "QtGui", qt_version, "QtGui")
-        qt_tools_rootdir = self.conf.get("user.qt:tools_directory", None)
-        tc.cache_variables["CMAKE_AUTOMOC_EXECUTABLE"] = os.path.join(qt_tools_rootdir, "moc.exe" if self.settings_build.os == "Windows" else "moc")
-        tc.cache_variables["CMAKE_AUTORCC_EXECUTABLE"] = os.path.join(qt_tools_rootdir, "rcc.exe" if self.settings_build.os == "Windows" else "rcc")
+        # Set module path for Versioning.cmake (needed for ADS >= 4.5.0)
+        if Version(self.version) >= "4.5.0":
+            tc.cache_variables["CMAKE_MODULE_PATH"] = f"{self.source_folder}/cmake/modules"
+
+        # Only set Qt-specific variables when Qt is from Conan (not platform_requires)
+        if "qt" in self.dependencies:
+            # https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/blob/a16d17a8bf375127847ac8f40af1ebcdb841b13c/src/CMakeLists.txt#L12
+            # TODO: the upstream Qt recipe should expose this variable
+            qt_version = str(self.dependencies["qt"].ref.version)
+            qt_include_root = self.dependencies["qt"].cpp_info.includedirs[0]
+            tc.cache_variables[f"Qt{self._qt_major}Gui_PRIVATE_INCLUDE_DIRS"] = os.path.join(qt_include_root, "QtGui", qt_version, "QtGui")
+            qt_tools_rootdir = self.conf.get("user.qt:tools_directory", None)
+            if qt_tools_rootdir:
+                tc.cache_variables["CMAKE_AUTOMOC_EXECUTABLE"] = os.path.join(qt_tools_rootdir, "moc.exe" if self.settings_build.os == "Windows" else "moc")
+                tc.cache_variables["CMAKE_AUTORCC_EXECUTABLE"] = os.path.join(qt_tools_rootdir, "rcc.exe" if self.settings_build.os == "Windows" else "rcc")
+        # When Qt is from system (platform_requires), CMake find_package will handle it
+
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()
@@ -92,15 +115,26 @@ class QtADS(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
-        if Version(self.version) >= 4:
-            name = f"qt{self._qt_major}advanceddocking"
-            self.cpp_info.includedirs.append(os.path.join("include", name))
-            lib_name = f"{name}d" if self.settings.build_type == "Debug" else name
+        if Version(self.version) >= "4.4":
+            # ADS 4.4+ uses naming: qtadvanceddocking-qt{major}
+            base_name = f"qtadvanceddocking-qt{self._qt_major}"
+            # Include directory uses the same naming as the library
+            self.cpp_info.includedirs.append(os.path.join("include", base_name))
+            # For CMake target, use the consolidated name without hyphen for compatibility
+            cmake_name = f"qt{self._qt_major}advanceddocking"
+            lib_name = f"{base_name}d" if self.settings.build_type == "Debug" else base_name
+        elif Version(self.version) >= 4:
+            # ADS 4.0-4.3 uses naming: qt{major}advanceddocking (no hyphen)
+            base_name = f"qt{self._qt_major}advanceddocking"
+            self.cpp_info.includedirs.append(os.path.join("include", base_name))
+            cmake_name = base_name
+            lib_name = f"{base_name}d" if self.settings.build_type == "Debug" else base_name
         else:
             lib_name = "qtadvanceddocking"
+            cmake_name = lib_name
 
-        self.cpp_info.set_property("cmake_file_name", lib_name)
-        self.cpp_info.set_property("cmake_target_name", f"ads::{lib_name}")
+        self.cpp_info.set_property("cmake_file_name", cmake_name)
+        self.cpp_info.set_property("cmake_target_name", f"ads::{cmake_name}")
 
         if self.options.shared:
             self.cpp_info.libs = [lib_name]

--- a/recipes/qt-advanced-docking-system/all/conanfile.py
+++ b/recipes/qt-advanced-docking-system/all/conanfile.py
@@ -3,7 +3,7 @@ import os
 from conan import ConanFile
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import apply_conandata_patches, copy, get, rmdir
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, copy, get, rmdir
 from conan.tools.scm import Version
 
 required_conan_version = ">=2.0.9"
@@ -33,7 +33,6 @@ class QtADS(ConanFile):
         "fPIC": True,
     }
     implements = ["auto_shared_fpic"]
-    exports_sources = "patches/*"
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -43,12 +42,14 @@ class QtADS(ConanFile):
 
     def build_requirements(self):
         self.tool_requires("qt/<host_version>")
-        self.tool_requires("cmake/[>=3.27 <5]") # to be able to use CMAKE_AUTOMOC_EXECUTABLE
+        self.tool_requires("cmake/[>=3.27]") # to be able to use CMAKE_AUTOMOC_EXECUTABLE
 
     def validate(self):
         if Version(self.dependencies["qt"].ref.version) >= "6.0.0":
-            # Qt6 requires C++17 as a minimum
-            check_min_cppstd(self, 17)
+            check_min_cppstd(self, 17) # Qt6 requires C++17 as a minimum
+
+    def export_sources(self):
+        export_conandata_patches(self)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/qt-advanced-docking-system/all/conanfile.py
+++ b/recipes/qt-advanced-docking-system/all/conanfile.py
@@ -1,8 +1,10 @@
 import os
 
 from conan import ConanFile
+from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir
+from conan.tools.scm import Version
 
 required_conan_version = ">=2.0.9"
 
@@ -42,6 +44,11 @@ class QtADS(ConanFile):
         self.tool_requires("qt/<host_version>")
         self.tool_requires("cmake/[>=3.27 <5]") # to be able to use CMAKE_AUTOMOC_EXECUTABLE
 
+    def validate(self):
+        if Version(self.dependencies["qt"].ref.version) >= "6.0.0":
+            # Qt6 requires C++17 as a minimum
+            check_min_cppstd(self, 17)
+
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
@@ -79,7 +86,7 @@ class QtADS(ConanFile):
 
     def package_info(self):
         # Detect Qt major version from installed include directory name
-        qt_major = 6 if os.path.isdir(os.path.join(self.package_folder, "include", "qtadvanceddocking-qt6")) else 5
+        qt_major = 6 if Version(self.dependencies["qt"].ref.version) >= "6.0.0" else 5
 
         base_name = f"qtadvanceddocking-qt{qt_major}"
         self.cpp_info.includedirs.append(os.path.join("include", base_name))

--- a/recipes/qt-advanced-docking-system/all/conanfile.py
+++ b/recipes/qt-advanced-docking-system/all/conanfile.py
@@ -60,7 +60,7 @@ class QtADS(ConanFile):
         # The upstream CMakeLists.txt only sets CMAKE_MODULE_PATH inside an
         # if(NOT ADS_VERSION) block. Since we supply ADS_VERSION, that block is
         # skipped and src/CMakeLists.txt cannot find Versioning.cmake.
-        tc.cache_variables["CMAKE_MODULE_PATH"] = f"{self.source_folder}/cmake/modules"
+        tc.cache_variables["CMAKE_MODULE_PATH"] = os.path.join(self.source_folder, "cmake", "modules").replace("\\", "/")
 
         qt_tools_rootdir = self.conf.get("user.qt:tools_directory", None)
         if qt_tools_rootdir:

--- a/recipes/qt-advanced-docking-system/all/conanfile.py
+++ b/recipes/qt-advanced-docking-system/all/conanfile.py
@@ -3,7 +3,7 @@ import os
 from conan import ConanFile
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, get, rmdir
+from conan.tools.files import apply_conandata_patches, copy, get, rmdir
 from conan.tools.scm import Version
 
 required_conan_version = ">=2.0.9"
@@ -33,6 +33,7 @@ class QtADS(ConanFile):
         "fPIC": True,
     }
     implements = ["auto_shared_fpic"]
+    exports_sources = "patches/*"
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -51,6 +52,7 @@ class QtADS(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/recipes/qt-advanced-docking-system/all/conanfile.py
+++ b/recipes/qt-advanced-docking-system/all/conanfile.py
@@ -1,10 +1,8 @@
 import os
 
 from conan import ConanFile
-from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir
-from conan.tools.scm import Version
 
 required_conan_version = ">=2.0.9"
 
@@ -22,15 +20,6 @@ class QtADS(ConanFile):
     homepage = "https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System"
     topics = ("qt", "gui")
 
-    # Note: This recipe supports platform_requires for system Qt on Linux.
-    # However, version 4.3.1 requires Qt private headers and is NOT compatible
-    # with platform_requires. Versions 4.4.1+ work with platform_requires.
-    # Use platform_requires in your profile like:
-    #   [platform_requires]
-    #   qt/6.10.1
-    #   [platform_tool_requires]
-    #   qt/6.10.1
-
     package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
@@ -43,22 +32,6 @@ class QtADS(ConanFile):
     }
     implements = ["auto_shared_fpic"]
 
-    @property
-    def _qt_major(self):
-        # Handle platform_requires case where Qt is not in dependencies
-        if "qt" not in self.dependencies:
-            # When Qt is from system (platform_requires), default to Qt6
-            # This is a reasonable assumption for modern systems
-            return 6
-        return Version(self.dependencies["qt"].ref.version).major
-
-    @property
-    def _min_cppstd(self):
-        if self._qt_major >= 6:
-            return 17
-        else:
-            return 14
-
     def layout(self):
         cmake_layout(self, src_folder="src")
 
@@ -69,9 +42,6 @@ class QtADS(ConanFile):
         self.tool_requires("qt/<host_version>")
         self.tool_requires("cmake/[>=3.27 <5]") # to be able to use CMAKE_AUTOMOC_EXECUTABLE
 
-    def validate(self):
-        check_min_cppstd(self, self._min_cppstd)
-
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
@@ -80,22 +50,15 @@ class QtADS(ConanFile):
         tc.cache_variables["ADS_VERSION"] = self.version
         tc.cache_variables["BUILD_EXAMPLES"] = "OFF"
         tc.cache_variables["BUILD_STATIC"] = not self.options.shared
-        # Set module path for Versioning.cmake (needed for ADS >= 4.5.0)
-        if Version(self.version) >= "4.5.0":
-            tc.cache_variables["CMAKE_MODULE_PATH"] = f"{self.source_folder}/cmake/modules"
+        # The upstream CMakeLists.txt only sets CMAKE_MODULE_PATH inside an
+        # if(NOT ADS_VERSION) block. Since we supply ADS_VERSION, that block is
+        # skipped and src/CMakeLists.txt cannot find Versioning.cmake.
+        tc.cache_variables["CMAKE_MODULE_PATH"] = f"{self.source_folder}/cmake/modules"
 
-        # Only set Qt-specific variables when Qt is from Conan (not platform_requires)
-        if "qt" in self.dependencies:
-            # https://github.com/githubuser0xFFFF/Qt-Advanced-Docking-System/blob/a16d17a8bf375127847ac8f40af1ebcdb841b13c/src/CMakeLists.txt#L12
-            # TODO: the upstream Qt recipe should expose this variable
-            qt_version = str(self.dependencies["qt"].ref.version)
-            qt_include_root = self.dependencies["qt"].cpp_info.includedirs[0]
-            tc.cache_variables[f"Qt{self._qt_major}Gui_PRIVATE_INCLUDE_DIRS"] = os.path.join(qt_include_root, "QtGui", qt_version, "QtGui")
-            qt_tools_rootdir = self.conf.get("user.qt:tools_directory", None)
-            if qt_tools_rootdir:
-                tc.cache_variables["CMAKE_AUTOMOC_EXECUTABLE"] = os.path.join(qt_tools_rootdir, "moc.exe" if self.settings_build.os == "Windows" else "moc")
-                tc.cache_variables["CMAKE_AUTORCC_EXECUTABLE"] = os.path.join(qt_tools_rootdir, "rcc.exe" if self.settings_build.os == "Windows" else "rcc")
-        # When Qt is from system (platform_requires), CMake find_package will handle it
+        qt_tools_rootdir = self.conf.get("user.qt:tools_directory", None)
+        if qt_tools_rootdir:
+            tc.cache_variables["CMAKE_AUTOMOC_EXECUTABLE"] = os.path.join(qt_tools_rootdir, "moc.exe" if self.settings_build.os == "Windows" else "moc")
+            tc.cache_variables["CMAKE_AUTORCC_EXECUTABLE"] = os.path.join(qt_tools_rootdir, "rcc.exe" if self.settings_build.os == "Windows" else "rcc")
 
         tc.generate()
         deps = CMakeDeps(self)
@@ -115,23 +78,13 @@ class QtADS(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
-        if Version(self.version) >= "4.4":
-            # ADS 4.4+ uses naming: qtadvanceddocking-qt{major}
-            base_name = f"qtadvanceddocking-qt{self._qt_major}"
-            # Include directory uses the same naming as the library
-            self.cpp_info.includedirs.append(os.path.join("include", base_name))
-            # For CMake target, use the consolidated name without hyphen for compatibility
-            cmake_name = f"qt{self._qt_major}advanceddocking"
-            lib_name = f"{base_name}d" if self.settings.build_type == "Debug" else base_name
-        elif Version(self.version) >= 4:
-            # ADS 4.0-4.3 uses naming: qt{major}advanceddocking (no hyphen)
-            base_name = f"qt{self._qt_major}advanceddocking"
-            self.cpp_info.includedirs.append(os.path.join("include", base_name))
-            cmake_name = base_name
-            lib_name = f"{base_name}d" if self.settings.build_type == "Debug" else base_name
-        else:
-            lib_name = "qtadvanceddocking"
-            cmake_name = lib_name
+        # Detect Qt major version from installed include directory name
+        qt_major = 6 if os.path.isdir(os.path.join(self.package_folder, "include", "qtadvanceddocking-qt6")) else 5
+
+        base_name = f"qtadvanceddocking-qt{qt_major}"
+        self.cpp_info.includedirs.append(os.path.join("include", base_name))
+        cmake_name = f"qt{qt_major}advanceddocking"
+        lib_name = f"{base_name}d" if self.settings.build_type == "Debug" else base_name
 
         self.cpp_info.set_property("cmake_file_name", cmake_name)
         self.cpp_info.set_property("cmake_target_name", f"ads::{cmake_name}")

--- a/recipes/qt-advanced-docking-system/all/patches/fix-versioning-no-git.patch
+++ b/recipes/qt-advanced-docking-system/all/patches/fix-versioning-no-git.patch
@@ -1,3 +1,6 @@
+Versioning.cmake unconditionally overwrites PROJECT_VERSION_* with empty strings when git is unavailable
+causing malformed Windows RC files. The package build is not built from git.
+
 --- a/cmake/modules/Versioning.cmake
 +++ b/cmake/modules/Versioning.cmake
 @@ -24,10 +24,12 @@ string(REGEX REPLACE "^v" "" GIT_DESC "${GIT_DESC_RAW}")

--- a/recipes/qt-advanced-docking-system/all/patches/fix-versioning-no-git.patch
+++ b/recipes/qt-advanced-docking-system/all/patches/fix-versioning-no-git.patch
@@ -1,0 +1,19 @@
+--- a/cmake/modules/Versioning.cmake
++++ b/cmake/modules/Versioning.cmake
+@@ -24,10 +24,12 @@ string(REGEX REPLACE "^v" "" GIT_DESC "${GIT_DESC_RAW}")
+
+ # Extract major.minor.patch
+ string(REGEX MATCH "^([0-9]+)\\.([0-9]+)\\.([0-9]+)" _ "${GIT_DESC}")
+-set(PROJECT_VERSION_MAJOR "${CMAKE_MATCH_1}")
+-set(PROJECT_VERSION_MINOR "${CMAKE_MATCH_2}")
+-set(PROJECT_VERSION_PATCH "${CMAKE_MATCH_3}")
+-
++if(CMAKE_MATCH_1)
++    set(PROJECT_VERSION_MAJOR "${CMAKE_MATCH_1}")
++    set(PROJECT_VERSION_MINOR "${CMAKE_MATCH_2}")
++    set(PROJECT_VERSION_PATCH "${CMAKE_MATCH_3}")
++endif()
++# If git is not available, PROJECT_VERSION_* retain values set by project()
+ set(PROJECT_VERSION_STRING
+     "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}"
+ )

--- a/recipes/qt-advanced-docking-system/all/test_package/CMakeLists.txt
+++ b/recipes/qt-advanced-docking-system/all/test_package/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.15)
 project(test_package CXX)
 
-find_package(qt6advanceddocking REQUIRED CONFIG)
-find_package(Qt6 REQUIRED)
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core Gui Widgets)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Gui Widgets)
+find_package(qt${QT_VERSION_MAJOR}advanceddocking REQUIRED CONFIG)
 add_executable(example example.cpp)
-target_link_libraries(example ads::qt6advanceddocking Qt6::Core)
+target_link_libraries(example ads::qt${QT_VERSION_MAJOR}advanceddocking Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Gui Qt${QT_VERSION_MAJOR}::Widgets)

--- a/recipes/qt-advanced-docking-system/config.yml
+++ b/recipes/qt-advanced-docking-system/config.yml
@@ -1,5 +1,3 @@
 versions:
   "4.5.0":
     folder: "all"
-  "4.3.1":
-    folder: "all"

--- a/recipes/qt-advanced-docking-system/config.yml
+++ b/recipes/qt-advanced-docking-system/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "4.5.0":
+    folder: "all"
   "4.3.1":
     folder: "all"


### PR DESCRIPTION
### Summary
Changes to recipe: **qt-advanced-docking-system/all**

#### Motivation
This PR adds the latest upstream versions (4.5.0 and 4.4.1) of Qt Advanced Docking System and introduces support for `platform_requires`. The `platform_requires` feature enables users to build against system-installed Qt instead of building Qt from Conan, which is particularly valuable for:
- Systems with non-standard filesystem layouts (NixOS, Guix, etc.) where dynamically-linked executables from generic Linux distributions don't work
- Environments where Qt is already installed and configured system-wide
- Faster builds when Qt is available locally

Additionally, this PR fixes several compatibility issues discovered during testing, including CMake 4.x support, Qt5/Qt6 test_package compatibility, and version-specific library naming corrections.

#### Details

**New Versions Added:**
- 4.5.0 (latest upstream release)
- 4.4.1

**platform_requires Support:**
The recipe now detects when Qt comes from `platform_requires` by checking `if "qt" not in self.dependencies` and skips Conan-specific Qt configuration, allowing CMake's `find_package` to locate the system Qt installation.

Example profile usage:
```ini
[platform_requires]
qt/6.10.1

[platform_tool_requires]
qt/6.10.1
```

**Important limitations:**
- Version 4.3.1 requires Qt private headers and is NOT compatible with `platform_requires`
- Version 4.4.1 has upstream build system issues with Qt5 (requires private headers but build system doesn't expose them properly)
- **Recommendation:** Use Qt6 for `platform_requires` - Qt5 has limited compatibility

**Bug Fixes:**

1. **CMake 4.x compatibility**: Updated cmake requirement from `[>=3.27 <4]` to `[>=3.27 <5]` to support cmake 4.x

2. **test_package Qt5/Qt6 compatibility**: Fixed test_package to dynamically detect Qt major version using `Qt${QT_VERSION_MAJOR}` variables instead of hardcoding Qt6

3. **Library naming fix for 4.0-4.3.x**: Fixed `package_info()` to correctly handle library naming differences:
   - Versions 4.0-4.3.x: `qt{major}advanceddocking` (e.g., `libqt6advanceddocking_static.a`)
   - Versions 4.4+: `qtadvanceddocking-qt{major}` (e.g., `libqtadvanceddocking-qt6_static.a`)

4. **CMAKE_AUTOMOC_EXECUTABLE conditional fix**: Only set CMAKE_AUTOMOC_EXECUTABLE and CMAKE_AUTORCC_EXECUTABLE when `user.qt:tools_directory` config is provided

**Development Note:**
This PR was developed with assistance from Claude Code for implementation and testing automation. All changes have been personally reviewed and tested by the contributor.

**Testing:**

*Qt6 (Comprehensive):*
- Platform_requires (NixOS): Versions 4.5.0 and 4.4.1 with system Qt 6.10.1 and cmake 4.1.2 (shared builds)
- Traditional Conan (Ubuntu): All three versions (4.3.1, 4.4.1, 4.5.0) with Qt and cmake from Conan (both static and shared builds)
- **Result:** All 8 Qt6 test configurations passed ✅

*Qt5 (Limited):*
- Tested with Qt 5.15.18 from Conan on Ubuntu
- ✅ Versions 4.3.1 and 4.5.0 build successfully
- ❌ Version 4.4.1 fails (upstream build system issue with private Qt headers)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
