### PR TITLE
libqasm: add version 1.3.0

### DIFF
--- a/recipes/libqasm/all/conandata.yml
+++ b/recipes/libqasm/all/conandata.yml
@@ -2,30 +2,3 @@ sources:
   "1.3.0":
     url: "https://github.com/QuTech-Delft/libqasm/releases/download/1.3.0/libqasm-1.3.0.tar.gz"
     sha256: "d4f2ab9264537670451754c163ec694728850363883ed53cd5b7f3e77c05b850"
-  "1.2.1":
-    url: "https://github.com/QuTech-Delft/libqasm/releases/download/1.2.1/libqasm-1.2.1.tar.gz"
-    sha256: "4303cbc9d0d928dc2b72769a79772e8e71d6e562de9b6ba3ca435da7a73d2739"
-  "1.2.0":
-    url: "https://github.com/QuTech-Delft/libqasm/releases/download/1.2.0/libqasm-1.2.0.tar.gz"
-    sha256: "9142085d3782c8b2094f66cf1fc3719040dfadc62f55ab722636fca109e27c20"
-  "1.1.0":
-    url: "https://github.com/QuTech-Delft/libqasm/releases/download/1.1.0/libqasm-1.1.0.tar.gz"
-    sha256: "cf317c465e741360ae147e46346c57294c23882269e3b3dabb3c5d5ac703414a"
-  "1.0.0":
-    url: "https://github.com/QuTech-Delft/libqasm/releases/download/1.0.0/libqasm-1.0.0.tar.gz"
-    sha256: "22968e2892194e69ca3cea9f4655c2f51470aae60d9e7dbd662136eb4088c984"
-  "0.6.9":
-    url: "https://github.com/QuTech-Delft/libqasm/releases/download/0.6.9/libqasm-0.6.9.tar.gz"
-    sha256: "23c5d0e4e506e1974668408f8018034d1b1303e65c6d2d28639eae9499759c4d"
-  "0.6.8":
-    url: "https://github.com/QuTech-Delft/libqasm/releases/download/0.6.8/libqasm-0.6.8.tar.gz"
-    sha256: "b98ff44f0c569a0cc20b3728ba7d4711299aaac07d4dadfe52e638b366b91251"
-  "0.6.7":
-    url: "https://github.com/QuTech-Delft/libqasm/releases/download/0.6.7/libqasm-0.6.7.tar.gz"
-    sha256: "3e85be4f433b178b89e32bc738bd4f69266cd1c4ad0ed12b5367381ac6e44eb2"
-  "0.6.6":
-    url: "https://github.com/QuTech-Delft/libqasm/releases/download/0.6.6/libqasm-0.6.6.tar.gz"
-    sha256: "b3a2d1670f8865ce22bcc62c6a696ee7e0764a7b76901a4f082efa2287e0cbad"
-  "0.6.5":
-    url: "https://github.com/QuTech-Delft/libqasm/releases/download/0.6.5/libqasm-0.6.5.tar.gz"
-    sha256: "0577622a512d1f64892949af02abe3d0b53195ad454045715a0ebf837ecde0d6"

--- a/recipes/libqasm/all/conanfile.py
+++ b/recipes/libqasm/all/conanfile.py
@@ -5,12 +5,11 @@ from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMakeToolchain, CMakeDeps, CMake, cmake_layout
-from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import copy, get, rm, replace_in_file
 from conan.tools.microsoft import is_msvc
 from conan.tools.scm import Version
 
-required_conan_version = ">=1.60.0 <2 || >=2.0.6"
+required_conan_version = ">=2.0.6"
 
 
 class LibqasmConan(ConanFile):
@@ -75,8 +74,7 @@ class LibqasmConan(ConanFile):
             self.tool_requires("cpython/3.12.2")
 
     def validate(self):
-        if self.settings.compiler.cppstd:
-            check_min_cppstd(self, self._min_cppstd)
+        check_min_cppstd(self, self._min_cppstd)
         minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
         if minimum_version and Version(self.settings.compiler.version) < minimum_version:
             raise ConanInvalidConfiguration(f"{self.ref} requires C++{self._min_cppstd},"
@@ -106,8 +104,6 @@ class LibqasmConan(ConanFile):
         tc.variables["LIBQASM_BUILD_PYTHON"] = self.options.build_python
         tc.variables["LIBQASM_BUILD_TESTS"] = self._should_build_test
         tc.generate()
-        env = VirtualBuildEnv(self)
-        env.generate()
 
     def _patch_sources(self):
         werror = "/WX" if is_msvc(self) else "-Werror"

--- a/recipes/libqasm/config.yml
+++ b/recipes/libqasm/config.yml
@@ -1,21 +1,3 @@
 versions:
   "1.3.0":
     folder: all
-  "1.2.1":
-    folder: all
-  "1.2.0":
-    folder: all
-  "1.1.0":
-    folder: all
-  "1.0.0":
-    folder: all
-  "0.6.9":
-    folder: all
-  "0.6.8":
-    folder: all
-  "0.6.7":
-    folder: all
-  "0.6.6":
-    folder: all
-  "0.6.5":
-    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **libqasm/1.3.0**

#### Motivation
Just a version bump.

#### Details
`config.yml` and `conandata.yml` point to the newly created libqasm/1.3.0.


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan