### PR TITLE
lcms: fix Meson static lib naming on Windows

### DIFF
--- a/recipes/lcms/all/conanfile.py
+++ b/recipes/lcms/all/conanfile.py
@@ -2,7 +2,7 @@ import os
 
 from conan import ConanFile
 from conan.tools.apple import fix_apple_shared_install_name
-from conan.tools.files import copy, get, rm, rmdir
+from conan.tools.files import copy, get, rename, rm, rmdir
 from conan.tools.layout import basic_layout
 from conan.tools.meson import Meson, MesonToolchain
 
@@ -62,6 +62,15 @@ class LcmsConan(ConanFile):
         rm(self, "*.pdb", os.path.join(self.package_folder, "bin"))
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         fix_apple_shared_install_name(self)
+
+        # Meson uses 'libfoo.a' naming on Windows even with MSVC+ninja, by design
+        # (mesonbuild/meson#7378). Rename to 'lcms2.lib' so consumers can find it.
+        if self.settings.os == "Windows" and not self.options.shared:
+            lib_dir = os.path.join(self.package_folder, "lib")
+            wrong = os.path.join(lib_dir, "liblcms2.a")
+            correct = os.path.join(lib_dir, "lcms2.lib")
+            if os.path.exists(wrong) and not os.path.exists(correct):
+                rename(self, wrong, correct)
 
     def package_info(self):
         self.cpp_info.set_property("pkg_config_name", "lcms2")


### PR DESCRIPTION
### Summary
Changes to recipe: **lcms/2.16**, **lcms/2.17**

#### Motivation
Meson deliberately uses `libfoo.a` naming on Windows even with MSVC + ninja backend
([mesonbuild/meson#7378](https://github.com/mesonbuild/meson/issues/7378), open since
June 2020, intentional design choice). This means static builds of lcms produce
`liblcms2.a` instead of `lcms2.lib`, which breaks consumers that expect MSVC-style
names (e.g. ffmpeg's autotools `configure` via pkg-config, CMake's `find_library()`).

Previously reported in #29391 (no fix proposed).
Related Conan feature request #11866 (helper to fix Meson static lib names on Windows).

#### Details
Added a rename workaround in `package()`: after `meson.install()`, renames `liblcms2.a` → `lcms2.lib` on Windows static builds.

The guard is:
- `self.settings.os == "Windows"` (not `is_msvc()`) to also cover clang-cl
- `not self.options.shared` (shared builds produce the correct `.dll` + `.lib`)
- File existence check to be a no-op if Meson ever changes this behavior

Only the `package()` method is changed; build and configuration are untouched.

#### Test matrix

| OS | Compiler | Generator | Linkage | Result |
|----|----------|-----------|---------|--------|
| Linux | Clang 20.1.2 | Ninja | static | ✅ pass |
| Linux | Clang 20.1.2 | Ninja | shared | ✅ pass |
| Linux | GCC 14.2.0 | Ninja | static | ✅ pass |
| Linux | GCC 14.2.0 | Ninja | shared | ✅ pass |
| macOS | Apple Clang 21.0.0 | Ninja | static | ✅ pass |
| macOS | Apple Clang 21.0.0 | Ninja | shared | ✅ pass |
| macOS | Clang 21.1.8 (homebrew) | Ninja | static | ✅ pass |
| macOS | Clang 21.1.8 (homebrew) | Ninja | shared | ✅ pass |
| Windows | Clang 19 (clang-cl) | Ninja | static | ✅ pass |
| Windows | Clang 19 (clang-cl) | Ninja | shared | ✅ pass |
| Windows | MSVC 194 | Ninja | static | ✅ pass |
| Windows | MSVC 194 | Ninja | shared | ✅ pass |

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
