### PR TITLE
boost: expand version range of libbacktrace dependency

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -827,7 +827,7 @@ class BoostConan(ConanFile):
         if self._with_zstd:
             self.requires("zstd/[>=1.5 <1.6]")
         if self._with_stacktrace_backtrace:
-            self.requires("libbacktrace/cci.20210118", transitive_headers=True, transitive_libs=True)
+            self.requires("libbacktrace/[>=cci.20210118 <=cci.20240730]", transitive_headers=True, transitive_libs=True)
 
         if self._with_icu:
             self.requires("icu/74.2")


### PR DESCRIPTION
### Summary
Changes to recipe:  **boost/all**

#### Motivation

There are new versions of `libbacktrace` available, but `boost` is pining dependency to an old version

#### Details

Expand the version range of `libbacktrace` for `boost` dependencies.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
