### PR TITLE
Wt: link only to the Boost libraries that are actually needed.

### DIFF
--- a/recipes/wt/all/conanfile.py
+++ b/recipes/wt/all/conanfile.py
@@ -296,7 +296,7 @@ class WtConan(ConanFile):
             self.cpp_info.components["wtmain"].system_libs = ["ws2_32", "mswsock", "winmm"]
             self.cpp_info.components["wtmain"].system_libs.extend(["dwrite", "d2d1", "shlwapi"])
         self.cpp_info.components["wtmain"].requires = ["boost::chrono", "boost::filesystem", "boost::thread",
-                                                       "boost::container", "boost::date_time", "boost::atomic", "boost::system" ]
+                                                       "boost::container", "boost::date_time", "boost::atomic", "boost::system"]
         if self.options.with_ssl:
             self.cpp_info.components["wtmain"].requires.append("openssl::openssl")
         if self.options.get_safe("with_unwind"):

--- a/recipes/wt/all/conanfile.py
+++ b/recipes/wt/all/conanfile.py
@@ -295,7 +295,8 @@ class WtConan(ConanFile):
         elif self.settings.os == "Windows":
             self.cpp_info.components["wtmain"].system_libs = ["ws2_32", "mswsock", "winmm"]
             self.cpp_info.components["wtmain"].system_libs.extend(["dwrite", "d2d1", "shlwapi"])
-        self.cpp_info.components["wtmain"].requires = ["boost::boost"]
+        self.cpp_info.components["wtmain"].requires = ["boost::chrono", "boost::filesystem", "boost::thread",
+                                                       "boost::container", "boost::date_time", "boost::atomic", "boost::system" ]
         if self.options.with_ssl:
             self.cpp_info.components["wtmain"].requires.append("openssl::openssl")
         if self.options.get_safe("with_unwind"):
@@ -307,13 +308,13 @@ class WtConan(ConanFile):
         if self.options.with_test:
             self.cpp_info.components["wttest"].set_property("cmake_target_name", "Wt::Test")
             self.cpp_info.components["wttest"].libs = ["wttest{}".format(suffix)]
-            self.cpp_info.components["wttest"].requires = ["wtmain"]
+            self.cpp_info.components["wttest"].requires = ["wtmain", "boost::unit_test_framework", "zlib::zlib"]
 
         # wthttp
         if self.options.connector_http:
             self.cpp_info.components["wthttp"].set_property("cmake_target_name", "Wt::HTTP")
             self.cpp_info.components["wthttp"].libs = ["wthttp{}".format(suffix)]
-            self.cpp_info.components["wthttp"].requires = ["wtmain", "boost::boost", "zlib::zlib"]
+            self.cpp_info.components["wthttp"].requires = ["wtmain", "boost::program_options", "zlib::zlib"]
             if self.options.with_ssl:
                 self.cpp_info.components["wthttp"].requires.append("openssl::openssl")
 

--- a/recipes/wt/all/conanfile.py
+++ b/recipes/wt/all/conanfile.py
@@ -96,7 +96,7 @@ class WtConan(ConanFile):
         return ["program_options", "filesystem", "thread"]
 
     def requirements(self):
-        self.requires("boost/[>=1.83.0 <1.87.0]", transitive_headers = True)
+        self.requires("boost/[>=1.83.0 <=1.91.0]", transitive_headers = True)
         if self.options.connector_http:
             self.requires("zlib/[>=1.2.11 <2]")
         if self.options.with_ssl:
@@ -296,7 +296,7 @@ class WtConan(ConanFile):
             self.cpp_info.components["wtmain"].system_libs = ["ws2_32", "mswsock", "winmm"]
             self.cpp_info.components["wtmain"].system_libs.extend(["dwrite", "d2d1", "shlwapi"])
         self.cpp_info.components["wtmain"].requires = ["boost::chrono", "boost::filesystem", "boost::thread",
-                                                       "boost::container", "boost::date_time", "boost::atomic", "boost::system"]
+                                                       "boost::container", "boost::date_time", "boost::atomic"]
         if self.options.with_ssl:
             self.cpp_info.components["wtmain"].requires.append("openssl::openssl")
         if self.options.get_safe("with_unwind"):


### PR DESCRIPTION
### Summary
Changes to recipe:  **wt/***

#### Motivation
Currently the Wt Conan recipe let consumers link to target `boost::boost`. The results is that when building Boost as shared libraries your executable needs **all** Boost shared libraries, even boost_unit_test_framework.
Our applications run on embedded targets, of which some have little RAM and storage space so every library that is not needed should be omitted.

#### Details
In package_info() specify the actually needed boost targets instead of the catch-all `boost::boost` target.

Note: currently building of the Wt test package fails for me on Linux when option with_unwind is True, with or without this PR. libunwind requires xzutils::xzutils. Even though the libunwind recipe contains the line 
`self.cpp_info.components["unwind"].requires.append("xz_utils::xz_utils")`
the lzma library is not added to the linker command.
I think this should be fixed in the libunwind recipe rather than in the wt recipe?

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
