### PR TITLE
libcurl: Fixed breaking if-else

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -713,14 +713,14 @@ class LibcurlConan(ConanFile):
 
         if self.options.with_ssl == "openssl":
             self.cpp_info.components["curl"].requires.append("openssl::openssl")
-        if self.settings.os == "Linux" and self.options.with_ldap:
-            self.cpp_info.components["curl"].requires.append("openldap::openldap")
         if self.options.with_ssl == "libressl":
             self.cpp_info.components["curl"].requires.append("libressl::libressl")
         if self.options.with_ssl == "wolfssl":
             self.cpp_info.components["curl"].requires.append("wolfssl::wolfssl")
         if self.options.with_ssl == "mbedtls":
             self.cpp_info.components["curl"].requires.append("mbedtls::mbedtls")
+        if self.settings.os == "Linux" and self.options.with_ldap:
+            self.cpp_info.components["curl"].requires.append("openldap::openldap")
         if self.options.with_nghttp2:
             self.cpp_info.components["curl"].requires.append("libnghttp2::libnghttp2")
         if self.options.with_libssh2:


### PR DESCRIPTION
Hi, I think that latest PR made after 8.18.0 update broke libcurl recipe. I note it here #29762

this commit https://github.com/conan-io/conan-center-index/commit/6298c3e2e2ba6b3ed45540cd4c46b30b934f4753 add unrelated code in between `if: -> elif:`  handling of `with_ssl` option

```python
        if self.options.with_ssl == "openssl":
            self.requires(f"openssl/[>=3 <4]")
        if self.settings.os == "Linux" and self.options.with_ldap:     #  THIS ISADDED IN BETWEEN self.options.with_ssl if -> elif
            self.requires("openldap/[>=2.6 <3]")                              #  <<<<< !!!!!!!!!!!!!!!!!!
        elif self.options.with_ssl == "libressl":
            self.requires("libressl/[>=3.5 <4]")
        elif self.options.with_ssl == "wolfssl":
            self.requires("wolfssl/5.6.6")
```

_Originally posted by @HekyM in https://github.com/conan-io/conan-center-index/issues/29762#issuecomment-4082586969_

Closes: https://github.com/conan-io/conan-center-index/issues/29804

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
