### PR TITLE
[package] beeping-core/0.0.0

### DIFF
--- a/recipes/beeping-core/all/conandata.yml
+++ b/recipes/beeping-core/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.0.0":
+    url: "https://github.com/beeping-io/beeping-core/archive/refs/tags/v0.0.0.tar.gz"
+    sha256: "1e07d7b704f324497f70e1181d00aed5b03fd51a2f68de5675a14a8ba168806d"

--- a/recipes/beeping-core/all/conandata.yml
+++ b/recipes/beeping-core/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "0.0.0":
-    url: "https://github.com/beeping-io/beeping-core/archive/refs/tags/v0.0.0.tar.gz"
-    sha256: "1e07d7b704f324497f70e1181d00aed5b03fd51a2f68de5675a14a8ba168806d"
+  "0.8.1":
+    url: "https://github.com/beeping-io/beeping-core/archive/refs/tags/v0.8.1.tar.gz"
+    sha256: "794a460617170b10030d45a0633f4db850b54ab2a026d53738c8179816b13455"

--- a/recipes/beeping-core/all/conanfile.py
+++ b/recipes/beeping-core/all/conanfile.py
@@ -1,0 +1,88 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
+from conan.tools.files import copy, get
+from conan.tools.build import check_min_cppstd
+from conan.tools.scm import Version
+import os
+
+
+required_conan_version = ">=2.0.6"
+
+
+class BeepingCoreConan(ConanFile):
+    name = "beeping-core"
+    description = "C++20 library for encoding and decoding data over sound"
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/beeping-io/beeping-core"
+    topics = ("audio", "dsp", "data-over-sound", "fsk", "sound", "encoding")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+    implements = ["auto_shared_fpic"]
+
+    @property
+    def _min_cppstd(self):
+        return 20
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "apple-clang": "15",
+            "clang": "16",
+            "gcc": "13",
+            "msvc": "193",
+            "Visual Studio": "17",
+        }
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("spdlog/1.15.3")
+
+    def validate(self):
+        check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise Exception(
+                f"{self.ref} requires C++{self._min_cppstd}, "
+                f"which {self.settings.compiler} {self.settings.compiler.version} does not support."
+            )
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.cache_variables["BUILD_TESTING"] = False
+        tc.cache_variables["BEEPING_USE_EXTERNAL_SPDLOG"] = True
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE",
+             src=self.source_folder,
+             dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["BeepingCore"]
+        self.cpp_info.set_property("cmake_file_name", "BeepingCore")
+        self.cpp_info.set_property("cmake_target_name", "BeepingCore::BeepingCore")
+        if self.settings.os in ("Linux", "FreeBSD"):
+            self.cpp_info.system_libs = ["m", "pthread"]

--- a/recipes/beeping-core/all/test_package/CMakeLists.txt
+++ b/recipes/beeping-core/all/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.25)
+project(test_package LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(BeepingCore REQUIRED CONFIG)
+
+add_executable(test_package test_package.cpp)
+target_link_libraries(test_package PRIVATE BeepingCore::BeepingCore)

--- a/recipes/beeping-core/all/test_package/conanfile.py
+++ b/recipes/beeping-core/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import can_run
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/beeping-core/all/test_package/test_package.cpp
+++ b/recipes/beeping-core/all/test_package/test_package.cpp
@@ -1,0 +1,23 @@
+#include "BeepingCoreLib_api.h"
+
+#include <cstdio>
+#include <cstdlib>
+
+int main() {
+  const char* version = BEEPING_GetVersion();
+  if (version == nullptr) {
+    std::fprintf(stderr, "BEEPING_GetVersion returned null\n");
+    return EXIT_FAILURE;
+  }
+  std::printf("beeping-core version: %s\n", version);
+
+  void* handle = BEEPING_Create();
+  if (handle == nullptr) {
+    std::fprintf(stderr, "BEEPING_Create returned null\n");
+    return EXIT_FAILURE;
+  }
+  BEEPING_Destroy(handle);
+
+  std::printf("beeping-core test_package OK\n");
+  return EXIT_SUCCESS;
+}

--- a/recipes/beeping-core/config.yml
+++ b/recipes/beeping-core/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.0.0":
+    folder: all

--- a/recipes/beeping-core/config.yml
+++ b/recipes/beeping-core/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.0.0":
+  "0.8.1":
     folder: all


### PR DESCRIPTION
## Package description

**beeping-core** is a C++20 library for encoding and decoding data over sound
(Data Over Sound) using multi-tone FSK. It supports audible (3.3–10 kHz) and
inaudible (17.8–21 kHz, adaptive) frequency bands with Reed-Solomon forward
error correction.

- **Homepage**: https://github.com/beeping-io/beeping-core
- **License**: Apache-2.0
- **Release**: https://github.com/beeping-io/beeping-core/releases/tag/v0.0.0
- **Requires**: spdlog/1.15.3

## Checklist

- [x] Recipe compiles and links on macOS (Apple Clang 21, arm64 + x86_64)
- [x] `conan create` passes end-to-end (source → build → package → test_package)
- [x] `test_package` verifies `BEEPING_GetVersion()` + `BEEPING_Create()`/`BEEPING_Destroy()`
- [x] `conandata.yml` has real sha256 from published v0.0.0 tag
- [x] `check_min_cppstd(self, 20)` validates C++ standard
- [x] LICENSE copied to `licenses/` in `package()`
- [x] `url` points to conan-center-index, `homepage` to upstream repo
- [x] 6 topics: audio, dsp, data-over-sound, fsk, sound, encoding

## Platforms tested

| Platform | Compiler | Status |
|---|---|---|
| macOS universal (arm64+x86_64) | Apple Clang 21 | CI verified |
| Linux amd64 | GCC 13 | CI verified |
| Linux arm64 | GCC 13 | CI verified |
| Android (arm64-v8a, armeabi-v7a, x86_64) | NDK r26d | CI verified |
| iOS (device + simulator XCFramework) | Apple Clang | CI verified |
| WASM | Emscripten 3.1.64 | CI verified |