### PR TITLE
catch2: bump version to 3.14.0

### DIFF
--- a/recipes/catch2/2.x.x/conandata.yml
+++ b/recipes/catch2/2.x.x/conandata.yml
@@ -2,18 +2,3 @@ sources:
   "2.13.10":
     url: "https://github.com/catchorg/Catch2/archive/v2.13.10.tar.gz"
     sha256: "d54a712b7b1d7708bc7a819a8e6e47b2fde9536f487b89ccbca295072a7d9943"
-  "2.13.9":
-    url: "https://github.com/catchorg/Catch2/archive/v2.13.9.tar.gz"
-    sha256: "06dbc7620e3b96c2b69d57bf337028bf245a211b3cddb843835bfe258f427a52"
-  "2.13.8":
-    url: "https://github.com/catchorg/Catch2/archive/v2.13.8.tar.gz"
-    sha256: "b9b592bd743c09f13ee4bf35fc30eeee2748963184f6bea836b146e6cc2a585a"
-  "2.13.7":
-    url: "https://github.com/catchorg/Catch2/archive/v2.13.7.tar.gz"
-    sha256: "3cdb4138a072e4c0290034fe22d9f0a80d3bcfb8d7a8a5c49ad75d3a5da24fae"
-  "2.12.4":
-    url: "https://github.com/catchorg/Catch2/archive/v2.12.4.tar.gz"
-    sha256: "5436725bbc6ee131a0bc9545bef31f0adabbb21fbc39fb6f1b2a42c12e4f8107"
-  "2.11.3":
-    url: "https://github.com/catchorg/Catch2/archive/v2.11.3.tar.gz"
-    sha256: "9a6967138062688f04374698fce4ce65908f907d8c0fe5dfe8dc33126bd46543"

--- a/recipes/catch2/3.x.x/conandata.yml
+++ b/recipes/catch2/3.x.x/conandata.yml
@@ -2,12 +2,3 @@ sources:
   "3.14.0":
     url: "https://github.com/catchorg/Catch2/archive/refs/tags/v3.14.0.tar.gz"
     sha256: "ba2a939efead3c833c499cf487e185762f419a71d30158cd1b43c6079c586490"
-  "3.13.0":
-    url: "https://github.com/catchorg/Catch2/archive/refs/tags/v3.13.0.tar.gz"
-    sha256: "650795f6501af514f806e78c554729847b98db6935e69076f36bb03ed2e985ef"
-  "3.12.0":
-    url: "https://github.com/catchorg/Catch2/archive/v3.12.0.tar.gz"
-    sha256: "e077079f214afc99fee940d91c14cf1a8c1d378212226bb9f50efff75fe07b23"
-  "3.11.0":
-    url: "https://github.com/catchorg/Catch2/archive/v3.11.0.tar.gz"
-    sha256: "82fa1cb59dc28bab220935923f7469b997b259eb192fb9355db62da03c2a3137"

--- a/recipes/catch2/config.yml
+++ b/recipes/catch2/config.yml
@@ -1,21 +1,5 @@
 versions:
   "3.14.0":
     folder: 3.x.x
-  "3.13.0":
-    folder: 3.x.x
-  "3.12.0":
-    folder: 3.x.x
-  "3.11.0":
-    folder: 3.x.x
   "2.13.10":
-    folder: 2.x.x
-  "2.13.9":
-    folder: 2.x.x
-  "2.13.8":
-    folder: 2.x.x
-  "2.13.7":
-    folder: 2.x.x
-  "2.12.4":
-    folder: 2.x.x
-  "2.11.3":
     folder: 2.x.x


### PR DESCRIPTION
### Summary

Changes to recipe:  **catch2/3.14.0**

#### Motivation

Update to latest version. 3.13.0 is not compilable with clang-22. For this the `__COUNTER__` fix introduced in 3.14.0 is required.

#### Details

Closes #29920


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
