### PR TITLE
libvpx: fix clang-cl support on Windows

### DIFF
--- a/recipes/libvpx/all/conanfile.py
+++ b/recipes/libvpx/all/conanfile.py
@@ -128,7 +128,7 @@ class LibVPXConan(ConanFile):
         elif self._is_clang_cl:
             # clang-cl uses MSVC ABI — build with VS target; derive VS version from runtime_version
             rv = str(self.settings.compiler.runtime_version)
-            vc_version = {"v144": "18", "v143": "17", "v142": "16", "v141": "15"}.get(rv)
+            vc_version = {"v145": "18", "v144": "17", "v143": "17", "v142": "16", "v141": "15"}.get(rv)
             if not vc_version:
                 raise ConanInvalidConfiguration(
                     f"Unknown runtime_version '{rv}' for clang-cl — update the libvpx recipe"


### PR DESCRIPTION
### Summary

Changes to recipe: **libvpx/1.16.0**

> **Prerequisite for ffmpeg clang-cl support.**
> libvpx is a direct ffmpeg dependency - without this fix, libvpx can't build at all with clang-cl.
> A dedicated ffmpeg clang-cl PR will follow.

#### Motivation

clang-cl shares MSVC's ABI, linker and vcxproj build system, but `is_msvc()` returns `False` for it.
This causes multiple failures:
1. **Target selection**: clang on Windows falls into the `gcc` branch → invalid target name `x86_64-win64-gcc` which configure rejects.
2. **Static runtime**: `--enable-static-msvcrt` never passed, build uses wrong CRT.
3. **CC override**: gen_msvs_vcxproj.sh receives custom CC flags it can't handle.
4. **BUILD_ROOT**: MSYS2's `cygpath -m .` returns `.` instead of an absolute path, producing garbled include paths in the generated vcxproj.
5. **LTO check**: WholeProgramOptimization not disabled for clang-cl.
6. **Lib naming**: `msvc_runtime_flag()` fails for clang → empty suffix, wrong lib name.
7. **Package step**: libs not found in the build folder subdirectory.

#### Details

- Add `_is_clang_cl` and `_is_msvc_like` properties.
- **`_target_name`**: add clang-cl branch deriving VS version from `runtime_version`  (e.g., `v143` → `vs17`).
  Both MSVC and clang-cl now raise `ConanInvalidConfiguration` on unknown compiler/runtime versions instead of
  silently falling back or crashing with a `KeyError`.
- **`generate()`**: use `_is_msvc_like` for static MSVCRT detection and for CC env override.
- **`_patch_sources()`**: extend LTO check to `_is_msvc_like`.
- **`_fix_msvc_build_root()`**: new method — replaces `BUILD_ROOT?=.` in the generated Makefile with an absolute MSYS2-style path so `cygpath -m` resolves correctly.
- **`_lib_name`**: add clang-cl branch deriving CRT suffix from `runtime` + `runtime_type` (e.g., `dynamic` + `Release` → `md`).
- **`package()`**: use `_is_msvc_like` to find libs in build subfolder.

#### Test matrix

| OS | Compiler | Generator | Linkage | Result |
|----|----------|-----------|---------|--------|
| Linux | Clang 20.1.2 | Ninja | static | ✅ pass |
| Linux | Clang 20.1.2 | Ninja | shared | ✅ pass |
| Linux | GCC 14.2.0 | Ninja | static | ✅ pass |
| Linux | GCC 14.2.0 | Ninja | shared | ✅ pass |
| macOS | Apple Clang 21.0.0 | Ninja | static | ✅ pass |
| macOS | Apple Clang 21.0.0 | Ninja | shared | ✅ pass |
| macOS | Clang 21.1.8 (homebrew) | Ninja | static | ✅ pass |
| macOS | Clang 21.1.8 (homebrew) | Ninja | shared | ✅ pass |
| Windows | Clang 19 (clang-cl) | Ninja | static | ✅ pass |
| Windows | Clang 19 (clang-cl) | Ninja | shared | ✅ pass |
| Windows | MSVC 194 | Ninja | static | ✅ pass |
| Windows | MSVC 194 | Ninja | shared | ✅ pass |

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
