### PR TITLE
flecs: Add version 4.1.4 and 4.1.5

### DIFF
--- a/recipes/flecs/all/conandata.yml
+++ b/recipes/flecs/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.1.5":
+    url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v4.1.5.tar.gz"
+    sha256: "8b94f56dfdda0b3c86110f651a4e0ec1c59030db43bb4810ae296a0630682ab9"
   "4.1.4":
     url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v4.1.4.tar.gz"
     sha256: "1ecd4b2b463388d1243c15a900dd62096b28cebba48ad76c204b562304945f0d"

--- a/recipes/flecs/all/conandata.yml
+++ b/recipes/flecs/all/conandata.yml
@@ -2,6 +2,9 @@ sources:
   "4.1.5":
     url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v4.1.5.tar.gz"
     sha256: "8b94f56dfdda0b3c86110f651a4e0ec1c59030db43bb4810ae296a0630682ab9"
+  "4.1.4":
+    url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v4.1.4.tar.gz"
+    sha256: "1ecd4b2b463388d1243c15a900dd62096b28cebba48ad76c204b562304945f0d"
   "3.2.11":
     url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v3.2.11.tar.gz"
     sha256: "8ebc5f6f3ec7bbba30b0afe9d22f157437925772857ea1c6e4201eb5d31b4fe5"

--- a/recipes/flecs/all/conandata.yml
+++ b/recipes/flecs/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.1.4":
+    url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v4.1.4.tar.gz"
+    sha256: "1ecd4b2b463388d1243c15a900dd62096b28cebba48ad76c204b562304945f0d"
   "4.1.1":
     url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v4.1.1.tar.gz"
     sha256: "4b3f2c073dcdbd2a62ce3e9fc5409504ab65acedacd9e3e650fd9a64ceac5881"

--- a/recipes/flecs/all/conandata.yml
+++ b/recipes/flecs/all/conandata.yml
@@ -2,57 +2,6 @@ sources:
   "4.1.5":
     url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v4.1.5.tar.gz"
     sha256: "8b94f56dfdda0b3c86110f651a4e0ec1c59030db43bb4810ae296a0630682ab9"
-  "4.1.4":
-    url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v4.1.4.tar.gz"
-    sha256: "1ecd4b2b463388d1243c15a900dd62096b28cebba48ad76c204b562304945f0d"
-  "4.1.1":
-    url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v4.1.1.tar.gz"
-    sha256: "4b3f2c073dcdbd2a62ce3e9fc5409504ab65acedacd9e3e650fd9a64ceac5881"
-  "4.0.4":
-    url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v4.0.4.tar.gz"
-    sha256: "a3b6238a913f65d90db18759ab5442393901da914e4a9bfe30aa8823687dce86"
-  "4.0.0":
-    url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v4.0.0.tar.gz"
-    sha256: "6c9826c8602f797acd775269d143763adfb3d3a93031cc81bced2b6d267469d2"
   "3.2.11":
     url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v3.2.11.tar.gz"
     sha256: "8ebc5f6f3ec7bbba30b0afe9d22f157437925772857ea1c6e4201eb5d31b4fe5"
