### PR TITLE
args-parser: bump version to 6.3.6

### DIFF
--- a/recipes/args-parser/all/conandata.yml
+++ b/recipes/args-parser/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "6.3.6":
+    url: "https://github.com/igormironchik/args-parser/archive/refs/tags/6.3.6.tar.gz"
+    sha256: "d65b205f3314ec4353f8c11ef21f567967f56b15a9c81c35162c2dfa45231924"
   "6.3.5":
     url: "https://github.com/igormironchik/args-parser/archive/refs/tags/6.3.5.tar.gz"
     sha256: "e6eaebece03224e69c91ab540a3f0b349b1ccf5952db5a9a5760ff0bcf8567f6"

--- a/recipes/args-parser/config.yml
+++ b/recipes/args-parser/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "6.3.6":
+    folder: all
   "6.3.5":
     folder: all
   "6.2.0.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **args-parser/[6.3.6]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
Version of the library was bumped.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
