### PR TITLE
fe-bell-rapidxml: new recipe, version 1.17

### DIFF
--- a/recipes/fe-bell-rapidxml/all/conandata.yml
+++ b/recipes/fe-bell-rapidxml/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.17":
+    url: "https://github.com/Fe-Bell/RapidXML/archive/refs/tags/v117.tar.gz"
+    sha256: "1e1ef609a30439467bbfcec117566c5e3c29104648e87694344f147b405c9c87"

--- a/recipes/fe-bell-rapidxml/all/conanfile.py
+++ b/recipes/fe-bell-rapidxml/all/conanfile.py
@@ -1,0 +1,40 @@
+from conan import ConanFile
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+import os
+
+required_conan_version = ">=2.0.0"
+
+
+class RapidXMLFeBellConan(ConanFile):
+    name = "fe-bell-rapidxml"
+    description = "RapidXml is an attempt to create the fastest XML parser possible, maintained by Fe-Bell."
+    license = "MIT"
+    topics = ("xml", "parser", "header-only")
+    homepage = "https://github.com/Fe-Bell/RapidXML"
+    url = "https://github.com/conan-io/conan-center-index"
+
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def package(self):
+        copy(self, "LICENSE.md", src=self.source_folder,
+             dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, "*.hpp", src=os.path.join(self.source_folder, "RapidXML"),
+             dst=os.path.join(self.package_folder, "include", "rapidxml"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "fe-bell-rapidxml")
+        self.cpp_info.set_property("cmake_target_name", "fe-bell-rapidxml::fe-bell-rapidxml")
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/fe-bell-rapidxml/all/test_package/CMakeLists.txt
+++ b/recipes/fe-bell-rapidxml/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(fe-bell-rapidxml REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE fe-bell-rapidxml::fe-bell-rapidxml)

--- a/recipes/fe-bell-rapidxml/all/test_package/conanfile.py
+++ b/recipes/fe-bell-rapidxml/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/fe-bell-rapidxml/all/test_package/test_package.cpp
+++ b/recipes/fe-bell-rapidxml/all/test_package/test_package.cpp
@@ -1,0 +1,25 @@
+#include <rapidxml/rapidxml.hpp>
+#include <rapidxml/rapidxml_print.hpp>
+
+#include <cstdio>
+#include <cstring>
+#include <iostream>
+
+int main() {
+    char xml[] = "<MyBeerJournal>"
+                 "<Brewery name=\"Test Brewery\" location=\"Test City\"/>"
+                 "</MyBeerJournal>";
+
+    rapidxml::xml_document<> doc;
+    doc.parse<0>(xml);
+
+    rapidxml::xml_node<>* root = doc.first_node("MyBeerJournal");
+    for (rapidxml::xml_node<>* brewery = root->first_node("Brewery");
+         brewery; brewery = brewery->next_sibling()) {
+        printf("I have visited %s in %s.\n",
+               brewery->first_attribute("name")->value(),
+               brewery->first_attribute("location")->value());
+    }
+
+    return 0;
+}

--- a/recipes/fe-bell-rapidxml/config.yml
+++ b/recipes/fe-bell-rapidxml/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.17":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe: **fe-bell-rapidxml/1.17**

#### Motivation
New recipe for [Fe-Bell/RapidXML](https://github.com/Fe-Bell/RapidXML), a maintained fork of the RapidXml XML parser — a header-only C++ library focused on speed. This library is not yet available in ConanCenter.

#### Details
- Added new recipe for `fe-bell-rapidxml` version `1.17`
- Header-only library packaged with `package_type = "header-library"`
- Exposes CMake target `fe-bell-rapidxml::fe-bell-rapidxml`
- Headers installed under `include/rapidxml/`
- Includes `test_package` with a basic XML parsing test

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan