### PR TITLE
fft-real: new recipe, version 0.0.0.cci.20160622

### DIFF
--- a/recipes/fft-real/all/conandata.yml
+++ b/recipes/fft-real/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.0.0.cci.20160622":
+    url: "https://github.com/cyrilcode/fft-real/archive/c6da77695a8b1e1302a10f42efe0b210c2871aa9.tar.gz"
+    sha256: "6cfaf0ddf656d8e2cb3bacb486bf59f3e5d3fb705750f905c89a3e56a3386707"

--- a/recipes/fft-real/all/conanfile.py
+++ b/recipes/fft-real/all/conanfile.py
@@ -1,0 +1,47 @@
+from conan import ConanFile
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+import os
+
+required_conan_version = ">=2.0.0"
+
+
+class FftRealConan(ConanFile):
+    name = "fft-real"
+    description = (
+        "C++ template class computing DFT and inverse DFT "
+        "(FFT algorithm) for arrays of real numbers. Portable ISO C++."
+    )
+    license = "WTFPL"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/cyrilcode/fft-real"
+    topics = ("fft", "dft", "ifft", "signal-processing", "header-only")
+
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def package(self):
+        copy(self, "license.txt",
+             src=self.source_folder,
+             dst=os.path.join(self.package_folder, "licenses"))
+        for pattern in ("*.h", "*.hpp"):
+            copy(self, pattern,
+                 src=os.path.join(self.source_folder, "src"),
+                 dst=os.path.join(self.package_folder, "include", "ffft"),
+                 excludes="test*")
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "fft-real")
+        self.cpp_info.set_property("cmake_target_name", "fft-real::fft-real")
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/fft-real/all/test_package/CMakeLists.txt
+++ b/recipes/fft-real/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(PackageTest CXX)
+
+find_package(fft-real REQUIRED CONFIG)
+
+add_executable(test_package src/test_package.cpp)
+target_link_libraries(test_package PRIVATE fft-real::fft-real)

--- a/recipes/fft-real/all/test_package/conanfile.py
+++ b/recipes/fft-real/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/fft-real/all/test_package/src/test_package.cpp
+++ b/recipes/fft-real/all/test_package/src/test_package.cpp
@@ -1,0 +1,19 @@
+#include "ffft/FFTReal.h"
+
+#include <cstdio>
+#include <vector>
+
+int main() {
+    const long len = 64;
+    ffft::FFTReal<float> fft_object(len);
+
+    std::vector<float> x(len, 1.0f);
+    std::vector<float> f(len, 0.0f);
+
+    fft_object.do_fft(f.data(), x.data());
+    fft_object.do_ifft(f.data(), x.data());
+    fft_object.rescale(x.data());
+
+    std::printf("fft-real: FFT/IFFT computed successfully on %ld samples\n", len);
+    return 0;
+}

--- a/recipes/fft-real/config.yml
+++ b/recipes/fft-real/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.0.0.cci.20160622":
+    folder: "all"


### PR DESCRIPTION
### Summary
Changes to recipe: **fft-real/0.0.0.cci.20160622**

#### Motivation
New recipe for [fft-real](https://github.com/cyrilcode/fft-real), a header-only ISO C++ template library for computing DFT and inverse DFT (FFT algorithm) on arrays of real numbers. This library is not yet available in ConanCenter.

#### Details
- Added new recipe for `fft-real` version `0.0.0.cci.20160622` (pinned to upstream commit `c6da7769`)
- Header-only library packaged with `package_type = "header-library"`
- Headers installed under `include/ffft/`
- Exposes CMake target `fft-real::fft-real`
- Includes `test_package` with a basic FFT usage test

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan