### PR TITLE
capstone: Add 'arm64' and 'aarch64' to supported architectures

### DIFF
--- a/recipes/capstone/all/conandata.yml
+++ b/recipes/capstone/all/conandata.yml
@@ -2,6 +2,3 @@ sources:
   "5.0.6":
     url: "https://github.com/capstone-engine/capstone/archive/refs/tags/5.0.6.tar.gz"
     sha256: "240ebc834c51aae41ca9215d3190cc372fd132b9c5c8aa2d5f19ca0c325e28f9"
-  "5.0.7":
-    url: "https://github.com/capstone-engine/capstone/archive/refs/tags/5.0.7.tar.gz"
-    sha256: "6427a724726d161d1e05fb49fff8cd0064f67836c04ffca3c11d6d859e719caa"

--- a/recipes/capstone/all/conanfile.py
+++ b/recipes/capstone/all/conanfile.py
@@ -42,6 +42,12 @@ class CapstoneConan(ConanFile):
     options.update({a: [True, False] for a in _archs})
     default_options.update({a: True for a in _archs})
 
+    def config_options(self):
+        if str(self.version).startswith("5."):
+            del self.options.aarch64
+        else:
+            del self.options.arm64
+        
     def layout(self):
         cmake_layout(self, src_folder="src")
 

--- a/recipes/capstone/all/conanfile.py
+++ b/recipes/capstone/all/conanfile.py
@@ -38,7 +38,7 @@ class CapstoneConan(ConanFile):
     implements = ["auto_shared_fpic"]
     languages = "C"
 
-    _archs = ["arm", "m68k", "mips", "ppc", "sparc", "sysz", "xcore", "x86", "tms320c64x", "m680x", "evm"]
+    _archs = ["arm", "arm64", "aarch64", "m68k", "mips", "ppc", "sparc", "sysz", "xcore", "x86", "tms320c64x", "m680x", "evm"]
     options.update({a: [True, False] for a in _archs})
     default_options.update({a: True for a in _archs})
 

--- a/recipes/capstone/all/conanfile.py
+++ b/recipes/capstone/all/conanfile.py
@@ -38,15 +38,9 @@ class CapstoneConan(ConanFile):
     implements = ["auto_shared_fpic"]
     languages = "C"
 
-    _archs = ["arm", "arm64", "aarch64", "m68k", "mips", "ppc", "sparc", "sysz", "xcore", "x86", "tms320c64x", "m680x", "evm"]
+    _archs = ["arm", "arm64", "m68k", "mips", "ppc", "sparc", "sysz", "xcore", "x86", "tms320c64x", "m680x", "evm"]
     options.update({a: [True, False] for a in _archs})
     default_options.update({a: True for a in _archs})
-
-    def config_options(self):
-        if str(self.version).startswith("5."):
-            del self.options.aarch64
-        else:
-            del self.options.arm64
         
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -66,6 +60,8 @@ class CapstoneConan(ConanFile):
         tc.cache_variables["CAPSTONE_USE_DEFAULT_ALLOC"] = self.options.use_default_alloc
         for a in self._archs:
             tc.cache_variables[f"CAPSTONE_{a.upper()}_SUPPORT"] = self.options.get_safe(a)
+        # Newer versions have aarch64 naming for arm64
+        tc.cache_variables["CAPSTONE_AARCH64_SUPPORT"] = self.options.get_safe("arm64")
 
         tc.generate()
 

--- a/recipes/capstone/all/conanfile.py
+++ b/recipes/capstone/all/conanfile.py
@@ -38,7 +38,7 @@ class CapstoneConan(ConanFile):
     implements = ["auto_shared_fpic"]
     languages = "C"
 
-    _archs = ["arm", "arm64", "m68k", "mips", "ppc", "sparc", "sysz", "xcore", "x86", "tms320c64x", "m680x", "evm"]
+    _archs = ["arm", "aarch64", "m68k", "mips", "ppc", "sparc", "sysz", "xcore", "x86", "tms320c64x", "m680x", "evm"]
     options.update({a: [True, False] for a in _archs})
     default_options.update({a: True for a in _archs})
         
@@ -60,8 +60,8 @@ class CapstoneConan(ConanFile):
         tc.cache_variables["CAPSTONE_USE_DEFAULT_ALLOC"] = self.options.use_default_alloc
         for a in self._archs:
             tc.cache_variables[f"CAPSTONE_{a.upper()}_SUPPORT"] = self.options.get_safe(a)
-        # Newer versions have aarch64 naming for arm64
-        tc.cache_variables["CAPSTONE_AARCH64_SUPPORT"] = self.options.get_safe("arm64")
+        # Older versions have arm64 naming for aarch64
+        tc.cache_variables["CAPSTONE_ARM64_SUPPORT"] = self.options.get_safe("aarch64")
 
         tc.generate()
 

--- a/recipes/capstone/config.yml
+++ b/recipes/capstone/config.yml
@@ -1,5 +1,3 @@
 versions:
   "5.0.6":
     folder: "all"
-  "5.0.7":
-    folder: "all"


### PR DESCRIPTION


### Summary
Changes to recipe:  **lib/capstone**

#### Motivation
Arm 64-bit support requires a separate define. 

#### Details

In capstone 6 they switch from CAPSTONE_ARM64_SUPPORT to CAPSTONE_AARCH64_SUPPORT, so we add both,
which is harmless for the non-existing case (missing archs just create CAPSTONE_xxx_SUPPORT defines which are silently ignored).

ref: https://github.com/capstone-engine/capstone/blob/next/docs/cs_v6_release_guide.md


---
- [ x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ x] If this is a bug fix, please link related issue or provide bug details
- [ x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
