### PR TITLE
libpcap: Add version 1.10.6

### DIFF
--- a/recipes/libpcap/all/conandata.yml
+++ b/recipes/libpcap/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.10.6":
+    url: "https://www.tcpdump.org/release/libpcap-1.10.6.tar.xz"
+    sha256: "ec97d1206bdd19cb6bdd043eaa9f0037aa732262ec68e070fd7c7b5f834d5dfc"
   "1.10.5":
     url: "https://www.tcpdump.org/release/libpcap-1.10.5.tar.xz"
     sha256: "84fa89ac6d303028c1c5b754abff77224f45eca0a94eb1a34ff0aa9ceece3925"

--- a/recipes/libpcap/all/conanfile.py
+++ b/recipes/libpcap/all/conanfile.py
@@ -101,7 +101,7 @@ class LibPcapConan(ConanFile):
             tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_OpenSSL"] = True
 
             if Version(self.version) >= "1.10.5":
-                self.output.warning("PCAP on Windows is currently built with package capture capabilities - only support is for reading/writing capture files")
+                self.output.warning("PCAP on Windows is currently built without package capture capabilities - only support is for reading/writing capture files")
                 tc.cache_variables["PCAP_TYPE"] = "null"
             tc.generate()
         else:

--- a/recipes/libpcap/all/conanfile.py
+++ b/recipes/libpcap/all/conanfile.py
@@ -101,7 +101,7 @@ class LibPcapConan(ConanFile):
             tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_OpenSSL"] = True
 
             if Version(self.version) >= "1.10.5":
-                self.output.warning("PCAP on Windows is currently built without package capture capabilities - only support is for reading/writing capture files")
+                self.output.warning("PCAP on Windows is currently built with package capture capabilities - only support is for reading/writing capture files")
                 tc.cache_variables["PCAP_TYPE"] = "null"
             tc.generate()
         else:

--- a/recipes/libpcap/config.yml
+++ b/recipes/libpcap/config.yml
@@ -1,4 +1,6 @@
-versions:
+versions:  
+  "1.10.6":
+    folder: all
   "1.10.5":
     folder: all
   "1.10.4":


### PR DESCRIPTION
### Summary
Changes to recipe: Add **libpcap/1.10.6**

#### Motivation
libpcap 1.10.6 addresses CVE-2025-11961 and CVE-2025-11964.

#### Details
Add new version; no changes in the recipe (except one fixed warning message).

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
