### PR TITLE
Botan: bump latest version to 3.11.1

### DIFF
--- a/recipes/botan/all/conandata.yml
+++ b/recipes/botan/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.11.1":
+    url: "https://github.com/randombit/botan/archive/3.11.1.tar.gz"
+    sha256: "444e41174889d8404cd409e260d85814aadcd1c49076da8fd6763f58ce36608d"
   "3.11.0":
     url: "https://github.com/randombit/botan/archive/3.11.0.tar.gz"
     sha256: "a8c6428478f23c68792de1b6fbeac6169772e25e6b3dbb5a8b5dd4e393b01b54"

--- a/recipes/botan/config.yml
+++ b/recipes/botan/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.11.1":
+    folder: all
   "3.11.0":
     folder: all
   "3.7.1+rscs1":


### PR DESCRIPTION
### Summary

Changes to recipe:  **botan/3.11.1**

#### Motivation

This patch release [fixes two vulnerabilities](https://github.com/randombit/botan/blob/master/news.rst#version-3111-2026-03-31).

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
