### PR TITLE
libjxl: version bump 0.11.2 + fix C++23 Debug build + fPIC patch

### DIFF
--- a/recipes/libjxl/all/conandata.yml
+++ b/recipes/libjxl/all/conandata.yml
@@ -5,3 +5,12 @@ sources:
   "0.11.1":
     url: "https://github.com/libjxl/libjxl/archive/v0.11.1.tar.gz"
     sha256: "1492dfef8dd6c3036446ac3b340005d92ab92f7d48ee3271b5dac1d36945d3d9"
+patches:
+  "0.11.2":
+    - patch_file: "patches/001-remove-forced-pic.patch"
+      patch_description: "Remove hardcoded CMAKE_POSITION_INDEPENDENT_CODE (let Conan control fPIC)"
+      patch_type: "conan"
+  "0.11.1":
+    - patch_file: "patches/001-remove-forced-pic.patch"
+      patch_description: "Remove hardcoded CMAKE_POSITION_INDEPENDENT_CODE (let Conan control fPIC)"
+      patch_type: "conan"

--- a/recipes/libjxl/all/conanfile.py
+++ b/recipes/libjxl/all/conanfile.py
@@ -116,10 +116,9 @@ class LibjxlConan(ConanFile):
             # TODO: add support for the jpegli JPEG encoder library
             tc.variables["JPEGXL_ENABLE_JPEGLI"] = False
             tc.variables["JPEGXL_ENABLE_JPEGLI_LIBJPEG"] = False
-        # Workaround for libjxl#3159: DebugString() in dec_modular.cc uses unqualified
-        # scoped enum values (GlobalData instead of Kind::GlobalData) which MSVC rejects
-        # in C++23 mode (-std:c++latest). Setting JXL_DEBUG_V_LEVEL=0 disables the debug
-        # logging code path entirely, avoiding the compile error.
+        # Workaround for libjxl#3159: DebugString() in dec_modular.cc uses unqualified scoped enum values
+        # (GlobalData instead of Kind::GlobalData) which MSVC rejects in C++23 mode (-std:c++latest).
+        # Setting JXL_DEBUG_V_LEVEL=0 disables the debug logging code path entirely, avoiding the compile error.
         # https://github.com/libjxl/libjxl/issues/3159
         if Version(self.version) >= "0.9" and self.settings.build_type == "Debug" and is_msvc(self):
             tc.preprocessor_definitions["JXL_DEBUG_V_LEVEL"] = 0

--- a/recipes/libjxl/all/conanfile.py
+++ b/recipes/libjxl/all/conanfile.py
@@ -4,7 +4,7 @@ from conan import ConanFile
 from conan.tools.build import cross_building, stdcpp_library, check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.env import VirtualBuildEnv
-from conan.tools.files import copy, get, rmdir, save, rm, replace_in_file
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, save, rm, replace_in_file
 from conan.tools.gnu import PkgConfigDeps
 from conan.tools.microsoft import is_msvc
 from conan.tools.scm import Version
@@ -40,6 +40,7 @@ class LibjxlConan(ConanFile):
     }
 
     def export_sources(self):
+        export_conandata_patches(self)
         copy(self, "conan_deps.cmake", self.recipe_folder, os.path.join(self.export_sources_folder, "src"))
 
     def config_options(self):
@@ -115,10 +116,13 @@ class LibjxlConan(ConanFile):
             # TODO: add support for the jpegli JPEG encoder library
             tc.variables["JPEGXL_ENABLE_JPEGLI"] = False
             tc.variables["JPEGXL_ENABLE_JPEGLI_LIBJPEG"] = False
-        # TODO: can hopefully be removed in newer versions
+        # Workaround for libjxl#3159: DebugString() in dec_modular.cc uses unqualified
+        # scoped enum values (GlobalData instead of Kind::GlobalData) which MSVC rejects
+        # in C++23 mode (-std:c++latest). Setting JXL_DEBUG_V_LEVEL=0 disables the debug
+        # logging code path entirely, avoiding the compile error.
         # https://github.com/libjxl/libjxl/issues/3159
         if Version(self.version) >= "0.9" and self.settings.build_type == "Debug" and is_msvc(self):
-            tc.preprocessor_definitions["JXL_DEBUG_V_LEVEL"] = 1
+            tc.preprocessor_definitions["JXL_DEBUG_V_LEVEL"] = 0
         tc.generate()
 
         deps = CMakeDeps(self)
@@ -136,15 +140,14 @@ class LibjxlConan(ConanFile):
         return self.settings.get_safe("compiler.libcxx") in ["libstdc++", "libstdc++11"]
 
     def _patch_sources(self):
+        apply_conandata_patches(self)
         # Disable tools, extras and third_party
         save(self, os.path.join(self.source_folder, "tools", "CMakeLists.txt"), "")
         save(self, os.path.join(self.source_folder, "third_party", "CMakeLists.txt"), "")
         # FindAtomics.cmake values are set by CMakeToolchain instead
         save(self, os.path.join(self.source_folder, "cmake", "FindAtomics.cmake"), "")
 
-        # Allow fPIC to be set by Conan
-        replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
-                        "set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)", "")
+        # Allow fPIC to be set by Conan (per-target, the root CMakeLists.txt is handled by patch)
         for cmake_file in ["jxl.cmake", "jxl_threads.cmake", "jxl_cms.cmake", "jpegli.cmake"]:
             path = os.path.join(self.source_folder, "lib", cmake_file)
             if os.path.exists(path):

