### PR TITLE
Bump flatbuffers to 25.12.19

### DIFF
--- a/recipes/flatbuffers/all/conandata.yml
+++ b/recipes/flatbuffers/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "25.12.19-2026-02-06-03fffb2":
+    "url": "https://github.com/google/flatbuffers/archive/refs/tags/v25.12.19-2026-02-06-03fffb2.tar.gz"
+    "sha256": "ccbce58684691de1e7d51f5e87786266b37d06ab66e9dfe2d0ec106fe50aace0"
   "25.12.19":
     "url": "https://github.com/google/flatbuffers/archive/refs/tags/v25.12.19.tar.gz"
     "sha256": "f81c3162b1046fe8b84b9a0dbdd383e24fdbcf88583b9cb6028f90d04d90696a"

--- a/recipes/flatbuffers/all/conandata.yml
+++ b/recipes/flatbuffers/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "25.12.19":
+    "url": "https://github.com/google/flatbuffers/archive/refs/tags/v25.12.19.tar.gz"
+    "sha256": "f81c3162b1046fe8b84b9a0dbdd383e24fdbcf88583b9cb6028f90d04d90696a"
   "25.9.23":
     url: "https://github.com/google/flatbuffers/archive/refs/tags/v25.9.23.tar.gz"
     sha256: "9102253214dea6ae10c2ac966ea1ed2155d22202390b532d1dea64935c518ada"

--- a/recipes/flatbuffers/all/conandata.yml
+++ b/recipes/flatbuffers/all/conandata.yml
@@ -1,10 +1,7 @@
 sources:
-  "25.12.19-2026-02-06-03fffb2":
+  "25.12.19":
     "url": "https://github.com/google/flatbuffers/archive/refs/tags/v25.12.19-2026-02-06-03fffb2.tar.gz"
     "sha256": "ccbce58684691de1e7d51f5e87786266b37d06ab66e9dfe2d0ec106fe50aace0"
-  "25.12.19":
-    "url": "https://github.com/google/flatbuffers/archive/refs/tags/v25.12.19.tar.gz"
-    "sha256": "f81c3162b1046fe8b84b9a0dbdd383e24fdbcf88583b9cb6028f90d04d90696a"
   "25.9.23":
     url: "https://github.com/google/flatbuffers/archive/refs/tags/v25.9.23.tar.gz"
     sha256: "9102253214dea6ae10c2ac966ea1ed2155d22202390b532d1dea64935c518ada"

--- a/recipes/flatbuffers/config.yml
+++ b/recipes/flatbuffers/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "25.12.19-2026-02-06-03fffb2":
+    folder: all
   "25.12.19":
     folder: all
   "25.9.23":

--- a/recipes/flatbuffers/config.yml
+++ b/recipes/flatbuffers/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "25.12.19":
+    folder: all
   "25.9.23":
     folder: all
   "24.12.23":

--- a/recipes/flatbuffers/config.yml
+++ b/recipes/flatbuffers/config.yml
@@ -1,6 +1,4 @@
 versions:
-  "25.12.19-2026-02-06-03fffb2":
-    folder: all
   "25.12.19":
     folder: all
   "25.9.23":


### PR DESCRIPTION
### Summary
Changes to recipe:  **flatbuffers/25.12.19**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

Bumped to versions **25.12.19**

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->

The current release of FlatBuffers is **25.12.19-2026-02-06-03fffb2**, which is a patch of **25.12.19**.

Re-published `25.12.19-2026-02-06-03fffb2` as `25.12.19`

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
