### PR TITLE
mpmcqueue: Add a new version based on the last commit

### DIFF
--- a/recipes/mpmcqueue/all/conandata.yml
+++ b/recipes/mpmcqueue/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.cci.20230918":
+    url: "https://github.com/rigtorp/MPMCQueue/archive/b9808ede08f26fa9df4df4e081d19cace8f6c6ea.tar.gz"
+    sha256: "bdfcf2429aebe892eb7b4a2edbc2d889365fa52264bf9501d937e8484166ec6a"
   "1.0":
     url: "https://github.com/rigtorp/MPMCQueue/archive/refs/tags/v1.0.tar.gz"
     sha256: "f009ef10b66f2b8bc6e3a4f50577efbdfea0c163464cd7de368378f173007b75"

--- a/recipes/mpmcqueue/config.yml
+++ b/recipes/mpmcqueue/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.0.cci.20230918":
+    folder: all
   "1.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **mpmcqueue/1.0.cci.20230918**

#### Motivation
The 1.0 release is missing the size function which I need and there is no release since then and no activity from the maintainer in the latest issues, so I'd just add a version referencing the last commit on master.

#### Details
https://github.com/rigtorp/MPMCQueue/compare/v1.0...master

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
