### PR TITLE
Fix libiconv for Windows clang (not clang-cl)

### DIFF
--- a/recipes/libiconv/all/conanfile.py
+++ b/recipes/libiconv/all/conanfile.py
@@ -46,7 +46,9 @@ class LibiconvConan(ConanFile):
 
     @property
     def _msvc_tools(self):
-        return ("clang-cl", "llvm-lib", "lld-link") if self._is_clang_cl else ("cl", "lib", "link")
+        compilers = self.conf.get("tools.build:compiler_executables", default={})
+        compiler = compilers.get("c") or compilers.get("cpp")
+        return (compiler or "clang-cl", "llvm-lib", "lld-link") if self._is_clang_cl else ("cl", "lib", "link")
 
     def export_sources(self):
         export_conandata_patches(self)
@@ -94,11 +96,13 @@ class LibiconvConan(ConanFile):
         env = tc.environment()
         if is_msvc(self) or self._is_clang_cl:
             cc, lib, link = self._msvc_tools
+            if cc.endswith("clang-cl"):
+                cc = f"{cc} -nologo"
             build_aux_path = os.path.join(self.source_folder, "build-aux")
             lt_compile = unix_path(self, os.path.join(build_aux_path, "compile"))
             lt_ar = unix_path(self, os.path.join(build_aux_path, "ar-lib"))
-            env.define("CC", f"{lt_compile} {cc} -nologo")
-            env.define("CXX", f"{lt_compile} {cc} -nologo")
+            env.define("CC", f"{lt_compile} {cc}")
+            env.define("CXX", f"{lt_compile} {cc}")
             env.define("LD", link)
             env.define("STRIP", ":")
             env.define("AR", f"{lt_ar} {lib}")

--- a/recipes/libiconv/all/conanfile.py
+++ b/recipes/libiconv/all/conanfile.py
@@ -96,7 +96,7 @@ class LibiconvConan(ConanFile):
         env = tc.environment()
         if is_msvc(self) or self._is_clang_cl:
             cc, lib, link = self._msvc_tools
-            if cc.endswith("clang-cl"):
+            if cc.endswith("cl"):
                 cc = f"{cc} -nologo"
             build_aux_path = os.path.join(self.source_folder, "build-aux")
             lt_compile = unix_path(self, os.path.join(build_aux_path, "compile"))


### PR DESCRIPTION
### Summary
Libiconv

#### Motivation
Close https://github.com/conan-io/conan-center-index/issues/29816

The recipe was failing to build with Windows LLVM clang (not clang-cl), because the recipe was hardcoding ``clang-cl``.

#### Details
I have tested it with profile:
```
[settings]
arch=x86_64
build_type=Release
compiler=clang
compiler.version=18
compiler.cppstd=20
compiler.runtime=dynamic
compiler.runtime_type=Release
compiler.runtime_version=v144
os=Windows

[conf]
tools.cmake.cmaketoolchain:generator=Ninja
tools.build:compiler_executables={"c": "clang", "cpp": "clang"}
tools.compilation:verbosity=verbose

[buildenv]
PATH=+(path)C:/ws/LLVM/18.1/bin

[tool_requires]
ninja/[*]
```
And doing the variations of ``tools.build:compiler_executables`` to ``clang``, ``clang-cl`` and using a full path to ``clang`` compiler.


