### PR TITLE
openimageio: Add 3.1.12.0

### DIFF
--- a/recipes/openimageio/all/conandata.yml
+++ b/recipes/openimageio/all/conandata.yml
@@ -1,12 +1,12 @@
 sources:
-  "3.1.11.0":
-    url: "https://github.com/AcademySoftwareFoundation/OpenImageIO/releases/download/v3.1.11.0/OpenImageIO-3.1.11.0.tar.gz"
-    sha256: "c547db09f45bc2b66bdbaa1d21c8e418beaa471ad9a9c4b1ef0a772cf9eb323d"
+  "3.1.12.0":
+    url: "https://github.com/AcademySoftwareFoundation/OpenImageIO/releases/download/v3.1.12.0/OpenImageIO-3.1.12.0.tar.gz"
+    sha256: "704511376faf32767cdcd9aa9a6d0be2b03b91f849ad9008227dc9f0e14bc265"
   "2.5.19.1":
     url: "https://github.com/AcademySoftwareFoundation/OpenImageIO/archive/refs/tags/v2.5.19.1.tar.gz"
     sha256: "adb73f270f2eaae81c3c7cde311239944ae9faf6d206552da4ee12d746628b26"
 patches:
-  "3.1.11.0":
-    - patch_file: "patches/3.1.11.0-conan-fixes.patch"
+  "3.1.12.0":
+    - patch_file: "patches/3.1.12.0-conan-fixes.patch"
   "2.5.19.1":
     - patch_file: "patches/2.5.19.1-conan-fixes.patch"

--- a/recipes/openimageio/all/patches/3.1.12.0-conan-fixes.patch
+++ b/recipes/openimageio/all/patches/3.1.12.0-conan-fixes.patch
@@ -1,8 +1,8 @@
 diff --git CMakeLists.txt CMakeLists.txt
-index a5fcfdbd4..a86afae9e 100644
+index 4e9f4e7e4..c44cb8573 100644
 --- CMakeLists.txt
 +++ CMakeLists.txt
-@@ -288,7 +288,7 @@ if (OIIO_BUILD_TOOLS AND NOT BUILD_OIIOUTIL_ONLY)
+@@ -287,7 +287,7 @@ if (OIIO_BUILD_TOOLS AND NOT BUILD_OIIOUTIL_ONLY)
      add_subdirectory (src/iinfo)
      add_subdirectory (src/maketx)
      add_subdirectory (src/oiiotool)
@@ -12,7 +12,7 @@ index a5fcfdbd4..a86afae9e 100644
  endif ()
  
 diff --git src/cmake/externalpackages.cmake src/cmake/externalpackages.cmake
-index 8aba22812..702f7a44c 100644
+index f10cfc852..ec8989f81 100644
 --- src/cmake/externalpackages.cmake
 +++ src/cmake/externalpackages.cmake
 @@ -238,7 +238,7 @@ checked_find_package (fmt REQUIRED

--- a/recipes/openimageio/config.yml
+++ b/recipes/openimageio/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "3.1.11.0":
+  "3.1.12.0":
     folder: all
   "2.5.19.1":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **openimageio/3.1.12.0**

#### Motivation
Monthly release with a ton of small fixes & small improvements.

#### Details
* https://github.com/AcademySoftwareFoundation/OpenImageIO/releases/tag/v3.1.12.0
* https://github.com/AcademySoftwareFoundation/OpenImageIO/compare/v3.1.11.0...v3.1.12.0

I saw one build related change happening in two files:
```
-            ${BZIP2_LIBRARIES}
+            $<TARGET_NAME_IF_EXISTS:BZip2::BZip2>
```
Which is fine as this is the exact naming and upper/lower casing of the target name for bzip2.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!