### PR TITLE
ffmpeg: fix MSVC dynamic debug + add clang-cl support on Windows

### DIFF
--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -464,6 +464,18 @@ class FFMpegConan(ConanFile):
             "SunOS": "sunos",
         }.get(str(self.settings.os), "none")
 
+    @property
+    def _is_msvc_like(self):
+        """True for both MSVC and clang-cl on Windows.
+
+        clang-cl accepts cl.exe flags and needs --toolchain=msvc,
+        -LIBPATH: (not -L), and cl-style output paths.
+        """
+        return is_msvc(self) or (
+            self.settings.os == "Windows"
+            and str(self.settings.compiler) == "clang"
+        )
+
     def _patch_sources(self):
         apply_conandata_patches(self)
         if Version(self.version) < "5.1":
@@ -491,10 +503,10 @@ class FFMpegConan(ConanFile):
     def _default_compilers(self):
         if self.settings.compiler == "gcc":
             return {"cc": "gcc", "cxx": "g++"}
+        elif self._is_msvc_like:
+            return {"cc": "cl.exe", "cxx": "cl.exe"}
         elif self.settings.compiler in ["clang", "apple-clang"]:
             return {"cc": "clang", "cxx": "clang++"}
-        elif is_msvc(self):
-            return {"cc": "cl.exe", "cxx": "cl.exe"}
         return {}
 
     def _create_toolchain(self):
@@ -685,7 +697,11 @@ class FFMpegConan(ConanFile):
         if self.settings.build_type == "Debug":
             args.extend([
                 "--disable-optimizations",
-                "--disable-mmx",
+                # --disable-mmx removed: it cascades to disable all x86 SIMD (SSE/AVX/etc.)
+                # and empties X86ASMFLAGS. Combined with --disable-optimizations (-Od on MSVC),
+                # which prevents dead-code elimination of EXTERNAL_*() guards, this causes
+                # unresolved NASM symbols at link time. Runtime dispatch (av_get_cpu_flags)
+                # is safe regardless.
                 "--disable-stripping",
                 "--enable-debug",
             ])
@@ -725,7 +741,7 @@ class FFMpegConan(ConanFile):
             # unlike other tools that use the PKG_CONFIG environment variable
             # if we are aware the user has requested a specific pkg-config, we pass it to the configure script
             args.append(f"--pkg-config={unix_path(self, pkg_config)}")
-        if is_msvc(self):
+        if self._is_msvc_like:
             args.append("--toolchain=msvc")
             if not check_min_vs(self, "190", raise_invalid=False):
                 # Visual Studio 2013 (and earlier) doesn't support "inline" keyword for C (only for C++)
@@ -742,8 +758,8 @@ class FFMpegConan(ConanFile):
         tc.configure_args.extend(args)
         tc.generate()
 
-        if is_msvc(self):
-            # Custom AutotoolsDeps for cl like compilers
+        if self._is_msvc_like:
+            # Custom AutotoolsDeps for cl-like compilers (MSVC + clang-cl)
             # workaround for https://github.com/conan-io/conan/issues/12784
             includedirs = []
             defines = []
@@ -810,7 +826,7 @@ class FFMpegConan(ConanFile):
         autotools.install()
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         rmdir(self, os.path.join(self.package_folder, "share"))
-        if is_msvc(self):
+        if self._is_msvc_like:
             if self.options.shared:
                 # ffmpeg created `.lib` files in the `/bin` folder
                 for fn in os.listdir(os.path.join(self.package_folder, "bin")):

--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -755,6 +755,14 @@ class FFMpegConan(ConanFile):
             args.append("--extra-cflags={}".format(" ".join(tc.cflags)))
         if tc.ldflags:
             args.append("--extra-ldflags={}".format(" ".join(tc.ldflags)))
