### PR TITLE
wiringpi/3.10: fix Debug build failure with const switch-case labels

### DIFF
--- a/recipes/wiringpi/all/conandata.yml
+++ b/recipes/wiringpi/all/conandata.yml
@@ -23,3 +23,9 @@ sources:
   "2.50":
     url: "https://github.com/WiringPi/WiringPi/archive/final_official_2.50.tar.gz"
     sha256: "f1ddf17e876f88e074d4597767e365a1b5ef20414a38754884935b38d8c8e932"
+patches:
+  "3.10":
+    - patch_file: "patches/3.10-0001-fix-const-switch-case.patch"
+      patch_description: "Replace switch with if-else to fix 'case label does not reduce to an integer constant' error in Debug builds"
+      patch_type: "backport"
+      patch_source: "https://github.com/WiringPi/WiringPi/pull/387"

--- a/recipes/wiringpi/all/conanfile.py
+++ b/recipes/wiringpi/all/conanfile.py
@@ -2,7 +2,7 @@ import os
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import get, copy
+from conan.tools.files import get, copy, apply_conandata_patches, export_conandata_patches
 from conan.tools.scm import Version
 
 required_conan_version = ">=1.53.0"
@@ -31,6 +31,7 @@ class WiringpiConan(ConanFile):
 
     def export_sources(self):
         copy(self, "CMakeLists.txt", self.recipe_folder, self.export_sources_folder)
+        export_conandata_patches(self)
 
     def configure(self):
         if self.options.shared:
@@ -52,11 +53,6 @@ class WiringpiConan(ConanFile):
             if self.settings.compiler == "gcc" and \
                 Version(self.settings.compiler.version) < 8:
                 raise ConanInvalidConfiguration(f"{self.ref} requires gcc >= 8")
-            # wiringPi.c:1755:9: error: case label does not reduce to an integer constant
-            if self.settings.compiler == "gcc" and \
-                Version(self.settings.compiler.version).major == 11 and \
-                self.settings.build_type == "Debug":
-                raise ConanInvalidConfiguration(f"{self.ref} doesn't support gcc 11 in Debug build")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -71,6 +67,7 @@ class WiringpiConan(ConanFile):
         tc.generate()
 
     def build(self):
+        apply_conandata_patches(self)
         cmake = CMake(self)
         cmake.configure(build_script_folder=os.path.join(self.source_folder, os.pardir))
         cmake.build()

--- a/recipes/wiringpi/all/patches/3.10-0001-fix-const-switch-case.patch
+++ b/recipes/wiringpi/all/patches/3.10-0001-fix-const-switch-case.patch
@@ -1,0 +1,17 @@
+--- a/wiringPi/wiringPi.c
++++ b/wiringPi/wiringPi.c
+@@ -2182,10 +2182,10 @@
+     }
+
+     if (PI_MODEL_5 == RaspberryPiModel) {
+-      switch(gpio[2*pin] & RP1_STATUS_LEVEL_MASK) {
+-        default: // 11 or 00 not allowed, give LOW!
+-        case RP1_STATUS_LEVEL_LOW:  return LOW ;
+-        case RP1_STATUS_LEVEL_HIGH: return HIGH ;
++      if ((gpio[2*pin] & RP1_STATUS_LEVEL_MASK) == RP1_STATUS_LEVEL_HIGH) {
++        return HIGH ;
++      } else { // 11 or 00 not allowed, give LOW!
++        return LOW ;
+       }
+     } else {
+       if ((*(gpio + gpioToGPLEV [pin]) & (1 << (pin & 31))) != 0)


### PR DESCRIPTION
### Summary

wiringpi/3.10 fails to build with `build_type=Debug` (`-O0`) on any GCC version because `const unsigned int` variables are used as `switch` case labels — which are not integer constant expressions in strictly-conforming C. With optimization enabled (`-O1`+), GCC inlines the values before checking, masking the issue.

### Changes

- **Backport patch** from upstream [WiringPi/WiringPi#387](https://github.com/WiringPi/WiringPi/pull/387): replaces the `switch` statement with `if-else` in `digitalRead()`
- **Remove** the `ConanInvalidConfiguration` workaround that blocked GCC 11 + Debug builds — the patch fixes the root cause for all compiler versions
- **Add** `apply_conandata_patches` / `export_conandata_patches` to the recipe

### Upstream references

- [WiringPi/WiringPi#336](https://github.com/WiringPi/WiringPi/issues/336) — case label does not reduce to an integer constant
- [WiringPi/WiringPi#386](https://github.com/WiringPi/WiringPi/issues/386) — Compile errors when optimization is disabled
- [WiringPi/WiringPi#387](https://github.com/WiringPi/WiringPi/pull/387) — Fix (merged Aug 2025, not included in tag 3.10)

### Test plan

- [x] `conan create` with `build_type=Debug`, GCC 13 (x86_64) — **pass**
- [x] `conan create` with `build_type=Debug`, GCC 10 (cross armv7hf) — **pass** (was the original failure)
- [x] `conan create` with `build_type=Release`, GCC 10 (cross armv7hf) — **pass** (regression check)