### PR TITLE
libpng: add version 1.6.56

### DIFF
--- a/recipes/libpng/all/conandata.yml
+++ b/recipes/libpng/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "1.6.55":
-    url: "https://download.sourceforge.net/libpng/libpng-1.6.55.tar.xz"
-    sha256: "d925722864837ad5ae2a82070d4b2e0603dc72af44bd457c3962298258b8e82d"
+  "1.6.56":
+    url: "https://download.sourceforge.net/libpng/libpng-1.6.56.tar.xz"
+    sha256: "f7d8bf1601b7804f583a254ab343a6549ca6cf27d255c302c47af2d9d36a6f18"

--- a/recipes/libpng/config.yml
+++ b/recipes/libpng/config.yml
@@ -1,4 +1,4 @@
 versions:
 # Keep only the latest version, unless there's strong reasons to keep older ones
-  "1.6.55":
+  "1.6.56":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **libpng/1.6.56**

#### Motivation
Upstream fixes including CVE-2026-33416 & CVE-2026-33636

#### Details
https://github.com/pnggroup/libpng/compare/v1.6.55...v1.6.56

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