+
+        # On Linux, libsoxr statically links libm functions (ceil, log, sin…).
+        # ffmpeg's configure uses `require libsoxr soxr.h soxr_create -lsoxr`
+        # (not pkg-config), so -lm must be injected via --extra-libs for the
+        # link test to succeed. macOS/Windows don't need this (libm is implicit).
+        if self.options.get_safe("with_soxr") and self.settings.os in ("Linux", "FreeBSD"):
+            args.append("--extra-libs=-lm")
+
         tc.configure_args.extend(args)
         tc.generate()
 


### PR DESCRIPTION
### Summary

Changes to recipe:  **ffmpeg/4.4.6**, **ffmpeg/7.1.3**, **ffmpeg/8.1** (all versions)

> **Prerequisite PRs** (must be merged before this one builds when twolame is enabled):
> - [ ] #29865
>
> **Prerequisite PRs** (must be merged before this one builds with clang-cl):
> - [ ] #29916
> - [ ] #29917
> - [ ] #29922
> - [ ] #29923
> - [ ] #29925
> - [x] #29926
> - [x] ~#29927~
>  won't be fixed, has to be built using MSVC in the Conan profile (see [#29863](https://github.com/conan-io/conan-center-index/issues/29873#issuecomment-4207144629)):
>  `openssl/*:tools.build:compiler_executables={"c": "cl", "cpp": "cl"}`
> - [ ] #29928
> - [ ] #29929
>
> Without these, ffmpeg's clang-cl dependency chain is broken.

#### Motivation

Two independent bugs affect ffmpeg builds on Windows:
1. **Debug builds produce unresolved NASM symbols**:
   `--disable-mmx` in the Debug configure flags cascades to disable all x86 SIMD extensions (SSE2, AVX2, etc.), which empties `X86ASMFLAGS` (→ NASM assembly files are never compiled).
   Combined with `--disable-optimizations` (MSVC `-Od`), the compiler does not eliminate dead code guarded by `EXTERNAL_*()` macros (`(0 && ...)`), so function pointer assignments to the missing NASM symbols survive to the linker:
   ```
   libavcodec\avcodec-62.dll : fatal error LNK1120: 12 unresolved externals
   ```
   GCC/Clang are not affected because they eliminate `if(0)` branches even at `-O0`.
   ELF linkers also don't require all symbols resolved in shared libs by default.
   This bug only manifests on **Windows + MSVC + Debug + shared**.

2. **clang-cl not supported**:
   clang-cl shares MSVC's ABI, linker, and toolchain but `is_msvc()` returns `False`.
   This causes the recipe to skip `--toolchain=msvc`, use GCC-style AutotoolsDeps instead of MSVC-style, and to skip `.lib` renaming in `package()`.

#### Details

**Fix 1: remove `--disable-mmx`:**
- Remove `--disable-mmx` from the Debug configure args.
  This flag was presumably added to reduce compile time in Debug, but it has the side effect of disabling ALL x86 SIMD (SSE, AVX, etc.) and the x86asm (NASM) subsystem entirely.
- Runtime SIMD dispatch via `av_get_cpu_flags()` is safe regardless of compile-time SIMD enablement - this is how ffmpeg is designed to work.

**Fix 2: `_is_msvc_like` property:**
- Add `_is_msvc_like` property returning `True` for both MSVC and clang on Windows.
  Applied to 4 locations:
  - `_default_compilers`: clang-cl gets `cc=cl.exe` (must come before the generic clang branch which returns `cc=clang`)
  - `generate()` toolchain: passes `--toolchain=msvc` for clang-cl
  - `generate()` AutotoolsDeps: uses MSVC-style `-LIBPATH:` / `-I` flags
  - `package()`: renames `.a` → `.lib` and moves import libs from `bin/` to `lib/`

#### Root cause analysis (Fix 1)