-  "3.2.8":
-    url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v3.2.8.tar.gz"
-    sha256: "b40453a77b66e220408c50b119da54b153c248cf6f7025575e3fd1a8ff79f748"
-  "3.2.4":
-    url: "https://github.com/SanderMertens/flecs/archive/v3.2.4.tar.gz"
-    sha256: "0b65426053418911cae1c3f347748fba6eb7d4ae8860ce7fcc91ef25f386d4a1"
-  "3.1.4":
-    url: "https://github.com/SanderMertens/flecs/archive/v3.1.4.tar.gz"
-    sha256: "cc73d529ddc47891fc16c7dd965ca9c4239d1caccae024c81364bf3d49286fe0"
-  "3.1.3":
-    url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v3.1.3.tar.gz"
-    sha256: "52da12a8bae260be21bf29d97af622241efd822737d0a15e551cd92e30abd5c9"
-  "3.1.2":
-    url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v3.1.2.tar.gz"
-    sha256: "1fe4f78b44f2ded1355179a8395bb254fbd8a9db88b9f8ecd890472d60acf723"
-  "3.1.1":
-    url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v3.1.1.tar.gz"
-    sha256: "f31edfa258b90d086c311ad5ccc60e8e1ab0448aa10856d96e9e503cc15c1c63"
-  "3.1.0":
-    url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v3.1.0.tar.gz"
-    sha256: "67e7cf4ff2abe661d9269b9d7f52ec7c39192f22e69bab638f27ef4337c12905"
-  "3.0.4":
-    url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v3.0.4.tar.gz"
-    sha256: "370e2bf1bd9fd6dc79b515887e7f048be676b0d95e23d43b2c8b76a5e645c8f4"
-  "3.0.1":
-    url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v3.0.1.tar.gz"
-    sha256: "a7c80dea0677721f83433623169cd4094c48270022c19adedac28331d546b539"
-  "2.4.8":
-    url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v2.4.8.tar.gz"
-    sha256: "9a8040a197e4b5e032524bc7183f68faa7b2f759c67b983b40018a7726561cac"
-  "2.4.7":
-    url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v2.4.7.tar.gz"
-    sha256: "ef3952fee5b83991fbd9aa77212c45171393b2dfd14001b2d1c7b97861934afa"
-  "2.4.6":
-    url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v2.4.6.tar.gz"
-    sha256: "e74798d4b387c85272b05ee574d991cbe1fb844680a1fc3d68818a02b5f59299"
-  "2.3.2":
-    url: "https://github.com/SanderMertens/flecs/archive/v2.3.2.tar.gz"
-    sha256: "ff2690953941b3f08d4e934e299fa8902e46ce8532edd176388d467ace33eebf"

--- a/recipes/flecs/all/conanfile.py
+++ b/recipes/flecs/all/conanfile.py
@@ -82,7 +82,7 @@ class FlecsConan(ConanFile):
             if self.settings.os in ["Linux", "FreeBSD"]:
                 self.cpp_info.components["_flecs"].system_libs.append("pthread")
             elif self.settings.os == "Windows":
-                self.cpp_info.components["_flecs"].system_libs.extend(["wsock32", "ws2_32"])
+                self.cpp_info.components["_flecs"].system_libs.extend(["wsock32", "ws2_32", "dbghelp"])
 
         # TODO: to remove in conan v2 once cmake_find_package* generators removed
         self.cpp_info.names["cmake_find_package"] = "flecs"

--- a/recipes/flecs/all/conanfile.py
+++ b/recipes/flecs/all/conanfile.py
@@ -47,14 +47,9 @@ class FlecsConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        if Version(self.version) < "3.0.1":
-            tc.variables["FLECS_STATIC_LIBS"] = not self.options.shared
-            tc.variables["FLECS_SHARED_LIBS"] = self.options.shared
-            tc.variables["FLECS_DEVELOPER_WARNINGS"] = False
-        else:
-            tc.variables["FLECS_STATIC"] = not self.options.shared
-            tc.variables["FLECS_SHARED"] = self.options.shared
-            tc.variables["FLECS_TESTS"] = False
+        tc.variables["FLECS_STATIC"] = not self.options.shared
+        tc.variables["FLECS_SHARED"] = self.options.shared
+        tc.variables["FLECS_TESTS"] = False
         tc.variables["FLECS_PIC"] = self.options.get_safe("fPIC", True)
         tc.generate()
 
@@ -74,7 +69,6 @@ class FlecsConan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "flecs")
         self.cpp_info.set_property("cmake_target_name", f"flecs::flecs{suffix}")
 
-        # TODO: back to global scope once cmake_find_package* generators removed
         self.cpp_info.components["_flecs"].libs = [f"flecs{suffix}"]
         if not self.options.shared:
             self.cpp_info.components["_flecs"].defines.append("flecs_STATIC")
