### PR TITLE
lua: Add version 5.5.0

### DIFF
--- a/recipes/lua/all/conandata.yml
+++ b/recipes/lua/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "5.5.0":
+    url: "https://www.lua.org/ftp/lua-5.5.0.tar.gz"
+    sha256: "57ccc32bbbd005cab75bcc52444052535af691789dba2b9016d5c50640d68b3d"
   "5.4.8":
     url: "https://www.lua.org/ftp/lua-5.4.8.tar.gz"
     sha256: "4f18ddae154e793e46eeab727c59ef1c0c0c2b744e7b94219710d76f530629ae"

--- a/recipes/lua/config.yml
+++ b/recipes/lua/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "5.5.0":
+    folder: all
   "5.4.8":
     folder: all
   "5.4.6":


### PR DESCRIPTION
### Summary
Changes to recipe:  **lua/5.5.0**

#### Motivation
Add new upstream version for lua

#### Details
There was one relevant change in lua's makefile: readline is now loaded dynamically by default. However, this does not affect this recipe; LUA_USE_READLINE, which is used in the recipe's CMakeLists.txt, is still supported.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
