### PR TITLE
logme: add version 2.4.13

### DIFF
--- a/recipes/logme/all/conandata.yml
+++ b/recipes/logme/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "2.4.10":
     url: "https://github.com/efmsoft/logme/archive/refs/tags/v2.4.10.tar.gz"
     sha256: "4cdc715b30320a342680b9222ada4ef672eccd8f44dbe835d718bec3e3f11471"
+  "2.4.13":
+    url: "https://github.com/efmsoft/logme/archive/refs/tags/v2.4.13.tar.gz"
+    sha256: "60625105dad590f677416e128315cb0644db16212b05e66ff22ff9326ff992b8"

--- a/recipes/logme/config.yml
+++ b/recipes/logme/config.yml
@@ -1,3 +1,5 @@
 versions:
   "2.4.10":
     folder: all
+  "2.4.13":
+    folder: all


### PR DESCRIPTION
Summary

Changes to recipe: logme/2.4.13

Motivation

New upstream release.

Details

Added version 2.4.13 to config.yml

Added source URL and sha256 for 2.4.13 to conandata.yml

No changes to the recipe logic are required

 Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)

 Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)

 If this is a bug fix, please link related issue or provide bug details

 Tested locally with at least one configuration using a recent version of Conan