@@ -84,9 +78,4 @@ class FlecsConan(ConanFile):
             elif self.settings.os == "Windows":
                 self.cpp_info.components["_flecs"].system_libs.extend(["wsock32", "ws2_32", "dbghelp"])
 
-        # TODO: to remove in conan v2 once cmake_find_package* generators removed
-        self.cpp_info.names["cmake_find_package"] = "flecs"
-        self.cpp_info.names["cmake_find_package_multi"] = "flecs"
-        self.cpp_info.components["_flecs"].names["cmake_find_package"] = f"flecs{suffix}"
-        self.cpp_info.components["_flecs"].names["cmake_find_package_multi"] = f"flecs{suffix}"
         self.cpp_info.components["_flecs"].set_property("cmake_target_name", f"flecs::flecs{suffix}")

--- a/recipes/flecs/all/conanfile.py
+++ b/recipes/flecs/all/conanfile.py
@@ -72,10 +72,9 @@ class FlecsConan(ConanFile):
         self.cpp_info.components["_flecs"].libs = [f"flecs{suffix}"]
         if not self.options.shared:
             self.cpp_info.components["_flecs"].defines.append("flecs_STATIC")
-        if Version(self.version) >= "3.0.0":
-            if self.settings.os in ["Linux", "FreeBSD"]:
-                self.cpp_info.components["_flecs"].system_libs.append("pthread")
-            elif self.settings.os == "Windows":
-                self.cpp_info.components["_flecs"].system_libs.extend(["wsock32", "ws2_32", "dbghelp"])
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.components["_flecs"].system_libs.append("pthread")
+        elif self.settings.os == "Windows":
+            self.cpp_info.components["_flecs"].system_libs.extend(["wsock32", "ws2_32", "dbghelp"])
 
         self.cpp_info.components["_flecs"].set_property("cmake_target_name", f"flecs::flecs{suffix}")

--- a/recipes/flecs/config.yml
+++ b/recipes/flecs/config.yml
@@ -1,39 +1,5 @@
 versions:
   "4.1.5":
     folder: all
-  "4.1.4":
-    folder: all
-  "4.1.1":
-    folder: all
-  "4.0.4":
-    folder: all
-  "4.0.0":
-    folder: all
   "3.2.11":
-    folder: all
-  "3.2.8":
-    folder: all
-  "3.2.4":
-    folder: all
-  "3.1.4":
-    folder: all
-  "3.1.3":
-    folder: all
-  "3.1.2":
-    folder: all
-  "3.1.1":
-    folder: all
-  "3.1.0":
-    folder: all
-  "3.0.4":
-    folder: all
-  "3.0.1":
-    folder: all
-  "2.4.8":
-    folder: all
-  "2.4.7":
-    folder: all
-  "2.4.6":
-    folder: all
-  "2.3.2":
     folder: all

--- a/recipes/flecs/config.yml
+++ b/recipes/flecs/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.1.5":
+    folder: all
   "4.1.4":
     folder: all
   "4.1.1":

--- a/recipes/flecs/config.yml
+++ b/recipes/flecs/config.yml
@@ -1,5 +1,7 @@
 versions:
   "4.1.5":
     folder: all
+  "4.1.4":
+    folder: all
   "3.2.11":
     folder: all

--- a/recipes/flecs/config.yml
+++ b/recipes/flecs/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.1.4":
+    folder: all
   "4.1.1":
     folder: all
   "4.0.4":


### PR DESCRIPTION
### Summary
Changes to recipe:  **flecs/4.1.4** and **flecs/4.1.5**

#### Motivation
Add recent release 4.1.4, needed by my company. Also added latest version 4.1.5 by request.

#### Details
4.1.4 requires dbghelp as a C++ component on Windows, which is a new dependency as of this version.
Tested on RHEL8 with Conan 2.15.0.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
