### PR TITLE
fix: libcurl Windows static build with libnghttp2

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -573,6 +573,8 @@ class LibcurlConan(ConanFile):
             tc.variables["CURL_DISABLE_WEBSOCKETS"] = not self.options.with_websockets
         if self.options.with_nghttp2:
             tc.variables["NGHTTP2_USE_STATIC_LIBS"] = not self.dependencies["libnghttp2"].options.shared
+        if self.options.with_zstd:
+            tc.variables["ZSTD_USE_STATIC_LIBS"] = not self.dependencies["zstd"].options.shared
 
         # Also disables NTLM_WB if set to false
         if not self.options.with_ntlm:

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -220,6 +220,13 @@ class LibcurlConan(ConanFile):
         cert_url = self.conf.get("user.libcurl.cert:url", check_type=str) or "https://curl.se/ca/cacert-2025-11-04.pem"
         cert_sha256 = self.conf.get("user.libcurl.cert:sha256", check_type=str) or "8ac40bdd3d3e151a6b4078d2b2029796e8f843e3f86fbf2adbc4dd9f05e79def"
         download(self, cert_url, "cacert.pem", verify=True, sha256=cert_sha256)
+        replace_in_file(self, "CMakeLists.txt", "find_package(NGHTTP2 MODULE)", "find_package(NGHTTP2 CONFIG REQUIRED)")
+        replace_in_file(self, "CMakeLists.txt", "find_package(Cares MODULE REQUIRED)", "find_package(Cares CONFIG REQUIRED)")
+        replace_in_file(self, os.path.join("CMake", "Macros.cmake"), "find_package(${_find_name})", "find_package(${_find_name} CONFIG REQUIRED)")
+        replace_in_file(self, os.path.join("CMake", "Macros.cmake"), "find_package(${_find_name} MODULE)", "find_package(${_find_name} CONFIG REQUIRED)")
+        replace_in_file(self, os.path.join("CMake", "Macros.cmake"), "find_package(${_find_name} REQUIRED)", "find_package(${_find_name} CONFIG REQUIRED)")
+        replace_in_file(self, os.path.join("CMake", "Macros.cmake"), "find_package(${_find_name} MODULE REQUIRED)", "find_package(${_find_name} CONFIG REQUIRED)")
+
 
     def generate(self):
         env = VirtualBuildEnv(self)
@@ -571,10 +578,6 @@ class LibcurlConan(ConanFile):
             tc.variables["CURL_DISABLE_FORM_API"] = not self.options.with_form_api
         if "with_websockets" in self.options:
             tc.variables["CURL_DISABLE_WEBSOCKETS"] = not self.options.with_websockets
-        if self.options.with_nghttp2:
-            tc.variables["NGHTTP2_USE_STATIC_LIBS"] = not self.dependencies["libnghttp2"].options.shared
-        if self.options.with_zstd:
-            tc.variables["ZSTD_USE_STATIC_LIBS"] = not self.dependencies["zstd"].options.shared
 
         # Also disables NTLM_WB if set to false
         if not self.options.with_ntlm:

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -571,6 +571,8 @@ class LibcurlConan(ConanFile):
             tc.variables["CURL_DISABLE_FORM_API"] = not self.options.with_form_api
         if "with_websockets" in self.options:
             tc.variables["CURL_DISABLE_WEBSOCKETS"] = not self.options.with_websockets
+        if self.options.with_nghttp2 and is_msvc(self) and not self.dependencies["libnghttp2"].options.shared:
+            tc.preprocessor_definitions["NGHTTP2_STATICLIB"] = "1"
 
         # Also disables NTLM_WB if set to false
         if not self.options.with_ntlm:

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -571,8 +571,8 @@ class LibcurlConan(ConanFile):
             tc.variables["CURL_DISABLE_FORM_API"] = not self.options.with_form_api
         if "with_websockets" in self.options:
             tc.variables["CURL_DISABLE_WEBSOCKETS"] = not self.options.with_websockets
-        if self.options.with_nghttp2 and is_msvc(self) and not self.dependencies["libnghttp2"].options.shared:
-            tc.preprocessor_definitions["NGHTTP2_STATICLIB"] = "1"
+        if self.options.with_nghttp2:
+            tc.variables["NGHTTP2_USE_STATIC_LIBS"] = not self.dependencies["libnghttp2"].options.shared
 
         # Also disables NTLM_WB if set to false
         if not self.options.with_ntlm:


### PR DESCRIPTION
### Summary
Changes to recipe:  **libcurl/8.19.0**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
close: https://github.com/conan-io/conan-center-index/issues/29909

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
Tested with:
* libcurl/8.19.0 
* OpenSSL/3.5.1 
* zlib/1.3.1 
* brotli/1.1.0 
* zstd/1.5.7 
* c-ares/1.34.6 
* nghttp2/1.68.1


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
