### PR TITLE
cavalier-contours: new recipe, version 0.0.0.cci.20240828

### DIFF
--- a/recipes/cavalier-contours/all/conandata.yml
+++ b/recipes/cavalier-contours/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.0.0.cci.20240828":
+    url: "https://github.com/jbuckmccready/CavalierContours/archive/31a012947aa2e7e9474e2ec90502825afe8b99a4.tar.gz"
+    sha256: "e971b2cfda72ab99c66198163b3479d12a8ee83f6e8718cab16d87d6d7cd4f65"

--- a/recipes/cavalier-contours/all/conanfile.py
+++ b/recipes/cavalier-contours/all/conanfile.py
@@ -1,0 +1,49 @@
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+import os
+
+required_conan_version = ">=2.0.0"
+
+
+class CavalierContoursConan(ConanFile):
+    name = "cavalier-contours"
+    description = (
+        "C++14 header-only library for processing 2D polylines containing "
+        "straight line and constant radius arc segments. Supports contour/parallel "
+        "offsetting and boolean operations (OR, AND, NOT, XOR) between closed polylines."
+    )
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/jbuckmccready/CavalierContours"
+    topics = ("geometry", "polyline", "offset", "cad", "cam", "header-only")
+
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        check_min_cppstd(self, 14)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder,
+             dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, "*.hpp",
+             src=os.path.join(self.source_folder, "include"),
+             dst=os.path.join(self.package_folder, "include"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "CavalierContours")
+        self.cpp_info.set_property("cmake_target_name", "CavalierContours::CavalierContours")
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/cavalier-contours/all/test_package/CMakeLists.txt
+++ b/recipes/cavalier-contours/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(CavalierContours REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE CavalierContours::CavalierContours)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)

--- a/recipes/cavalier-contours/all/test_package/conanfile.py
+++ b/recipes/cavalier-contours/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/cavalier-contours/all/test_package/test_package.cpp
+++ b/recipes/cavalier-contours/all/test_package/test_package.cpp
@@ -1,0 +1,20 @@
+#include <cavc/polylineoffset.hpp>
+
+#include <cassert>
+#include <vector>
+
+int main() {
+    // Simple closed square polyline
+    cavc::Polyline<double> input;
+    input.addVertex(0, 0, 0);
+    input.addVertex(10, 0, 0);
+    input.addVertex(10, 10, 0);
+    input.addVertex(0, 10, 0);
+    input.isClosed() = true;
+
+    // Offset inward by 1 unit — should produce a smaller square
+    std::vector<cavc::Polyline<double>> results = cavc::parallelOffset(input, -1.0);
+    assert(results.size() == 1);
+
+    return 0;
+}

--- a/recipes/cavalier-contours/config.yml
+++ b/recipes/cavalier-contours/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.0.0.cci.20240828":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe: **cavalier-contours/0.0.0.cci.20240828**

#### Motivation
New recipe for [CavalierContours](https://github.com/jbuckmccready/CavalierContours), a header-only C++14 library for processing 2D polylines with straight line and constant radius arc segments. This library is not yet available in ConanCenter.

#### Details
- Added new recipe for `cavalier-contours` version `0.0.0.cci.20240828` (pinned to upstream commit `31a01294`)
- Header-only library packaged with `package_type = "header-library"`
- Requires C++14 minimum standard
- Exposes CMake target `CavalierContours::CavalierContours`
- Includes `test_package` with a basic usage test

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan