### PR TITLE
[swig] Fixes PCRE2 integration

### DIFF
--- a/recipes/swig/all/conanfile.py
+++ b/recipes/swig/all/conanfile.py
@@ -93,7 +93,7 @@ class SwigConan(ConanFile):
         ]
         tc.extra_cflags.append("-DHAVE_PCRE=1")
         if self._use_pcre2:
-            env.define("PCRE2_LIBS", " ".join("-l" + lib for lib in self.dependencies["pcre2"].cpp_info.libs))
+            env.define("PCRE2_LIBS", " ".join("-l" + lib for lib in self.dependencies["pcre2"].cpp_info.components["pcre2-8"].libs))
 
         if self.settings.os in ["Linux", "FreeBSD"]:
             tc.configure_args.append("LIBS=-ldl")
@@ -149,7 +149,8 @@ class SwigConan(ConanFile):
         # https://github.com/swig/swig/blob/v4.1.1/configure.ac#L70-L92
         # https://github.com/swig/swig/blob/v4.0.2/configure.ac#L65-L86
         replace_in_file(self, os.path.join(self.source_folder, "configure.ac"),
-                        'AS_IF([test "x$with_pcre" != xno],', 'AS_IF([false],')
+                        'AS_IF([test "x$with_pcre" != xno],',
+                        'AC_DEFINE([HAVE_PCRE], [1], [Define if you have PCRE2 library])\nLIBS="$LIBS $PCRE2_LIBS"\nAS_IF([false],')
 
     def build(self):
         self._patch_sources()

--- a/recipes/swig/all/test_package/conanfile.py
+++ b/recipes/swig/all/test_package/conanfile.py
@@ -1,4 +1,5 @@
 import importlib
+import io
 import os
 import sys
 from pathlib import PurePath
@@ -69,5 +70,14 @@ class TestPackageConan(ConanFile):
         if can_run(self):
             if self._can_build:
                 self._test_swig_module()
-            self.run("swig -version")
-            self.run("swig -swiglib")
+            version_output = io.StringIO()
+            self.run("swig -version", stdout=version_output)
+            version_str = version_output.getvalue()
+            self.output.info(version_str)
+            assert "+pcre" in version_str, f"SWIG was not built with PCRE support:\n{version_str}"
+            swiglib_output = io.StringIO()
+            self.run("swig -swiglib", stdout=swiglib_output)
+            swiglib_raw = swiglib_output.getvalue().strip()
+            self.output.info(f"swig -swiglib raw output: {swiglib_raw}")
+            swiglib_path = PurePath(swiglib_raw)
+            assert swiglib_path.is_absolute(), f"swig -swiglib returned a non-absolute path: {swiglib_path}"


### PR DESCRIPTION
### Summary
Changes to recipe:  **swig/[*]**

#### Motivation

* Fix #29904

#### Details

# Root cause

`_patch_sources` replaced `AS_IF([test "x$with_pcre" != xno],` with `AS_IF([false],)` to bypass the `AX_PATH_GENERIC` call (which requires `pcre2-config` in PATH). But this also skipped everything inside the block, including:

- `AC_DEFINE([HAVE_PCRE], [1])` — so `config.h` never got `HAVE_PCRE` defined, causing `swig -version` to show `-pcre`
- `LIBS="$LIBS $PCRE2_LIBS"` — so the linker never got `-lpcre2-8`

Additionally, `PCRE2_LIBS` was being constructed from `cpp_info.libs` which is empty because the pcre2 conan recipe exposes its libraries through components (`pcre2-8`, `pcre2-posix`, etc.), not the top-level `libs`.

# Fix

Two changes:

**`generate()`** — use `cpp_info.components["pcre2-8"].libs` instead of `cpp_info.libs` to correctly populate `PCRE2_LIBS=-lpcre2-8`.

**`_patch_sources()`** — instead of just replacing the `AS_IF` condition with `false`, prepend the two statements that were being skipped before the bypassed block:

```m4
AC_DEFINE([HAVE_PCRE], [1], [Define if you have PCRE2 library])
LIBS="$LIBS $PCRE2_LIBS"
AS_IF([false], ...)   # still skips AX_PATH_GENERIC / pcre2-config lookup
```

This ensures `config.h` has `HAVE_PCRE=1` and the linker gets `-lpcre2-8`, while still not requiring `pcre2-config` to be in PATH.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
