### PR TITLE
libpng: publish version 1.6.58, stop publishing revs for 1.6.57

### DIFF
--- a/recipes/libpng/all/conandata.yml
+++ b/recipes/libpng/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "1.6.57":
-    url: "https://download.sourceforge.net/libpng/libpng-1.6.57.tar.xz"
-    sha256: "d10c20d7171569804cae8dfc13ba6dcd0662c41ed39d43d4d429314aafb10a80"
+  "1.6.58":
+    url: "https://download.sourceforge.net/libpng/libpng-1.6.58.tar.xz"
+    sha256: "28eb403f51f0f7405249132cecfe82ea5c0ef97f1b32c5a65828814ae0d34775"

--- a/recipes/libpng/config.yml
+++ b/recipes/libpng/config.yml
@@ -1,4 +1,4 @@
 versions:
 # Keep only the latest version, unless there's strong reasons to keep older ones
-  "1.6.57":
+  "1.6.58":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **libpng/1.6.58**

#### Motivation
libpng 1.6.58, has a simple bugfix for a regression introduced in 1.6.56: png_get_PLTE() returns stale palette data when either gamma correction or alpha-compositing is the only transform applied

#### Details
https://github.com/pnggroup/libpng/compare/v1.6.57...v1.6.58


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
