### PR TITLE
luajit: add lua52compat option

### DIFF
--- a/recipes/luajit/all/conanfile.py
+++ b/recipes/luajit/all/conanfile.py
@@ -22,8 +22,8 @@ class LuajitConan(ConanFile):
     topics = ("lua", "jit")
     provides = "lua"
     settings = "os", "arch", "compiler", "build_type"
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": False, "fPIC": True}
+    options = {"shared": [True, False], "fPIC": [True, False], "lua52compat": [True, False]}
+    default_options = {"shared": False, "fPIC": True, "lua52compat": False}
 
     def export_sources(self):
         export_conandata_patches(self)
@@ -95,6 +95,8 @@ class LuajitConan(ConanFile):
         args = [f"PREFIX={unix_path(self, self.package_folder)}"]
         if is_apple_os(self) and self._macosx_deployment_target:
             args.append(f"MACOSX_DEPLOYMENT_TARGET={self._macosx_deployment_target}")
+        if self.options.lua52compat:
+            args.append("XCFLAGS+=-DLUAJIT_ENABLE_LUA52COMPAT")
         return args
 
     @property
@@ -110,7 +112,8 @@ class LuajitConan(ConanFile):
         if is_msvc(self):
             with chdir(self, os.path.join(self.source_folder, "src")):
                 variant = '' if self.options.shared else 'static'
-                self.run(f"msvcbuild.bat {variant}", env="conanbuild")
+                compat = ' lua52compat' if self.options.lua52compat else ''
+                self.run(f"msvcbuild.bat {variant}{compat}", env="conanbuild")
         else:
             with chdir(self, self.source_folder):
                 autotools = Autotools(self)


### PR DESCRIPTION
Adds a `lua52compat` boolean option (default `False`) that enables `LUAJIT_ENABLE_LUA52COMPAT` at build time.

This lets consumers do `self.options["luajit"].lua52compat = True` instead of having to pass `-DLUAJIT_ENABLE_LUA52COMPAT` through `tools.build:cflags` everywhere.

On Unix it passes `XCFLAGS+=-DLUAJIT_ENABLE_LUA52COMPAT` to make, on Windows it passes `lua52compat` to `msvcbuild.bat` (which already supports it natively).

Closes #29976