--- a/recipes/libjxl/all/patches/001-remove-forced-pic.patch
+++ b/recipes/libjxl/all/patches/001-remove-forced-pic.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -30,7 +30,7 @@
+ if(CHECK_PIE_SUPPORTED)
+   check_pie_supported(LANGUAGES CXX)
+   if(CMAKE_CXX_LINK_PIE_SUPPORTED)
+-    set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
++    # Removed: let Conan/consumer control fPIC via CMake variables
+   endif()
+ endif()
+ 


### PR DESCRIPTION
### Summary

Changes to recipe: **libjxl/all** (version 0.11.2 added, recipe fixes for the other version)

> **Prerequisite for ffmpeg clang-cl support.**
> libjxl is a direct ffmpeg dependency (JPEG XL decoding) — this recipe correction is needed for the ffmpeg clang-cl PR that follows.

#### Motivation

**1. Version bump 0.11.2**  - security fixes:
- **CVE-2025-12474**: tile dimension overflow in low-memory rendering pipeline
- **CVE-2026-1837**: incorrect number of channels for gray-to-gray color transform

**2. Fix `JXL_DEBUG_V_LEVEL`**
   The existing workaround for [libjxl#3159](https://github.com/libjxl/libjxl/issues/3159) sets `JXL_DEBUG_V_LEVEL=1` for Debug+MSVC builds, but this is the wrong value.
   `JXL_DEBUG_V_LEVEL=1` **enables** the debug logging code in `dec_modular.cc`, whose `DebugString()` function uses unqualified scoped enum values:
```cpp
// lib/jxl/dec_modular.cc
case Kind::GlobalData:  return "GlobalData";   // OK in C++20
case GlobalData:        return "GlobalData";   // ERROR in C++23 with MSVC
```
   MSVC in C++23 mode (`/std:c++latest`) rejects `GlobalData` without the `Kind::` qualifier.
   The fix: set `JXL_DEBUG_V_LEVEL=0` instead, which disables the problematic code path entirely.

**3. Use patch file for fPIC**
   Replace the `replace_in_file` call that removes `set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)` from the root `CMakeLists.txt` with a proper `.patch` file applied via `apply_conandata_patches()`.
   The patch is cleaner (in my opinion).

#### Details

**Version bump:**
- Add `0.11.2` source URL + SHA256 to `conandata.yml`
- Add `0.11.2` to `config.yml`

**Bug fix (JXL_DEBUG_V_LEVEL):**
- Change `JXL_DEBUG_V_LEVEL` from `1` to `0` in `generate()` for Debug and MSVC
- Updated comment to explain the root cause (unqualified scoped enum values)

**fPIC patch:**
- Add `patches/001-remove-forced-pic.patch` for both 0.11.1 and 0.11.2
- Add `export_conandata_patches(self)` to `export_sources()`
- Add `apply_conandata_patches(self)` to `_patch_sources()`
- Remove `replace_in_file` call on root `CMakeLists.txt` (now handled by patch)

#### Test matrix 0.11.1

| OS | Compiler | Generator | Linkage | Result |
|----|----------|-----------|---------|--------|
| Linux | Clang 20.1.2 | Ninja | static | ✅ pass |
| Linux | Clang 20.1.2 | Ninja | shared | ✅ pass |
| Linux | GCC 14.2.0 | Ninja | static | ✅ pass |
| Linux | GCC 14.2.0 | Ninja | shared | ✅ pass |
| macOS | Apple Clang 21.0.0 | Ninja | static | ✅ pass |
| macOS | Apple Clang 21.0.0 | Ninja | shared | ✅ pass |
| macOS | Clang 21.1.8 (homebrew) | Ninja | static | ✅ pass |
| macOS | Clang 21.1.8 (homebrew) | Ninja | shared | ✅ pass |
| Windows | Clang 19 (clang-cl) | Ninja | static | ✅ pass |
| Windows | Clang 19 (clang-cl) | Ninja | shared | ✅ pass |
| Windows | MSVC 194 | Ninja | static | ✅ pass |
| Windows | MSVC 194 | Ninja | shared | ✅ pass |

#### Test matrix 0.11.2

| OS | Compiler | Generator | Linkage | Result |
|----|----------|-----------|---------|--------|
| Linux | Clang 20.1.2 | Ninja | static | ✅ pass |
| Linux | Clang 20.1.2 | Ninja | shared | ✅ pass |
| Linux | GCC 14.2.0 | Ninja | static | ✅ pass |
| Linux | GCC 14.2.0 | Ninja | shared | ✅ pass |
| macOS | Apple Clang 21.0.0 | Ninja | static | ✅ pass |
| macOS | Apple Clang 21.0.0 | Ninja | shared | ✅ pass |
| macOS | Clang 21.1.8 (homebrew) | Ninja | static | ✅ pass |
| macOS | Clang 21.1.8 (homebrew) | Ninja | shared | ✅ pass |
| Windows | Clang 19 (clang-cl) | Ninja | static | ✅ pass |
| Windows | Clang 19 (clang-cl) | Ninja | shared | ✅ pass |
| Windows | MSVC 194 | Ninja | static | ✅ pass |
| Windows | MSVC 194 | Ninja | shared | ✅ pass |

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
