### PR TITLE
xz_utils: add version 5.8.3

### DIFF
--- a/recipes/xz_utils/all/conandata.yml
+++ b/recipes/xz_utils/all/conandata.yml
@@ -1,8 +1,8 @@
 sources:
-  "5.8.2":
+  "5.8.3":
     url:
-      - "https://tukaani.org/xz/xz-5.8.2.tar.xz"
-    sha256: "890966ec3f5d5cc151077879e157c0593500a522f413ac50ba26d22a9a145214"
+      - "https://tukaani.org/xz/xz-5.8.3.tar.xz"
+    sha256: "fff1ffcf2b0da84d308a14de513a1aa23d4e9aa3464d17e64b9714bfdd0bbfb6"
   "5.4.5":
     url:
       - "https://tukaani.org/xz/xz-5.4.5.tar.xz"

--- a/recipes/xz_utils/config.yml
+++ b/recipes/xz_utils/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "5.8.2":
+  "5.8.3":
     folder: all
   "5.4.5":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **xz_utils/5.8.3**

#### Motivation
This version includes a fix for [CVE-2026-34743](https://tukaani.org/xz/index-append-overflow.html) which affects all XZ Utils versions since 5.0.0.

#### Details
https://github.com/tukaani-project/xz/releases/tag/v5.8.3


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
