### PR TITLE
npcap: Add version 1.86

### DIFF
--- a/recipes/npcap/all/conandata.yml
+++ b/recipes/npcap/all/conandata.yml
@@ -1,9 +1,16 @@
-# We don't need a new verion here for each release of Npcap
+# We don't need a new version here for each release of Npcap
 # Only a new version is required if the SDK version changes
 # You can find SDK version in https://github.com/nmap/npcap/blob/{GIT_TAG}/version.h
 
 sources:
   # Newer versions at the top
+  "1.86":
+    sdk:
+      url: https://npcap.com/dist/npcap-sdk-1.16.zip
+      sha256: f0a8be7778ee3ae1b99bbbecb27a3ff0f6c111a4093f1c78c5c5a099607184db
+    license:
+      url: https://raw.githubusercontent.com/nmap/npcap/v1.86/LICENSE
+      sha256: 0543f4f93939013f80852d33469b1b5a2623676b387994ffb7a01e34e443ac83
   "1.70":
     sdk:
       url: https://npcap.com/dist/npcap-sdk-1.13.zip

--- a/recipes/npcap/all/test_package/conanfile.py
+++ b/recipes/npcap/all/test_package/conanfile.py
@@ -14,7 +14,7 @@ class TestPackageConan(ConanFile):
     def requirements(self):
         self.requires(self.tested_reference_str)
         if can_run(self):
-            self.requires("libpcap/1.10.5")
+            self.requires("libpcap/[>=1.10.1 <2]")
 
     def configure(self):
         if can_run(self):

--- a/recipes/npcap/all/test_package/conanfile.py
+++ b/recipes/npcap/all/test_package/conanfile.py
@@ -14,7 +14,7 @@ class TestPackageConan(ConanFile):
     def requirements(self):
         self.requires(self.tested_reference_str)
         if can_run(self):
-            self.requires("libpcap/1.10.1")
+            self.requires("libpcap/1.10.5")
 
     def configure(self):
         if can_run(self):

--- a/recipes/npcap/config.yml
+++ b/recipes/npcap/config.yml
@@ -1,4 +1,6 @@
 versions:
   # Newer versions at the top
+  "1.86":
+    folder: all
   "1.70":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **npcap/1.86** (new version from upstream)

#### Motivation
#14477; latest npcap SDK required in private project

#### Details
* Update npcap to version 1.86 which is the corresponding release for the latest npcap SDK version 1.16.
* Update libpcap version to latest 1.10.5 in test package. This version includes the `cmake: suppress CMP0042 OLD deprecated warning.` fix which is required to build with cmake 4.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
