### PR TITLE
imgui: Add version 1.92.7

### DIFF
--- a/recipes/imgui/all/conandata.yml
+++ b/recipes/imgui/all/conandata.yml
@@ -15,20 +15,6 @@ sources:
     testengine:
       url: "https://github.com/ocornut/imgui_test_engine/archive/v1.92.7.tar.gz"
       sha256: "3bb2320044854abb479facdde01c38c8af2e0257a630eb4b582b100a4fa60043"
-  "1.92.2b":
-    core:
-      url: "https://github.com/ocornut/imgui/archive/v1.92.2b.tar.gz"
-      sha256: "da3d453cce74e0fb3d67f8d798a2a8d04fcaf0b33ce0e0131d0695dfc4f64191"
-    testengine:
-      url: "https://github.com/ocornut/imgui_test_engine/archive/v1.92.2.tar.gz"
-      sha256: "5914327269b2dd9ad66bead3be8577f99f5f572d196bbe4028f6812cf0356adb"
-  "1.92.2b-docking":
-    core:
-      url: "https://github.com/ocornut/imgui/archive/v1.92.2b-docking.tar.gz"
-      sha256: "f6ad86e6f938fdda4d5e362b9a9b39158963dd3257fdc9902efc148c0c0c39f9"
-    testengine:
-      url: "https://github.com/ocornut/imgui_test_engine/archive/v1.92.2.tar.gz"
-      sha256: "5914327269b2dd9ad66bead3be8577f99f5f572d196bbe4028f6812cf0356adb"
   "1.91.8":
     core:
       url: "https://github.com/ocornut/imgui/archive/v1.91.8.tar.gz"
@@ -43,14 +29,6 @@ sources:
     testengine:
       url: "https://github.com/ocornut/imgui_test_engine/archive/v1.91.8.tar.gz"
       sha256: "bdfc31cb819bd6e4df2d5da0316edf92b1011d1c4046293aafd9ae14106570e2"
-  "1.90.9":
-    core:
-      url: "https://github.com/ocornut/imgui/archive/v1.90.9.tar.gz"
-      sha256: "04943919721e874ac75a2f45e6eb6c0224395034667bf508923388afda5a50bf"
-  "1.90.9-docking":
-    core:
-      url: "https://github.com/ocornut/imgui/archive/v1.90.9-docking.tar.gz"
-      sha256: "48e7e4e4f154ad98d0946126a84e2375f849f6a67792129a805817dd60a34330"
   "1.90.5":
     core:
       url: "https://github.com/ocornut/imgui/archive/v1.90.5.tar.gz"
@@ -65,18 +43,10 @@ sources:
     testengine:
       url: "https://github.com/ocornut/imgui_test_engine/archive/v1.90.5.tar.gz"
       sha256: "79339246d8c919c5926df0a7bee99be585ebaf67cdaba89a0ac314b1f7846f92"
-  "1.88":
-    core:
-      url: "https://github.com/ocornut/imgui/archive/v1.88.tar.gz"
-      sha256: "9f14c788aee15b777051e48f868c5d4d959bd679fc5050e3d2a29de80d8fd32e"
   "1.87":
     core:
       url: "https://github.com/ocornut/imgui/archive/v1.87.tar.gz"
       sha256: "b54ceb35bda38766e36b87c25edf7a1cd8fd2cb8c485b245aedca6fb85645a20"
-  "1.86":
-    core:
-      url: "https://github.com/ocornut/imgui/archive/v1.86.tar.gz"
-      sha256: "6ba6ae8425a19bc52c5e067702c48b70e4403cd339cba02073a462730a63e825"
   "1.85":
     core:
       url: "https://github.com/ocornut/imgui/archive/v1.85.tar.gz"

--- a/recipes/imgui/config.yml
+++ b/recipes/imgui/config.yml
@@ -3,17 +3,9 @@ versions:
     folder: all
   "1.92.7-docking":
     folder: all
-  "1.92.2b":
-    folder: all
-  "1.92.2b-docking":
-    folder: all
   "1.91.8":
     folder: all
   "1.91.8-docking":
-    folder: all
-  "1.90.9":
-    folder: all
-  "1.90.9-docking":
     folder: all
   "1.90.5":
     folder: all
@@ -22,8 +14,6 @@ versions:
   "1.88":
     folder: all
   "1.87":
-    folder: all
-  "1.86":
     folder: all
   "1.85":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **imgui/1.92.7**

#### Motivation

Regular update but as usual with imgui, despite the patch level number increase, this brings a ton of small improvements and changes.

#### Details
* https://github.com/ocornut/imgui/releases/tag/v1.92.7
* And as usual no build related changes, as building in this repo is mainly assumed to be submoduling or so: https://github.com/ocornut/imgui/compare/v1.92.6...v1.92.7

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
