### PR TITLE
libmp3lame: quote CC path for clang-cl in Makefile.MSVC

### DIFF
--- a/recipes/libmp3lame/all/conanfile.py
+++ b/recipes/libmp3lame/all/conanfile.py
@@ -92,7 +92,9 @@ class LibMP3LameConan(ConanFile):
                 buildenv_vars = VirtualBuildEnv(self).vars()
                 cl = compilers_from_conf.get("c", buildenv_vars.get("CC", "clang-cl"))
                 link = buildenv_vars.get("LD", "lld-link")
-                replace_in_file(self, "Makefile.MSVC", "CC = cl", f"CC = {cl}")
+                # Quote the CC path: nmake's .c.obj inference rule cannot resolve
+                # subdirectory targets when $(CC) expands to a path with spaces.
+                replace_in_file(self, "Makefile.MSVC", "CC = cl", f'CC = "{cl}"')
                 replace_in_file(self, "Makefile.MSVC", "LN = link", f"LN = {link}")
                 # what is /GAy? MSDN doesn't know it
                 # clang-cl: error: no such file or directory: '/GAy'


### PR DESCRIPTION
### Summary
Changes to recipe: **libmp3lame/3.100**

> **Prerequisite for ffmpeg clang-cl support.**
> libmp3lame is a direct ffmpeg dependency - without this fix, nmake fails when CC path contains spaces
> (typical with VS-bundled clang-cl).
> A dedicated ffmpeg clang-cl PR will follow.

#### Motivation

When building libmp3lame with **clang-cl** on Windows, nmake's `.c.obj:` inference
rule fails to resolve subdirectory targets (e.g., `libmp3lame/encoder.obj`) when
`$(CC)` expands to a path containing spaces — for example:
```
C:/Program Files/Microsoft Visual Studio/2022/Professional/VC/Tools/Llvm/x64/bin/clang-cl.exe
```

nmake misinterprets the spaces in the command and produces:
```
NMAKE : fatal error U1073: don't know how to make 'libmp3lame\encoder.obj'
```

#### Details

Quote the CC value in the `replace_in_file` call inside `_build_vs()`.

No effect on MSVC builds (CC stays as `cl`, no spaces). No effect on Unix builds (they use autotools, not Makefile.MSVC).

#### Test matrix

| OS | Compiler | Generator | Linkage | Result |
|----|----------|-----------|---------|--------|
| Linux | Clang 20.1.2 | Ninja | static | ✅ pass |
| Linux | Clang 20.1.2 | Ninja | shared | ✅ pass |
| Linux | GCC 14.2.0 | Ninja | static | ✅ pass |
| Linux | GCC 14.2.0 | Ninja | shared | ✅ pass |
| macOS | Apple Clang 21.0.0 | Ninja | static | ✅ pass |
| macOS | Apple Clang 21.0.0 | Ninja | shared | ✅ pass |
| macOS | Clang 21.1.8 (homebrew) | Ninja | static | ✅ pass |
| macOS | Clang 21.1.8 (homebrew) | Ninja | shared | ✅ pass |
| Windows | Clang 19 (clang-cl) | Ninja | static | ✅ pass |
| Windows | Clang 19 (clang-cl) | Ninja | shared | ✅ pass |
| Windows | MSVC 194 | Ninja | static | ✅ pass |
| Windows | MSVC 194 | Ninja | shared | ✅ pass |

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
