### PR TITLE
freetype: update recipe to add support for 2.14.3

### DIFF
--- a/recipes/freetype/config.yml
+++ b/recipes/freetype/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "2.14.2":
+  "2.14.3":
     folder: meson
   "2.14.1":
     folder: meson

--- a/recipes/freetype/config.yml
+++ b/recipes/freetype/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.14.2":
+    folder: meson
   "2.14.1":
     folder: meson
   "2.13.3":

--- a/recipes/freetype/meson/conandata.yml
+++ b/recipes/freetype/meson/conandata.yml
@@ -1,9 +1,9 @@
 sources:
-  "2.14.2":
+  "2.14.3":
     url:
-      - "https://download.savannah.gnu.org/releases/freetype/freetype-2.14.2.tar.xz"
-      - "https://sourceforge.net/projects/freetype/files/freetype2/2.14.2/freetype-2.14.2.tar.xz"
-    sha256: "4b62dcab4c920a1a860369933221814362e699e26f55792516d671e6ff55b5e1"
+      - "https://download.savannah.gnu.org/releases/freetype/freetype-2.14.3.tar.xz"
+      - "https://sourceforge.net/projects/freetype/files/freetype2/2.14.3/freetype-2.14.3.tar.xz"
+    sha256: "36bc4f1cc413335368ee656c42afca65c5a3987e8768cc28cf11ba775e785a5f"
   "2.14.1":
     url:
       - "https://download.savannah.gnu.org/releases/freetype/freetype-2.14.1.tar.xz"

--- a/recipes/freetype/meson/conandata.yml
+++ b/recipes/freetype/meson/conandata.yml
@@ -1,4 +1,9 @@
 sources:
+  "2.14.2":
+    url:
+      - "https://download.savannah.gnu.org/releases/freetype/freetype-2.14.2.tar.xz"
+      - "https://sourceforge.net/projects/freetype/files/freetype2/2.14.2/freetype-2.14.2.tar.xz"
+    sha256: "4b62dcab4c920a1a860369933221814362e699e26f55792516d671e6ff55b5e1"
   "2.14.1":
     url:
       - "https://download.savannah.gnu.org/releases/freetype/freetype-2.14.1.tar.xz"


### PR DESCRIPTION
### Summary
Changes to recipe:  **freetype/2.14.2**

#### Motivation
Include patch for https://www.cve.org/CVERecord?id=CVE-2026-23865.

#### Details
Updated `config.yml` and `conandata.yml`. Seen several versions are still supported by the recipe, I left the existing version. I assumed they are necessary for other recipies.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
