### PR TITLE
wiringpi: CMake 4 support and stop publishing revisions for older versions

### DIFF
--- a/recipes/wiringpi/all/CMakeLists.txt
+++ b/recipes/wiringpi/all/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.15)
 project(wiringPi LANGUAGES C)
 
 file(GLOB SRC_FILES ${WIRINGPI_SRC_DIR}/wiringPi/*.c)

--- a/recipes/wiringpi/all/conandata.yml
+++ b/recipes/wiringpi/all/conandata.yml
@@ -2,24 +2,3 @@ sources:
   "3.10":
     url: "https://github.com/WiringPi/WiringPi/archive/refs/tags/3.10.tar.gz"
     sha256: "d0a7b182154e763b4baff1a57a5e0fca093fcf081f663cb2fb17f5ada564e016"
-  "3.8":
-    url: "https://github.com/WiringPi/WiringPi/archive/refs/tags/3.8.tar.gz"
-    sha256: "6159764d3d036486f0a110cd5393b1413c1f334d464b7337117fece59ea04bc9"
-  "3.6":
-    url: "https://github.com/WiringPi/WiringPi/archive/refs/tags/3.6.tar.gz"
-    sha256: "bec180a14ccd2d6b4eb5248d6553593511e7881348f56f8c98515a6d5d5444ee"
-  "3.4":
-    url: "https://github.com/WiringPi/WiringPi/archive/refs/tags/3.4.tar.gz"
-    sha256: "a81219e9ea0ce08295d2fc0457c69c4df0c6d2e846cb5817ba3247f673480d55"
-  "3.2":
-    url: "https://github.com/WiringPi/WiringPi/archive/refs/tags/3.2.tar.gz"
-    sha256: "45aeaf52d86631edb7a5c82a4f6d0050ef10c8b4de6c566cd8017fc52a17b68e"
-  "2.61-1":
-    url: "https://github.com/WiringPi/WiringPi/archive/refs/tags/2.61-1.tar.gz"
-    sha256: "b5dc6c6c2ba1349acf602fafd7b58aa81e3fc3216a33b983386264cca0033e12"
-  "cci.20210727":
-    url: "https://github.com/WiringPi/WiringPi/archive/7f8fe26e4f775abfced43c07657a353f03ddb2d0.tar.gz"
-    sha256: "d85f063b1bfe73fd23ed20a3dfb7968be97172a78113d510e2a5f7ddeacc4799"
-  "2.50":
-    url: "https://github.com/WiringPi/WiringPi/archive/final_official_2.50.tar.gz"
-    sha256: "f1ddf17e876f88e074d4597767e365a1b5ef20414a38754884935b38d8c8e932"

--- a/recipes/wiringpi/all/conanfile.py
+++ b/recipes/wiringpi/all/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import get, copy
 from conan.tools.scm import Version
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.4"
 
 class WiringpiConan(ConanFile):
     name = "wiringpi"
@@ -28,6 +28,7 @@ class WiringpiConan(ConanFile):
         "wpi_extensions": False,
         "with_devlib": True,
     }
+    languages = "C"
 
     def export_sources(self):
         copy(self, "CMakeLists.txt", self.recipe_folder, self.export_sources_folder)
@@ -35,39 +36,34 @@ class WiringpiConan(ConanFile):
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
-        self.settings.rm_safe("compiler.libcxx")
-        self.settings.rm_safe("compiler.cppstd")
 
     def layout(self):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        if  Version(self.version) >= "3.2":
-            self.requires("linux-headers-generic/6.5.9", transitive_headers=True)
+        self.requires("linux-headers-generic/6.5.9", transitive_headers=True)
 
     def validate(self):
         if self.settings.os != "Linux":
             raise ConanInvalidConfiguration(f"{self.ref} only works for Linux")
-        if Version(self.version) >= 3.0:
-            if self.settings.compiler == "gcc" and \
-                Version(self.settings.compiler.version) < 8:
-                raise ConanInvalidConfiguration(f"{self.ref} requires gcc >= 8")
-            # wiringPi.c:1755:9: error: case label does not reduce to an integer constant
-            if self.settings.compiler == "gcc" and \
-                Version(self.settings.compiler.version).major == 11 and \
-                self.settings.build_type == "Debug":
-                raise ConanInvalidConfiguration(f"{self.ref} doesn't support gcc 11 in Debug build")
+        if self.settings.compiler == "gcc" and \
+            Version(self.settings.compiler.version) < 8:
+            raise ConanInvalidConfiguration(f"{self.ref} requires gcc >= 8")
+        # wiringPi.c:1755:9: error: case label does not reduce to an integer constant
+        if self.settings.compiler == "gcc" and \
+            Version(self.settings.compiler.version).major == 11 and \
+            self.settings.build_type == "Debug":
+            raise ConanInvalidConfiguration(f"{self.ref} doesn't support gcc 11 in Debug build")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["WIRINGPI_SRC_DIR"] = self.source_folder.replace("\\", "/")
-        tc.variables["WIRINGPI_WITH_WPI_EXTENSIONS"] = self.options.wpi_extensions
-        tc.variables["WIRINGPI_WITH_DEV_LIB"] = self.options.with_devlib
-        if  Version(self.version) >= "3.2":
-            tc.variables["WIRINGPI_LINUX_HEADERS_DIR"] = self.dependencies["linux-headers-generic"].cpp_info.includedirs[0]
+        tc.cache_variables["WIRINGPI_SRC_DIR"] = self.source_folder.replace("\\", "/")
+        tc.cache_variables["WIRINGPI_WITH_WPI_EXTENSIONS"] = self.options.wpi_extensions
+        tc.cache_variables["WIRINGPI_WITH_DEV_LIB"] = self.options.with_devlib
+        tc.cache_variables["WIRINGPI_LINUX_HEADERS_DIR"] = self.dependencies["linux-headers-generic"].cpp_info.includedirs[0]
         tc.generate()
 
     def build(self):

--- a/recipes/wiringpi/config.yml
+++ b/recipes/wiringpi/config.yml
@@ -1,17 +1,3 @@
 versions:
   "3.10":
     folder: "all"
-  "3.8":
-    folder: "all"
-  "3.6":
-    folder: "all"
-  "3.4":
-    folder: "all"
-  "3.2":
-    folder: "all"
-  "2.61-1":
-    folder: "all"
-  "cci.20210727":
-    folder: "all"
-  "2.50":
-    folder: "all"


### PR DESCRIPTION
### Summary
Changes to recipe:  **wiringpi**

#### Motivation

Reported in https://github.com/conan-io/conan-center-index/issues/26878#issuecomment-3946618570

#### Details
- Stop publishing revisions for older versions (they are still available on the conancenter remote!!).
- Clean proper "dead/inaccessible" branches.
- Remove some legacy Conan v1 code.

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
