### PR TITLE
libpng: add version 1.6.57

### DIFF
--- a/recipes/libpng/all/conandata.yml
+++ b/recipes/libpng/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "1.6.56":
-    url: "https://download.sourceforge.net/libpng/libpng-1.6.56.tar.xz"
-    sha256: "f7d8bf1601b7804f583a254ab343a6549ca6cf27d255c302c47af2d9d36a6f18"
+  "1.6.57":
+    url: "https://download.sourceforge.net/libpng/libpng-1.6.57.tar.xz"
+    sha256: "d10c20d7171569804cae8dfc13ba6dcd0662c41ed39d43d4d429314aafb10a80"

--- a/recipes/libpng/config.yml
+++ b/recipes/libpng/config.yml
@@ -1,4 +1,4 @@
 versions:
 # Keep only the latest version, unless there's strong reasons to keep older ones
-  "1.6.56":
+  "1.6.57":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **libpng/1.6.57**

#### Motivation
upstream fixes including CVE-2026-34757

#### Details
https://github.com/pnggroup/libpng/compare/v1.6.56...v1.6.57

Closes https://github.com/conan-io/conan-center-index/issues/29972

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
