### PR TITLE
libx265: fix clang-cl support on Windows

### DIFF
--- a/recipes/libx265/all/conanfile.py
+++ b/recipes/libx265/all/conanfile.py
@@ -39,6 +39,10 @@ class Libx265Conan(ConanFile):
         "with_numa": False,
     }
 
+    @property
+    def _is_msvc_like(self):
+        return is_msvc(self) or (self.settings.os == "Windows" and self.settings.compiler == "clang")
+
     def export_sources(self):
         export_conandata_patches(self)
 
@@ -52,7 +56,7 @@ class Libx265Conan(ConanFile):
         # FIXME: Disable assembly by default if host is Android for the moment. It fails to build
         if (self.settings.compiler == "apple-clang" and "arm" in self.settings.arch) or self.settings.os == "Android":
             self.options.assembly = False
-        if is_msvc(self) and self.settings.arch == "armv8":
+        if self._is_msvc_like and self.settings.arch == "armv8":
             # Build errors, possibly unsupported
             self.options.assembly = False
 
@@ -110,7 +114,7 @@ class Libx265Conan(ConanFile):
         tc.variables["MAIN12"] = self.options.bit_depth == 12
         tc.variables["ENABLE_HDR10_PLUS"] = self.options.HDR10
         tc.variables["ENABLE_SVT_HEVC"] = self.options.SVG_HEVC_encoder
-        if is_msvc(self):
+        if self._is_msvc_like:
             tc.variables["STATIC_LINK_CRT"] = is_msvc_static_runtime(self)
             tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0091"] = "NEW"
         if self.settings.os == "Linux":
@@ -148,13 +152,13 @@ class Libx265Conan(ConanFile):
         cmake.install()
 
         if self.options.shared:
-            if is_msvc(self):
+            if self._is_msvc_like:
                 static_lib = "x265-static.lib"
             else:
                 static_lib = "libx265.a"
             os.unlink(os.path.join(self.package_folder, "lib", static_lib))
 
-        if is_msvc(self):
+        if self._is_msvc_like:
             name = "libx265.lib" if self.options.shared else "x265-static.lib"
             rename(self, os.path.join(self.package_folder, "lib", name),
                          os.path.join(self.package_folder, "lib", "x265.lib"))


### PR DESCRIPTION
### Summary

Changes to recipe: **libx265/3.6**, **libx265/4.1**

> **Prerequisite for ffmpeg clang-cl support.**
> libx265 is a direct ffmpeg dependency - without this fix, ffmpeg's `configure` fails with `LNK1181` when built with clang-cl.
> A dedicated ffmpeg clang-cl PR will follow.

#### Motivation

The recipe uses `is_msvc(self)` in several places for Windows-specific logic:
- `config_options()`: disable ARM64 assembly for MSVC
- `generate()`: set `STATIC_LINK_CRT` CMake variable
- `package()`: rename `x265-static.lib` → `x265.lib` and remove extra static lib

clang-cl on Windows uses the same ABI, tools, and naming conventions as MSVC, but `is_msvc()` returns `False` for `compiler=clang`. This causes:
1. `x265-static.lib` not renamed → FFmpeg's configure fails with `LNK1181: cannot open input file 'x265.lib'`
2. `STATIC_LINK_CRT` not set → CRT linkage mode ignored

#### Details

Added `_is_msvc_like` property that returns `True` for both MSVC and clang-cl (clang on Windows).
Applied to 4 callsites in `config_options()`, `generate()`, and `package()`.

The `validate()` method's `is_msvc()` + `is_msvc_static_runtime()` check is intentionally left unchanged — runtime validation needs the exact MSVC check.

#### Test matrix 3.6

| OS | Compiler | Generator | Linkage | Result |
|----|----------|-----------|---------|--------|
|| Linux | Clang 20.1.2 | Ninja | static | ✅ pass |
| Linux | Clang 20.1.2 | Ninja | shared | ✅ pass |
| Linux | GCC 14.2.0 | Ninja | static | ✅ pass |
| Linux | GCC 14.2.0 | Ninja | shared | ✅ pass |
 macOS | Apple Clang 21.0.0 | Ninja | static | ✅ pass |
| macOS | Apple Clang 21.0.0 | Ninja | shared | ✅ pass |
| macOS | Clang 21.1.8 (homebrew) | Ninja | static | ✅ pass |
| macOS | Clang 21.1.8 (homebrew) | Ninja | shared | ✅ pass |
| Windows | Clang 19 | Ninja | static | ✅ pass |
| Windows | Clang 19 | Ninja | shared | ✅ pass |
| Windows | MSVC 194 | Ninja | static | ✅ pass |
| Windows | MSVC 194 | Ninja | shared | ✅ pass |

#### Test matrix 4.1

| OS | Compiler | Generator | Linkage | Result |
|----|----------|-----------|---------|--------|
| Linux | Clang 20.1.2 | Ninja | static | ✅ pass |
| Linux | Clang 20.1.2 | Ninja | shared | ✅ pass |
| Linux | GCC 14.2.0 | Ninja | static | ✅ pass |
| Linux | GCC 14.2.0 | Ninja | shared | ✅ pass |
| macOS | Apple Clang 21.0.0 | Ninja | static | ✅ pass |
| macOS | Apple Clang 21.0.0 | Ninja | shared | ✅ pass |
| macOS | Clang 21.1.8 (homebrew) | Ninja | static | ✅ pass |
| macOS | Clang 21.1.8 (homebrew) | Ninja | shared | ✅ pass |
| Windows | Clang 19 | Ninja | static | ✅ pass |
| Windows | Clang 19 | Ninja | shared | ✅ pass |
| Windows | MSVC 194 | Ninja | static | ✅ pass |
| Windows | MSVC 194 | Ninja | shared | ✅ pass |

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
