### PR TITLE
Update to SQLite3 Multiple Ciphers 2.3.2

### DIFF
--- a/recipes/sqlite3mc/all/conandata.yml
+++ b/recipes/sqlite3mc/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.3.2":
+    url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v2.3.2.tar.gz"
+    sha256: "cd7ece3cb6a98868f8e8a10c5e44ead625a986d59be0950732bc9dd55aaad304"
   "2.2.7":
     url: "https://github.com/utelle/SQLite3MultipleCiphers/archive/refs/tags/v2.2.7.tar.gz"
     sha256: "b863ace2d6aab6a9d287c024fb9ad27b699e2876e6e95495c491a2d4db2126df"

--- a/recipes/sqlite3mc/config.yml
+++ b/recipes/sqlite3mc/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.3.2":
+    folder: all
   "2.2.7":
     folder: all
   "2.2.3":


### PR DESCRIPTION
### Summary
Changes to recipe:  **sqlite3mc**

#### Motivation

**sqlite3mc version 2.3.2** supports the latest SQLite version 3.51.3, and includes important bug fixes.

#### Details

**Important bug fixes:**
- Handle correctly raw key/salt material in conjunction with the plain header option
- Support compiling with _clang v22_ and above
- Avoid use of function sqlite3mc_cipher_name that is not thread-safe
- Support linking statically with `libsodium` at the same time

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
