### PR TITLE
cminpack: Include Accelerate framework only for Macos

### DIFF
--- a/recipes/cminpack/all/conanfile.py
+++ b/recipes/cminpack/all/conanfile.py
@@ -1,6 +1,7 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir
+from conan.tools.apple import is_apple_os
 import os
 
 required_conan_version = ">=1.54.0"
@@ -93,8 +94,9 @@ class CMinpackConan(ConanFile):
             self.cpp_info.components['cminpack-single'].system_libs.append("m")
 
         # required apple frameworks
-        self.cpp_info.components['cminpack-double'].frameworks.append("Accelerate")
-        self.cpp_info.components['cminpack-single'].frameworks.append("Accelerate")
+        if is_apple_os(self):
+            self.cpp_info.components['cminpack-double'].frameworks.append("Accelerate")
+            self.cpp_info.components['cminpack-single'].frameworks.append("Accelerate")
 
         if not self.options.shared and self.settings.os == "Windows":
             self.cpp_info.components['cminpack-double'].defines.append("CMINPACK_NO_DLL")


### PR DESCRIPTION
### Summary
Changes to recipe:  **cminpack/1.3.8**

Only include frameworks for Macos to avoid compilation errors on other OS's.

#### Motivation
Unconditionally adding framework components (Accelerate) breaks gcc 14.3.0 / cmake 3.30.5 / conan 2.18.1 Linux build

#### Details
```
[build] : /usr/local/bin/c++ (...)  -framework Accelerate  (...) :
[build] c++: error: unrecognized command-line option ‘-framework
```


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
