### PR TITLE
botan: refactor cmake file handling and add logic to distinguish apple-clang

### DIFF
--- a/recipes/botan/all/conanfile.py
+++ b/recipes/botan/all/conanfile.py
@@ -260,8 +260,6 @@ class BotanConan(ConanFile):
         with chdir(self, self.source_folder):
             # Note: this will fail to properly consider the package_folder if a "conan build" followed by a "conan export-pkg" is executed
             self.run(self._make_install_cmd)
-        if Version(self.version) >= "3.3.0":
-            rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
         fix_apple_shared_install_name(self)
 
     def package_info(self):
@@ -466,7 +464,10 @@ class BotanConan(ConanFile):
             self.output.warning("Disabling usage of getentropy(), getrandom(), and explicit_bzero() due to old glibc version")
             build_flags.append('--without-os-features=getentropy,getrandom,explicit_bzero')
 
-        build_flags.append('--without-pkg-config')
+        if Version(self.version) >= "3.3.0":
+            # Botan 3.3+ started shipping CMake config files, but we don't need
+            # them for Conan. Disable the installation of those files at build.
+            build_flags.append('--without-cmake-config')
 
         call_python = 'python' if self.settings.os == 'Windows' else ''
 
@@ -479,6 +480,7 @@ class BotanConan(ConanFile):
                          ' --build-targets={targets}'
                          ' --distribution-info="Conan"'
                          ' --without-documentation'
+                         ' --without-pkg-config'
                          ' --cc-abi-flags="{abi}"'
                          ' --extra-cxxflags="{cxxflags}"'
                          ' --cc={compiler}'

--- a/recipes/botan/all/conanfile.py
+++ b/recipes/botan/all/conanfile.py
@@ -303,7 +303,10 @@ class BotanConan(ConanFile):
     @property
     def _configure_cmd(self):
         if self.settings.compiler in ('clang', 'apple-clang'):
-            botan_compiler = 'clang'
+            if Version(self.version) >= "3.5.0" and self.settings.compiler == 'apple-clang':
+                botan_compiler = 'xcode'
+            else:
+                botan_compiler = 'clang'
         elif self.settings.compiler == 'gcc':
             botan_compiler = 'gcc'
         elif self.settings.os == 'Emscripten':


### PR DESCRIPTION
### Summary

Changes to recipe:  **botan/>=3.3**

#### Motivation

Starting with Botan 3.3.0 it ships with CMake config files that hook into `find_package()`. Given that Conan typically generates its own such CMake config files, they've always been removed from the package. Now, the recipe uses `--without-cmake-config` at configure-time which is more sustainable than manually deleting the generated files from the installation directory.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
