### PR TITLE
cminpack: CMake 4 support

### DIFF
--- a/recipes/cminpack/all/conanfile.py
+++ b/recipes/cminpack/all/conanfile.py
@@ -4,7 +4,7 @@ from conan.tools.files import copy, get, rmdir
 from conan.tools.apple import is_apple_os
 import os
 
-required_conan_version = ">=1.54.0"
+required_conan_version = ">=2.1"
 
 
 class CMinpackConan(ConanFile):
@@ -44,8 +44,9 @@ class CMinpackConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["BUILD_EXAMPLES"] = "OFF"
-        tc.variables["CMINPACK_LIB_INSTALL_DIR"] = "lib"
+        tc.cache_variables["BUILD_EXAMPLES"] = "OFF"
+        tc.cache_variables["CMINPACK_LIB_INSTALL_DIR"] = "lib"
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
 
     def build(self):
@@ -76,18 +77,12 @@ class CMinpackConan(ConanFile):
         self.cpp_info.components['cminpack-double'].libs = ['cminpack' + self._library_postfix()]
         self.cpp_info.components['cminpack-double'].includedirs.append(minpack_include_dir)
         self.cpp_info.components["cminpack-double"].set_property("cmake_target_name", "cminpack::cminpack")
-        self.cpp_info.components["cminpack-double"].names["cmake_find_package"] = "cminpack"
-        self.cpp_info.components["cminpack-double"].names["cmake_find_package_multi"] = "cminpack"
-        self.cpp_info.components["cminpack-double"].names["pkg_config"] = "cminpack"
 
         # the single precision version
         self.cpp_info.components['cminpack-single'].libs = ['cminpacks' + self._library_postfix()]
         self.cpp_info.components['cminpack-single'].includedirs.append(minpack_include_dir)
         self.cpp_info.components['cminpack-single'].defines.append("__cminpack_float__")
         self.cpp_info.components["cminpack-single"].set_property("cmake_target_name", "cminpack::cminpacks")
-        self.cpp_info.components["cminpack-single"].names["cmake_find_package"] = "cminpacks"
-        self.cpp_info.components["cminpack-single"].names["cmake_find_package_multi"] = "cminpacks"
-        self.cpp_info.components["cminpack-single"].names["pkg_config"] = "cminpacks"
 
         if self.settings.os != "Windows":
             self.cpp_info.components['cminpack-double'].system_libs.append("m")


### PR DESCRIPTION
### Summary
Changes to recipe:  **cminpack/1.3.8**

#### Motivation

`cminpack` is not CMake 4 compatible
Reported in https://github.com/conan-io/conan-center-index/issues/26878#issuecomment-4258399441

#### Details
Maintainer changes: 
- Remove legacy conan v1 code reported by conanlinter.

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
