### PR TITLE
flatbuffers: add version 25.1.21

### DIFF
--- a/recipes/flatbuffers/all/conandata.yml
+++ b/recipes/flatbuffers/all/conandata.yml
@@ -2,6 +2,9 @@ sources:
   "25.9.23":
     url: "https://github.com/google/flatbuffers/archive/refs/tags/v25.9.23.tar.gz"
     sha256: "9102253214dea6ae10c2ac966ea1ed2155d22202390b532d1dea64935c518ada"
+  "25.1.21":
+    url: "https://github.com/google/flatbuffers/archive/refs/tags/v25.1.21.tar.gz"
+    sha256: "7ab210001df1cd6234d0263801eeed3b941098bc9d6b41331832dd29cea4b555"
   "24.12.23":
     url: "https://github.com/google/flatbuffers/archive/v24.12.23.tar.gz"
     sha256: "7e2ef35f1af9e2aa0c6a7d0a09298c2cb86caf3d4f58c0658b306256e5bcab10"


### PR DESCRIPTION
### Summary
Changes to recipe:  **flatbuffers/25.1.21**

#### Motivation
Add support of flatbuffers version 25.1.21

#### Details
No changes in recipe are necessary, only sha256 checksum & url update


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
