### PR TITLE
lz4: Fix licensing

### DIFF
--- a/recipes/lz4/all/conanfile.py
+++ b/recipes/lz4/all/conanfile.py
@@ -73,7 +73,7 @@ class LZ4Conan(ConanFile):
         cmake.build()
 
     def package(self):
-        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "lib", "licenses"))
+        copy(self, "LICENSE", src=os.path.join(self.source_folder, "lib"), dst=os.path.join(self.package_folder, "licenses"))
         cmake = CMake(self)
         cmake.install()
         if Version(self.version) >= "1.9.4":


### PR DESCRIPTION
We only distribute the library for this package, so the correct licensing would be that of the library itself.

In this case, that's BSD-2, no other code licensing otherwise is distributed.

Closes https://github.com/conan-io/conan-center-index/issues/29889


---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
