### PR TITLE
openssl: fix clang-cl support on Windows

### DIFF
--- a/recipes/openssl/3.x.x/conanfile.py
+++ b/recipes/openssl/3.x.x/conanfile.py
@@ -552,6 +552,11 @@ class OpenSSLConan(ConanFile):
 
     def package(self):
         copy(self, "*LICENSE*", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        # clang-cl: /Zi is treated as /Z7 (embedded debug info), so ossl_static.pdb
+        # is never created — but the Makefile's install_sw tries to copy it.
+        # Create a dummy so install doesn't fail; rm(*.pdb) below deletes it anyway.
+        if self._is_clang_cl and not self.options.shared:
+            save(self, os.path.join(self.source_folder, "ossl_static.pdb"), "")
         self._make_install()
         if is_apple_os(self):
             fix_apple_shared_install_name(self)


### PR DESCRIPTION
### Summary

Changes to recipe: **openssl/3.x.x** (all 3.x versions)

> **Prerequisite for ffmpeg clang-cl support.**
> openssl is a direct ffmpeg dependency - without this fix, OpenSSL static builds fail with clang-cl, blocking the ffmpeg build.
> A dedicated ffmpeg clang-cl PR will follow.

#### Motivation

When building OpenSSL as a **static library** with **clang-cl** on Windows, `nmake install_sw` fails because it tries to copy `ossl_static.pdb` - but clang-cl treats `/Zi` as `/Z7` (embedded debug info), so the PDB file is never produced.
```
NMAKE : fatal error U1073: don't know how to make 'ossl_static.pdb'
```

#### Details

Before calling `_make_install()`, create a dummy `ossl_static.pdb` file in the source folder when `_is_clang_cl and not self.options.shared`.
The existing `rm(*.pdb)` call later in `package()` cleans it up.

The recipe already recognizes clang-cl via its `_is_clang_cl` property.

#### Test matrix (all versions)

| OS | Compiler | Generator | Linkage | Result |
|----|----------|-----------|---------|--------|
| Linux | Clang 20.1.2 | Ninja | static | ✅ pass |
| Linux | Clang 20.1.2 | Ninja | shared | ✅ pass |
| Linux | GCC 14.2.0 | Ninja | static | ✅ pass |
| Linux | GCC 14.2.0 | Ninja | shared | ✅ pass |
| macOS | Apple Clang 21.0.0 | Ninja | static | ✅ pass |
| macOS | Apple Clang 21.0.0 | Ninja | shared | ✅ pass |
| macOS | Clang 21.1.8 (homebrew) | Ninja | static | ✅ pass |
| macOS | Clang 21.1.8 (homebrew) | Ninja | shared | ✅ pass |
| Windows | Clang 19 (clang-cl) | Ninja | static | ✅ pass |
| Windows | Clang 19 (clang-cl) | Ninja | shared | ✅ pass |
| Windows | MSVC 194 | Ninja | static | ✅ pass |
| Windows | MSVC 194 | Ninja | shared | ✅ pass |

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
