### PR TITLE
tree-gen: bump dependencies

### DIFF
--- a/recipes/tree-gen/all/conandata.yml
+++ b/recipes/tree-gen/all/conandata.yml
@@ -2,12 +2,3 @@ sources:
   "1.0.9":
     url: "https://github.com/QuTech-Delft/tree-gen/archive/refs/tags/1.0.9.tar.gz"
     sha256: "4ae8bd44f281ec76f25ac6f8228586467f7c7b2b9f67c4dc38ca524fb4e94d3a"
-  "1.0.8":
-    url: "https://github.com/QuTech-Delft/tree-gen/archive/refs/tags/1.0.8.tar.gz"
-    sha256: "a840f1da2fa377d2d791885d83b95dc15f081b308208d3497c395721488a4130"
-  "1.0.7":
-    url: "https://github.com/QuTech-Delft/tree-gen/archive/refs/tags/1.0.7.tar.gz"
-    sha256: "bd27c88d789efe1d187846d3b819fbaa1ba3a520d6d4181d1216c4a2e73e4e85"
-  "1.0.6":
-    url: "https://github.com/QuTech-Delft/tree-gen/archive/refs/tags/1.0.6.tar.gz"
-    sha256: "a7f6617830b3817b21cddc0f4442a04c10fbb89a19cabb1bbd0e8facb040cba8"

--- a/recipes/tree-gen/all/conanfile.py
+++ b/recipes/tree-gen/all/conanfile.py
@@ -3,9 +3,7 @@ import os
 from conan import ConanFile
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMakeToolchain, CMakeDeps, CMake, cmake_layout
-from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import copy, get
-from conan.tools.scm import Version
 
 required_conan_version = ">=2.1"
 
@@ -28,10 +26,6 @@ class TreeGenConan(ConanFile):
         "fPIC": True
     }
 
-    @property
-    def _should_build_test(self):
-        return not self.conf.get("tools.build:skip_test", default=True, check_type=bool)
-
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -44,11 +38,9 @@ class TreeGenConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def build_requirements(self):
-        if self._should_build_test:
-            self.test_requires("gtest/1.15.0")
         self.tool_requires("m4/1.4.19")
         if self.settings.os == "Windows":
-            self.tool_requires("winflexbison/2.5.24")
+            self.tool_requires("winflexbison/2.5.25")
         else:
             self.tool_requires("flex/2.6.4")
             self.tool_requires("bison/3.8.2")
@@ -63,10 +55,7 @@ class TreeGenConan(ConanFile):
             check_min_cppstd(self, 17)
 
     def requirements(self):
-        if Version(self.version) < "1.0.8":
-            self.requires("fmt/10.2.1", transitive_headers=True)
-        else:
-            self.requires("fmt/11.0.2", transitive_headers=True)
+        self.requires("fmt/[>=11.0.2 <13]", transitive_headers=True)
         self.requires("range-v3/0.12.0", transitive_headers=True)
 
     def source(self):
@@ -76,10 +65,7 @@ class TreeGenConan(ConanFile):
         deps = CMakeDeps(self)
         deps.generate()
         tc = CMakeToolchain(self)
-        tc.variables["TREE_GEN_BUILD_TESTS"] = self._should_build_test
         tc.generate()
-        env = VirtualBuildEnv(self)
-        env.generate()
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/tree-gen/config.yml
+++ b/recipes/tree-gen/config.yml
@@ -1,9 +1,3 @@
 versions:
   "1.0.9":
     folder: all
-  "1.0.8":
-    folder: all
-  "1.0.7":
-    folder: all
-  "1.0.6":
-    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **tree-gen/1.0.9**

#### Motivation
Bump dependencies so that we can compile this recipe and its dependants (`libqasm`) on Windows on ARM

- Removed `_should_build_test` which is something we do not want in CCI

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