ffmpeg's configure with `--disable-mmx`:
1. Sets `HAVE_SSE2_EXTERNAL=0`, `HAVE_AVX2_EXTERNAL=0`, etc. in `config.h`
2. Empties `X86ASMFLAGS` in `config.mak` → NASM `.asm` files never compiled
3. Dispatch files like `libavcodec/x86/lpc_init.c` are still compiled (they're C, not asm).
   They declare `extern` asm symbols unconditionally and assign them behind `EXTERNAL_SSE2(cpu_flags)` guards
4. `EXTERNAL_SSE2()` expands to `(HAVE_SSE2_EXTERNAL && ...)` = `(0 && ...)`
5. With optimizations, the compiler DCEs the dead branch → no reference to asm symbols → link succeeds
6. With `-Od` (MSVC Debug), no DCE → the `extern` function pointers are referenced → linker can't find them → 12 unresolved externals

#### Test matrix 8.1

| OS | Compiler | Generator | Linkage | Result |
|----|----------|-----------|---------|--------|
| Linux | Clang 20.1.2 | Ninja | static | ✅ pass |
| Linux | Clang 20.1.2 | Ninja | shared | ✅ pass |
| Linux | GCC 14.2.0 | Ninja | static | ✅ pass |
| Linux | GCC 14.2.0 | Ninja | shared | ✅ pass |
| macOS | Apple Clang 21.0.0 | Ninja | static | ✅ pass |
| macOS | Apple Clang 21.0.0 | Ninja | shared | ✅ pass |
| macOS | Clang 21.1.8 (homebrew) | Ninja | static | ✅ pass |
| macOS | Clang 21.1.8 (homebrew) | Ninja | shared | ✅ pass |
| Windows | Clang 19 (clang-cl) | Ninja | static | ✅ pass |
| Windows | Clang 19 (clang-cl) | Ninja | shared | ✅ pass |
| Windows | MSVC 194 | Ninja | static | ✅ pass |
| Windows | MSVC 194 | Ninja | shared | ✅ pass |

#### Test matrix 7.1.3

| OS | Compiler | Generator | Linkage | Result |
|----|----------|-----------|---------|--------|
| Linux | Clang 20.1.2 | Ninja | static | ✅ pass |
| Linux | Clang 20.1.2 | Ninja | shared | ✅ pass |
| Linux | GCC 14.2.0 | Ninja | static | ✅ pass |
| Linux | GCC 14.2.0 | Ninja | shared | ✅ pass |
| macOS | Apple Clang 21.0.0 | Ninja | static | ✅ pass |
| macOS | Apple Clang 21.0.0 | Ninja | shared | ✅ pass |
| macOS | Clang 21.1.8 (homebrew) | Ninja | static | ✅ pass |
| macOS | Clang 21.1.8 (homebrew) | Ninja | shared | ✅ pass |
| Windows | Clang 19 (clang-cl) | Ninja | static | ✅ pass |
| Windows | Clang 19 (clang-cl) | Ninja | shared | ✅ pass |
| Windows | MSVC 194 | Ninja | static | ✅ pass |
| Windows | MSVC 194 | Ninja | shared | ✅ pass |

#### Test matrix 4.4.6

| OS | Compiler | Generator | Linkage | Result |
|----|----------|-----------|---------|--------|
| Linux | Clang 20.1.2 | Ninja | static | ✅ pass |
| Linux | Clang 20.1.2 | Ninja | shared | ✅ pass |
| Linux | GCC 14.2.0 | Ninja | static | ✅ pass |
| Linux | GCC 14.2.0 | Ninja | shared | ✅ pass |
| macOS | Apple Clang 21.0.0 | Ninja | static | ✅ pass |
| macOS | Apple Clang 21.0.0 | Ninja | shared | ✅ pass |
| macOS | Clang 21.1.8 (homebrew) | Ninja | static | ✅ pass |
| macOS | Clang 21.1.8 (homebrew) | Ninja | shared | ✅ pass |
| Windows | Clang 19 (clang-cl) | Ninja | static | ✅ pass |
| Windows | Clang 19 (clang-cl) | Ninja | shared | ✅ pass |
| Windows | MSVC 194 | Ninja | static | ✅ pass |
| Windows | MSVC 194 | Ninja | shared | ✅ pass |

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
