### PR TITLE
botan: distinguish between clang and XCode's clang

### DIFF
--- a/recipes/botan/all/conanfile.py
+++ b/recipes/botan/all/conanfile.py
@@ -305,7 +305,10 @@ class BotanConan(ConanFile):
     @property
     def _configure_cmd(self):
         if self.settings.compiler in ('clang', 'apple-clang'):
-            botan_compiler = 'clang'
+            if Version(self.version) >= "3.5.0" and self.settings.compiler == 'apple-clang':
+                botan_compiler = 'xcode'
+            else:
+                botan_compiler = 'clang'
         elif self.settings.compiler == 'gcc':
             botan_compiler = 'gcc'
         elif self.settings.os == 'Emscripten':


### PR DESCRIPTION
### Summary
Changes to recipe:  **botan/>=3.5.0**

#### Motivation

Starting with Botan 3.5.0 its configuration scripts distinguish between vanilla clang and Xcode's clang fork to properly detect the feature sets of both compilers. This adapts the recipe accordingly to report the correct compiler type to Botan's `./configure.py`.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
