### PR TITLE
feat concurrentqueue: bump library version to v1.0.5

### DIFF
--- a/recipes/concurrentqueue/all/conandata.yml
+++ b/recipes/concurrentqueue/all/conandata.yml
@@ -5,12 +5,3 @@ sources:
   "1.0.4":
     url: "https://github.com/cameron314/concurrentqueue/archive/refs/tags/v1.0.4.tar.gz"
     sha256: "87fbc9884d60d0d4bf3462c18f4c0ee0a9311d0519341cac7cbd361c885e5281"
-  "1.0.3":
-    url: "https://github.com/cameron314/concurrentqueue/archive/refs/tags/v1.0.3.tar.gz"
-    sha256: "eb37336bf9ae59aca7b954db3350d9b30d1cab24b96c7676f36040aa76e915e8"
-  "1.0.2":
-    url: "https://github.com/cameron314/concurrentqueue/archive/refs/tags/v1.0.2.tar.gz"
-    sha256: "c3aeb97c97169f743a53ca33812ea2ab61dd06dfd28319ca3f0a0771372fc7fc"
-  "1.0.1":
-    url: "https://github.com/cameron314/concurrentqueue/archive/refs/tags/v1.0.1.tar.gz"
-    sha256: "7e715c793001e01851448320e8a416b80342b2e75db46d4c978e990a506060e6"

--- a/recipes/concurrentqueue/config.yml
+++ b/recipes/concurrentqueue/config.yml
@@ -3,9 +3,3 @@ versions:
     folder: all
   "1.0.4":
     folder: all
-  "1.0.3":
-    folder: all
-  "1.0.2":
-    folder: all
-  "1.0.1":
-    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **concurrentqueue/1.0.5**

https://github.com/cameron314/concurrentqueue/compare/v1.0.4...v1.0.5

#### Motivation

Closes: https://github.com/conan-io/conan-center-index/issues/29911

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
