### PR TITLE
userspace-rcu: fix pkg-config names and license

### DIFF
--- a/recipes/userspace-rcu/all/conanfile.py
+++ b/recipes/userspace-rcu/all/conanfile.py
@@ -13,7 +13,7 @@ required_conan_version = ">=1.53.0"
 class UserspaceRCUConan(ConanFile):
     name = "userspace-rcu"
     description = "Userspace RCU (read-copy-update) library"
-    license = "LGPL-2.1"
+    license = "LGPL-2.1-or-later"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://liburcu.org/"
     topics = "urcu"


### PR DESCRIPTION
### Summary
Changes to recipe:  **userspace-rcu/***

#### Motivation
- Upstream, pkg-config files are prefixed with "lib" (see https://git.lttng.org/?p=userspace-rcu.git;a=tree;f=src;h=bb3042fc8df219e7c960edabc95b2bcfd2f99814;hb=HEAD) while this recipe didn't use the prefix. This prevented using the package as a drop-in replacement.
- LGPL-2.1 license tag is deprecated (according to https://spdx.org/licenses/LGPL-2.1.html). Changed to "LGPL-2.1-or-later", which is the correct license according to https://git.lttng.org/?p=userspace-rcu.git;a=blob;f=LICENSE.md;h=6a5d2046c77bdeb228442d93bcc4b55ac9f84a54;hb=HEAD
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
- Change `license` property
- Changed `pkg_config_name` properties and added `pkg_config_aliases` for backward compatiblity

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
