### PR TITLE
cuda-api-wrappers: add version 0.8.2

### DIFF
--- a/recipes/cuda-api-wrappers/all/conandata.yml
+++ b/recipes/cuda-api-wrappers/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.8.2":
+    url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.8.2.tar.gz"
+    sha256: "14e0558bb6851600bd674b18b7416ca678ae3dc45198875d552fc826fded4c7e"
   "0.8.1":
     url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.8.1.tar.gz"
     sha256: "f5ccadf51455fa1154a0ac730c5dc3894d339ae87413c39f63bd5fa27a48ddba"

--- a/recipes/cuda-api-wrappers/config.yml
+++ b/recipes/cuda-api-wrappers/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.8.2":
+    folder: all
   "0.8.1":
     folder: all
   "0.8.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **cuda-api-wrappers/0.8.2**

#### Motivation
- Updates `cuda-api-wrappers` to 0.8.2

#### Details
- Add the newest 0.8.2 `cuda-api-wrappers` version


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
