### PR TITLE
stellar/0.1.0: new recipe

### DIFF
--- a/recipes/stellar/all/conandata.yml
+++ b/recipes/stellar/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.1.0":
+    url: "https://github.com/stescobedo92/stellar/archive/refs/tags/v0.1.0.tar.gz"
+    sha256: "34e445d0dc81703e8e40180b3a33cfadc5828d044903c1577e1b5bfba9dcaae7"

--- a/recipes/stellar/all/conanfile.py
+++ b/recipes/stellar/all/conanfile.py
@@ -1,0 +1,73 @@
+import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get
+from conan.tools.scm import Version
+from conan.tools.layout import basic_layout
+
+required_conan_version = ">=2.0.9"
+
+
+class StellarConan(ConanFile):
+    name = "stellar"
+    description = (
+        "Header-only C++23 toolkit extensions (ste::) — string, collection, "
+        "async and StringBuilder utilities."
+    )
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/stescobedo92/stellar"
+    topics = ("cpp23", "cxx23", "string", "utilities", "header-only",
+              "coroutines", "ranges")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    @property
+    def _min_cppstd(self):
+        return 23
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "gcc":            "13",
+            "clang":          "17",
+            "apple-clang":    "15",
+            "Visual Studio":  "17",
+            "msvc":           "193",
+        }
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler))
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}. "
+                f"{self.settings.compiler} {self.settings.compiler.version} is not supported."
+            )
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder,
+             dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, "*.hpp", src=os.path.join(self.source_folder, "include"),
+             dst=os.path.join(self.package_folder, "include"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name",   "stellar")
+        self.cpp_info.set_property("cmake_target_name", "stellar::stellar")
+        self.cpp_info.set_property("pkg_config_name",   "stellar")
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/stellar/all/test_package/CMakeLists.txt
+++ b/recipes/stellar/all/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.25)
+project(stellar_test_package LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(stellar CONFIG REQUIRED)
+
+add_executable(stellar_smoke src/smoke.cpp)
+target_link_libraries(stellar_smoke PRIVATE stellar::stellar)

--- a/recipes/stellar/all/test_package/conanfile.py
+++ b/recipes/stellar/all/test_package/conanfile.py
@@ -1,0 +1,27 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+
+class StellarTestConan(ConanFile):
+    settings   = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+    test_type  = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindir, "stellar_smoke")
+            self.run(cmd, env="conanrun")

--- a/recipes/stellar/all/test_package/src/smoke.cpp
+++ b/recipes/stellar/all/test_package/src/smoke.cpp
@@ -1,0 +1,13 @@
+#include <ste/ste.hpp>
+
+#include <cstdlib>
+#include <iostream>
+
+int main() {
+    ste::str s{"  my AWESOME name  "};
+    const auto pascal = s.NormalizeSpaces().ToPascalCase();
+    const auto slug   = ste::ToSlug("Hello, World! 100%");
+    std::cout << "pascal=" << pascal << " slug=" << slug << '\n';
+    return (pascal == "MyAwesomeName" && slug == "hello-world-100")
+        ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/recipes/stellar/config.yml
+++ b/recipes/stellar/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.1.0":
+    folder: all


### PR DESCRIPTION
Adds a new recipe `stellar` — a header-only C++23 toolkit (ste::) for string manipulation, collection utilities, StringBuilder and async (std::future + coroutines).

- Homepage: https://github.com/stescobedo92/stellar
- License: MIT
- Version: 0.1.0
- Sources: official GitHub Release tarball, SHA256 pinned in conandata.yml.

### Checklist
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] Checked that the pull request is one recipe per pull request.
- [x] Added a test_package exercising `find_package(stellar CONFIG)` + a runtime smoke check.
- [x] Set `package_type = "header-library"` and cleared package_id for header-only.
- [x] Minimum C++ standard is 23; compiler floors are enforced in `validate()`.