### PR TITLE
[boost] fix Python unit test

### DIFF
--- a/recipes/boost/all/test_package/CMakeLists.txt
+++ b/recipes/boost/all/test_package/CMakeLists.txt
@@ -79,8 +79,11 @@ if(NOT HEADER_ONLY)
         if(WIN32)
             set_target_properties(hello_ext PROPERTIES SUFFIX ".pyd")
         endif()
-        add_test(NAME test_boost_python COMMAND Python::Interpreter "${CMAKE_CURRENT_SOURCE_DIR}/python.py")
-        set_property(TEST test_boost_python PROPERTY ENVIRONMENT "PYTHONPATH=$<TARGET_FILE_DIR:hello_ext>")
+        add_custom_command(TARGET hello_ext POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E env "PYTHONPATH=$<TARGET_FILE_DIR:hello_ext>" ${Python_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/python.py"
+            WORKING_DIRECTORY $<TARGET_FILE_DIR:hello_ext>
+            COMMENT "Running Boost.Python test"
+        )
 
         add_executable(test_boost_numpy numpy.cpp)
         target_link_libraries(test_boost_numpy PRIVATE Boost::numpy Python::Python Python::NumPy)


### PR DESCRIPTION
Commit 7b7fa86db7f7 ("boost: simplify test package (#26736)") inadvertently removed the test definition for `test_boost_python`. This has been reinstated.

Cc: @uilianries 


### Summary
Changes to recipe:  **boost/[*]**

#### Motivation
Fixes a bug in the Boost recipe's Boost.Python unit test definition. Without this fix, the recipe fails to build unit tests if Boost.Python is enabled.

#### Details
Reinstate CMake `add_test` for Boost.Python unit test that was removed in Commit 7b7fa86db7f7.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
