### PR TITLE
Updated cuda-api-wrappers with version 0.8.2

### DIFF
--- a/recipes/cuda-api-wrappers/all/conandata.yml
+++ b/recipes/cuda-api-wrappers/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.8.2":
+    url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.8.2.tar.gz"
+    sha256: "14e0558bb6851600bd674b18b7416ca678ae3dc45198875d552fc826fded4c7e"
   "0.8.1":
     url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.8.1.tar.gz"
     sha256: "f5ccadf51455fa1154a0ac730c5dc3894d339ae87413c39f63bd5fa27a48ddba"

--- a/recipes/cuda-api-wrappers/all/conandata.yml
+++ b/recipes/cuda-api-wrappers/all/conandata.yml
@@ -2,21 +2,3 @@ sources:
   "0.8.2":
     url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.8.2.tar.gz"
     sha256: "14e0558bb6851600bd674b18b7416ca678ae3dc45198875d552fc826fded4c7e"
-  "0.8.1":
-    url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.8.1.tar.gz"
-    sha256: "f5ccadf51455fa1154a0ac730c5dc3894d339ae87413c39f63bd5fa27a48ddba"
-  "0.8.0":
-    url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.8.0.tar.gz"
-    sha256: "16c68e450e553d2839f00503a44e85b32c4f4e08f154e9f7c85f706bc5c79bf3"
-  "0.7.1":
-    url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.7.1.tar.gz"
-    sha256: "fa30c9fe43a62f5a3fd82a5deb477838fbf0bf455c73a2d2bb5ab6284184900b"
-  "0.7.0":
-    url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.7.0.tar.gz"
-    sha256: "a47d11607ffa0c41cfffe689840a14125520da3f4bb504267e9d232ebb846457"
-  "0.6.8":
-    url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.6.8.tar.gz"
-    sha256: "a0d1b062dbe41c99d06df4ae7885a053c2ae3815d6fe12df0458bc5277d08ed7"
-  "0.6.3":
-    url: "https://github.com/eyalroz/cuda-api-wrappers/archive/refs/tags/v0.6.3.tar.gz"
-    sha256: "45d896136dbb4df6c75c36071899b9fe47df9a03629c95208c2d5bda979d109e"

--- a/recipes/cuda-api-wrappers/all/conanfile.py
+++ b/recipes/cuda-api-wrappers/all/conanfile.py
@@ -3,9 +3,8 @@ import os
 from conan import ConanFile
 from conan.tools.files import get, copy
 from conan.tools.layout import basic_layout
-from conan.tools.scm import Version
 
-required_conan_version = ">=1.52.0"
+required_conan_version = ">=2"
 
 
 class CudaApiWrappersConan(ConanFile):
@@ -46,8 +45,5 @@ class CudaApiWrappersConan(ConanFile):
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
         self.cpp_info.set_property("cmake_target_name", "cuda-api-wrappers::runtime-and-driver")
-        if Version(self.version) < "0.7.0":
-            # For previously published versions the target name was different, maintain compatibility
-            self.cpp_info.set_property("cmake_target_aliases", ["cuda-api-wrappers::cuda-api-wrappers"])
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs = ["pthread"]

--- a/recipes/cuda-api-wrappers/all/test_package/conanfile.py
+++ b/recipes/cuda-api-wrappers/all/test_package/conanfile.py
@@ -6,8 +6,7 @@ import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def layout(self):
         cmake_layout(self)

--- a/recipes/cuda-api-wrappers/config.yml
+++ b/recipes/cuda-api-wrappers/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.8.2":
+    folder: all
   "0.8.1":
     folder: all
   "0.8.0":

--- a/recipes/cuda-api-wrappers/config.yml
+++ b/recipes/cuda-api-wrappers/config.yml
@@ -1,15 +1,3 @@
 versions:
   "0.8.2":
     folder: all
-  "0.8.1":
-    folder: all
-  "0.8.0":
-    folder: all
-  "0.7.1":
-    folder: all
-  "0.7.0":
-    folder: all
-  "0.6.8":
-    folder: all
-  "0.6.3":
-    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **cuda-api-wrappers/0.8.2**

#### Motivation
Added latest library release, version 0.8.2

#### Details
Simple addition of another version of the library. For the changes to the library itself, see its [release notes page for version 0.8.2](https://github.com/eyalroz/cuda-api-wrappers/releases/tag/v0.8.2). There has not been any change to the library's structure and CMake target names; but it now requires CMake 3.26 rather than 3.25 to be configured and installed, in case that matters.

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] *N/A*: If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

