### PR TITLE
Add nxpp/1.0.19

### DIFF
--- a/recipes/nxpp/all/conandata.yml
+++ b/recipes/nxpp/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.0.19":
+    url: "https://github.com/Mik1810/nxpp/archive/refs/tags/v1.0.19.tar.gz"
+    sha256: "71115cb63f8fe41d8d8aa88a03663abae9d981a49574fb2fbe43e954d08edc41"

--- a/recipes/nxpp/all/conanfile.py
+++ b/recipes/nxpp/all/conanfile.py
@@ -1,0 +1,54 @@
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+import os
+
+
+class NxppConan(ConanFile):
+    name = "nxpp"
+    package_type = "header-library"
+
+    license = "MIT"
+    author = "Mik1810"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/Mik1810/nxpp"
+    description = "Header-only C++20 graph library on top of Boost Graph Library"
+    topics = ("graph", "boost", "bgl", "header-only", "cxx20")
+
+    settings = "os", "arch", "compiler", "build_type"
+    default_options = {"boost/*:header_only": True}
+    no_copy_source = True
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, "20")
+
+    def requirements(self):
+        self.requires("boost/1.86.0", transitive_headers=True)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def package_id(self):
+        self.info.clear()
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder, dst=self.package_folder)
+        copy(
+            self,
+            "*.hpp",
+            src=os.path.join(self.source_folder, "include"),
+            dst=os.path.join(self.package_folder, "include"),
+        )
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.includedirs = ["include"]
+        self.cpp_info.set_property("cmake_file_name", "nxpp")
+        self.cpp_info.set_property("cmake_target_name", "nxpp::nxpp")
+        self.cpp_info.requires = ["boost::boost"]

--- a/recipes/nxpp/all/conanfile.py
+++ b/recipes/nxpp/all/conanfile.py
@@ -23,8 +23,7 @@ class NxppConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def validate(self):
-        if self.settings.compiler.get_safe("cppstd"):
-            check_min_cppstd(self, "20")
+        check_min_cppstd(self, "20")
 
     def requirements(self):
         self.requires("boost/1.86.0", transitive_headers=True)

--- a/recipes/nxpp/all/conanfile.py
+++ b/recipes/nxpp/all/conanfile.py
@@ -29,6 +29,9 @@ class NxppConan(ConanFile):
     def requirements(self):
         self.requires("boost/1.86.0", transitive_headers=True)
 
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.16]")
+
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 

--- a/recipes/nxpp/all/conanfile.py
+++ b/recipes/nxpp/all/conanfile.py
@@ -10,7 +10,6 @@ class NxppConan(ConanFile):
     package_type = "header-library"
 
     license = "MIT"
-    author = "Mik1810"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/Mik1810/nxpp"
     description = "Header-only C++20 graph library on top of Boost Graph Library"

--- a/recipes/nxpp/all/conanfile.py
+++ b/recipes/nxpp/all/conanfile.py
@@ -25,7 +25,7 @@ class NxppConan(ConanFile):
         check_min_cppstd(self, "20")
 
     def requirements(self):
-        self.requires("boost/[>=1.74.0 <2]", transitive_headers=True)
+        self.requires("boost/[>=1.86.0 <2]", transitive_headers=True)
 
     def build_requirements(self):
         self.tool_requires("cmake/[>=3.16]")

--- a/recipes/nxpp/all/conanfile.py
+++ b/recipes/nxpp/all/conanfile.py
@@ -38,7 +38,7 @@ class NxppConan(ConanFile):
         self.info.clear()
 
     def package(self):
-        copy(self, "LICENSE", src=self.source_folder, dst=self.package_folder)
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
         copy(
             self,
             "*.hpp",

--- a/recipes/nxpp/all/conanfile.py
+++ b/recipes/nxpp/all/conanfile.py
@@ -16,7 +16,6 @@ class NxppConan(ConanFile):
     topics = ("graph", "boost", "bgl", "header-only", "cxx20")
 
     settings = "os", "arch", "compiler", "build_type"
-    default_options = {"boost/*:header_only": True}
     no_copy_source = True
 
     def layout(self):

--- a/recipes/nxpp/all/conanfile.py
+++ b/recipes/nxpp/all/conanfile.py
@@ -25,7 +25,7 @@ class NxppConan(ConanFile):
         check_min_cppstd(self, "20")
 
     def requirements(self):
-        self.requires("boost/1.86.0", transitive_headers=True)
+        self.requires("boost/[>=1.74.0 <2]", transitive_headers=True)
 
     def build_requirements(self):
         self.tool_requires("cmake/[>=3.16]")

--- a/recipes/nxpp/all/test_package/CMakeLists.txt
+++ b/recipes/nxpp/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.16)
+project(test_package LANGUAGES CXX)
+
+find_package(nxpp CONFIG REQUIRED)
+
+add_executable(test_package test_package.cpp)
+target_link_libraries(test_package PRIVATE nxpp::nxpp)

--- a/recipes/nxpp/all/test_package/conanfile.py
+++ b/recipes/nxpp/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class NxppTestPackageConan(ConanFile):
+    test_type = "explicit"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            self.run(os.path.join(self.cpp.build.bindir, "test_package"), env="conanrun")

--- a/recipes/nxpp/all/test_package/test_package.cpp
+++ b/recipes/nxpp/all/test_package/test_package.cpp
@@ -1,0 +1,7 @@
+#include <nxpp.hpp>
+
+int main() {
+    nxpp::GraphInt graph;
+    graph.add_edge(0, 1, 2);
+    return graph.has_edge(0, 1) ? 0 : 1;
+}

--- a/recipes/nxpp/config.yml
+++ b/recipes/nxpp/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.0.19":
+    folder: all


### PR DESCRIPTION
# Add nxpp/1.0.19

## Summary
Add a new ConanCenter recipe for nxpp version 1.0.19.

## Details
- Recipe layout: recipes/nxpp/all
- Immutable source: GitHub tag tarball v1.0.19 with sha256 in conandata.yml
- Dependency: boost/1.86.0 forced header-only
- Includes test_package based on CMake and explicit test type

## Local Validation
- conan create packaging/conan-center-index/recipes/nxpp/all --version=1.0.19 --profile:build=default --profile:host=default -s:h compiler.cppstd=20
- Package build: PASS
- test_package build and run: PASS