### PR TITLE
glog: use version range for gflags requirement

### DIFF
--- a/recipes/glog/all/conanfile.py
+++ b/recipes/glog/all/conanfile.py
@@ -51,7 +51,7 @@ class GlogConan(ConanFile):
 
     def requirements(self):
         if self.options.with_gflags:
-            self.requires("gflags/2.2.2", transitive_headers=True, transitive_libs=True)
+            self.requires("gflags/[>=2.2.2 <3]", transitive_headers=True, transitive_libs=True)
         # 0.4.0 requires libunwind unconditionally
         if self.options.get_safe("with_unwind"):
             self.requires("libunwind/1.8.0", transitive_headers=True, transitive_libs=True)


### PR DESCRIPTION
### Summary
Changes to recipe:  glog

#### Motivation
Add flexibility to glog's gflags requirement.

#### Details
Allow glog to be built against gflags between 2.2.2 included and 3 excluded


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
