### PR TITLE
Add swaggercpp/0.2.1

### DIFF
--- a/recipes/swaggercpp/all/conandata.yml
+++ b/recipes/swaggercpp/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.2.1":
+    url: "https://github.com/stescobedo92/swagger-cpp/archive/refs/tags/v0.2.1.tar.gz"
+    sha256: "2b5f40fbc686673a69fe4b39570fc18a2f37cbee2dbd7a9c5980d67f38ccdaa1"

--- a/recipes/swaggercpp/all/conanfile.py
+++ b/recipes/swaggercpp/all/conanfile.py
@@ -1,0 +1,61 @@
+import os
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get
+
+
+class SwaggerCppRecipe(ConanFile):
+    name = "swaggercpp"
+    description = "Professional C++23 library for Swagger/OpenAPI parsing, validation, traversal, and serialization."
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/stescobedo92/swagger-cpp"
+    topics = ("swagger", "openapi", "openapi3", "cpp23", "api")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {"shared": [True, False], "fPIC": [True, False]}
+    default_options = {"shared": False, "fPIC": True}
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("cpp-httplib/[>=0.18 <1]")
+        self.requires("nlohmann_json/[>=3.12 <4]")
+        self.requires("yaml-cpp/[>=0.8 <1]")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
+        toolchain = CMakeToolchain(self)
+        toolchain.variables["SWAGGERCPP_BUILD_TESTS"] = False
+        toolchain.variables["SWAGGERCPP_BUILD_BENCHMARKS"] = False
+        toolchain.variables["SWAGGERCPP_BUILD_EXAMPLES"] = False
+        toolchain.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE",
+             src=self.source_folder,
+             dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["swaggercpp"]
+        self.cpp_info.set_property("cmake_find_mode", "none")
+        self.cpp_info.set_property("cmake_file_name", "swaggercpp")
+        self.cpp_info.set_property("cmake_target_name", "swaggercpp::swaggercpp")
+        self.cpp_info.includedirs = ["include"]

--- a/recipes/swaggercpp/all/conanfile.py
+++ b/recipes/swaggercpp/all/conanfile.py
@@ -14,7 +14,7 @@ class SwaggerCppRecipe(ConanFile):
     license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/stescobedo92/swagger-cpp"
-    topics = ("swagger", "openapi", "openapi3", "cpp23", "api")
+    topics = ("swagger", "openapi", "openapi3", "rest", "json", "yaml")
     package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {"shared": [True, False], "fPIC": [True, False]}
@@ -32,9 +32,9 @@ class SwaggerCppRecipe(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("cpp-httplib/0.39.0")
-        self.requires("nlohmann_json/3.12.0")
-        self.requires("yaml-cpp/0.9.0")
+        self.requires("cpp-httplib/0.39.0", visible=False)
+        self.requires("nlohmann_json/3.12.0", transitive_headers=True)
+        self.requires("yaml-cpp/0.9.0", transitive_headers=True)
 
     def validate(self):
         check_min_cppstd(self, 23)
@@ -70,3 +70,4 @@ class SwaggerCppRecipe(ConanFile):
         self.cpp_info.libs = ["swaggercpp"]
         self.cpp_info.set_property("cmake_file_name", "swaggercpp")
         self.cpp_info.set_property("cmake_target_name", "swaggercpp::swaggercpp")
+        self.cpp_info.set_property("pkg_config_name", "swaggercpp")

--- a/recipes/swaggercpp/all/conanfile.py
+++ b/recipes/swaggercpp/all/conanfile.py
@@ -1,8 +1,11 @@
 import os
 
 from conan import ConanFile
+from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, get
+from conan.tools.files import copy, get, rmdir
+
+required_conan_version = ">=2.0.9"
 
 
 class SwaggerCppRecipe(ConanFile):
@@ -21,13 +24,20 @@ class SwaggerCppRecipe(ConanFile):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
     def layout(self):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("cpp-httplib/[>=0.18 <1]")
-        self.requires("nlohmann_json/[>=3.12 <4]")
-        self.requires("yaml-cpp/[>=0.8 <1]")
+        self.requires("cpp-httplib/0.39.0")
+        self.requires("nlohmann_json/3.12.0")
+        self.requires("yaml-cpp/0.9.0")
+
+    def validate(self):
+        check_min_cppstd(self, 23)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -52,10 +62,11 @@ class SwaggerCppRecipe(ConanFile):
              dst=os.path.join(self.package_folder, "licenses"))
         cmake = CMake(self)
         cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
 
     def package_info(self):
         self.cpp_info.libs = ["swaggercpp"]
-        self.cpp_info.set_property("cmake_find_mode", "none")
         self.cpp_info.set_property("cmake_file_name", "swaggercpp")
         self.cpp_info.set_property("cmake_target_name", "swaggercpp::swaggercpp")
-        self.cpp_info.includedirs = ["include"]

--- a/recipes/swaggercpp/all/test_package/CMakeLists.txt
+++ b/recipes/swaggercpp/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.26)
+project(test_package CXX)
+
+find_package(swaggercpp CONFIG REQUIRED)
+
+add_executable(swaggercpp_test_package src/example.cpp)
+target_link_libraries(swaggercpp_test_package PRIVATE swaggercpp::swaggercpp)
+target_compile_features(swaggercpp_test_package PRIVATE cxx_std_23)

--- a/recipes/swaggercpp/all/test_package/conanfile.py
+++ b/recipes/swaggercpp/all/test_package/conanfile.py
@@ -1,0 +1,32 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+
+
+class SwaggerCppTestPackage(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
+        toolchain = CMakeToolchain(self)
+        toolchain.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindirs[0], "swaggercpp_test_package")
+            self.run(cmd, env="conanrun")

--- a/recipes/swaggercpp/all/test_package/src/example.cpp
+++ b/recipes/swaggercpp/all/test_package/src/example.cpp
@@ -18,6 +18,7 @@ int main() {
     })");
 
     if (!document) {
+        std::cerr << "Failed to parse swagger document\n";
         return 1;
     }
 

--- a/recipes/swaggercpp/all/test_package/src/example.cpp
+++ b/recipes/swaggercpp/all/test_package/src/example.cpp
@@ -1,0 +1,26 @@
+#include <iostream>
+
+#include "swaggercpp/swaggercpp.hpp"
+
+int main() {
+    auto document = swaggercpp::DocumentReader::read(R"({
+      "openapi": "3.1.0",
+      "info": { "title": "Conan", "version": "1.0.0" },
+      "paths": {
+        "/health": {
+          "get": {
+            "responses": {
+              "200": { "description": "ok" }
+            }
+          }
+        }
+      }
+    })");
+
+    if (!document) {
+        return 1;
+    }
+
+    std::cout << document.value().info.title << '\n';
+    return 0;
+}

--- a/recipes/swaggercpp/config.yml
+++ b/recipes/swaggercpp/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.2.1":
+    folder: all


### PR DESCRIPTION
## Description

Adds the initial recipe for [swaggercpp](https://github.com/stescobedo92/swagger-cpp) version `0.2.1`.

**swaggercpp** is a modern C++23 library for reading, writing, validating, traversing, and serializing Swagger/OpenAPI documents.

## Details

- License: MIT
- Version: 0.2.1
- Source: GitHub release tarball
- Dependencies: `cpp-httplib`, `nlohmann_json`, `yaml-cpp`
- Requires C++23

## Test

\`\`\`bash
conan create recipes/swaggercpp/all --version 0.2.1 -s compiler.cppstd=23
\`\`\`