### PR TITLE
couchbase_cxx_client: make spdlog dependency more flexible

### DIFF
--- a/recipes/couchbase_cxx_client/all/conanfile.py
+++ b/recipes/couchbase_cxx_client/all/conanfile.py
@@ -42,7 +42,7 @@ class CouchbaseCxxClientConan(ConanFile):
     def requirements(self):
         # these should match https://github.com/couchbase/couchbase-cxx-client/blob/main/couchbase-sdk-cxx-black-duck-manifest.yaml
         # as best as possible
-        self.requires("spdlog/[~1.15.0]")
+        self.requires("spdlog/[>=1.15 <2]")
         self.requires("fmt/[*]")
         self.requires("ms-gsl/4.0.0")
         self.requires("snappy/[~1.2.1]")


### PR DESCRIPTION
### Summary
Changes to recipe:  **couchbase_cxx_client/1.2.1**

#### Motivation
Original dependency fixed spdlog dependency to 1.15 as that is what couchbase was using in their dependency definition. 

To avoid client's from having to define `self.requires("spdlog/1.17.0", force=True)` if they use a newer version of spdlog, I want to make the definition a little bit more flexible. 

#### Details
We've been using 1.17 without issues and I'm confident other future versions will likely also be fine to allow a spdlog version >= 1.15 but less than 2.0

