### PR TITLE
[clix] add version 0.3.1

### DIFF
--- a/recipes/clix/all/conandata.yml
+++ b/recipes/clix/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.3.1":
+    url: "https://github.com/kkokotero/clix/archive/refs/tags/v0.3.1.tar.gz"
+    sha256: "229c25d5a59fb92bfdd37182b07e12f0ab1f2a6f5e3faa15ff583510483bf4f6"

--- a/recipes/clix/all/conanfile.py
+++ b/recipes/clix/all/conanfile.py
@@ -1,0 +1,79 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get
+from conan.tools.scm import Version
+import os
+
+required_conan_version = ">=2.0"
+
+
+class ClixConan(ConanFile):
+    name = "clix"
+    description = "A modern header-only C++ CLI toolkit with nested commands, validation, config files, env support, and shell completion."
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/kkokotero/clix"
+    topics = ("cli", "command-line", "parser", "header-only")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    @property
+    def _min_cppstd(self):
+        return "17"
+
+    @property
+    def _minimum_compiler_version(self):
+        return {
+            "gcc": "8",
+            "clang": "7",
+            "apple-clang": "10",
+            "Visual Studio": "15",
+            "msvc": "191",
+        }
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+
+        minimum_version = self._minimum_compiler_version.get(str(self.settings.compiler))
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["CLIX_BUILD_EXAMPLES"] = False
+        tc.variables["CLIX_BUILD_BENCHMARKS"] = False
+        tc.variables["BUILD_TESTING"] = False
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.includedirs = ["include"]
+        self.cpp_info.builddirs = [os.path.join("lib", "cmake", "clix")]
+        self.cpp_info.set_property("cmake_file_name", "clix")
+        self.cpp_info.set_property("cmake_target_name", "clix::clix")
+        self.cpp_info.set_property("pkg_config_name", "clix")

--- a/recipes/clix/all/test_package/CMakeLists.txt
+++ b/recipes/clix/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.23)
+project(test_package LANGUAGES CXX)
+
+find_package(clix CONFIG REQUIRED)
+
+add_executable(test_package test_package.cpp)
+target_link_libraries(test_package PRIVATE clix::clix)
+target_compile_features(test_package PRIVATE cxx_std_17)

--- a/recipes/clix/all/test_package/conanfile.py
+++ b/recipes/clix/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(f'"{bin_path}" echo smoke', env="conanrun")

--- a/recipes/clix/all/test_package/test_package.cpp
+++ b/recipes/clix/all/test_package/test_package.cpp
@@ -1,0 +1,15 @@
+#include <clix/cli.hpp>
+#include <clix/platform.hpp>
+
+int main(int argc, char** argv) {
+    auto info = clix::platform::current_info();
+    if (!info.has_filesystem || !info.has_process_environment) {
+        return 1;
+    }
+
+    clix::CLI cli("conan-center-test", "0.0.0");
+    auto& echo = cli.command("echo").description("Echo the provided value.");
+    echo.arg("value").description("Value to accept.");
+    echo.action([](const clix::Invocation&) {});
+    return cli.run(argc, argv);
+}

--- a/recipes/clix/config.yml
+++ b/recipes/clix/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.3.1":
+    folder: all


### PR DESCRIPTION
### Summary

Adds a new ConanCenter recipe for `clix/0.3.1`, a header-only C++ CLI toolkit.

### Testing

- [x] `conan create recipes/clix/all/conanfile.py --version=0.3.1 --build=missing`

Fixes #29838
