### PR TITLE
Added llnl-units/0.13.1

### DIFF
--- a/recipes/llnl-units/all/conandata.yml
+++ b/recipes/llnl-units/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.13.1":
+    url: "https://github.com/LLNL/units/archive/refs/tags/v0.13.1.tar.gz"
+    sha256: "e6a19f84a139ec6a06458d68778cc4e491a6e07428c8ac57faadcd3d6f81d50e"
   "0.9.1":
     url: "https://github.com/LLNL/units/archive/refs/tags/v0.9.1.tar.gz"
     sha256: "7edb83613a07cf55873f22d61c0062e46db6f8cb27d137866858811ec2e1ad4f"

--- a/recipes/llnl-units/all/conandata.yml
+++ b/recipes/llnl-units/all/conandata.yml
@@ -2,6 +2,3 @@ sources:
   "0.13.1":
     url: "https://github.com/LLNL/units/archive/refs/tags/v0.13.1.tar.gz"
     sha256: "e6a19f84a139ec6a06458d68778cc4e491a6e07428c8ac57faadcd3d6f81d50e"
-  "0.9.1":
-    url: "https://github.com/LLNL/units/archive/refs/tags/v0.9.1.tar.gz"
-    sha256: "7edb83613a07cf55873f22d61c0062e46db6f8cb27d137866858811ec2e1ad4f"

--- a/recipes/llnl-units/all/conanfile.py
+++ b/recipes/llnl-units/all/conanfile.py
@@ -62,12 +62,7 @@ class UnitsConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.preprocessor_definitions["UNITS_CMAKE_PROJECT_NAME"] = "LLNL-UNITS"
         tc.cache_variables["UNITS_ENABLE_TESTS"] = "OFF"
-        tc.preprocessor_definitions["UNITS_BUILD_SHARED_LIBRARY"] = self.options.shared
-        tc.preprocessor_definitions[
-            "UNITS_BUILD_STATIC_LIBRARY"
-        ] = not self.options.shared
         tc.generate()
 
     def build(self):
@@ -84,20 +79,9 @@ class UnitsConan(ConanFile):
         )
         cmake = CMake(self)
         cmake.install()
-        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
-        rmdir(self, os.path.join(self.package_folder, "share"))
-        rm(self, "*.la", os.path.join(self.package_folder, "lib"))
-        rm(self, "*.pdb", os.path.join(self.package_folder, "lib"))
-        rm(self, "*.pdb", os.path.join(self.package_folder, "bin"))
 
     def package_info(self):
         self.cpp_info.libs = ["units"]
-        namespace = self.conf.get("user.llnl-units:namespace", check_type=str)
-        base_type = self.conf.get("user.llnl-units:base_type", check_type=str, default="uint32_t")
-        self.cpp_info.defines = [f"UNITS_BASE_TYPE={base_type}"]
-        if namespace:
-            self.cpp_info.defines.append(f"UNITS_NAMESPACE={namespace}")
-
         self.cpp_info.set_property("cmake_file_name", "units")
         self.cpp_info.set_property("cmake_target_name", "units::units")

--- a/recipes/llnl-units/all/conanfile.py
+++ b/recipes/llnl-units/all/conanfile.py
@@ -63,7 +63,7 @@ class UnitsConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.preprocessor_definitions["UNITS_CMAKE_PROJECT_NAME"] = "LLNL-UNITS"
-        tc.preprocessor_definitions["UNITS_ENABLE_TESTS"] = "OFF"
+        tc.cache_variables["UNITS_ENABLE_TESTS"] = "OFF"
         tc.preprocessor_definitions["UNITS_BUILD_SHARED_LIBRARY"] = self.options.shared
         tc.preprocessor_definitions[
             "UNITS_BUILD_STATIC_LIBRARY"
@@ -97,7 +97,7 @@ class UnitsConan(ConanFile):
         base_type = self.conf.get("user.llnl-units:base_type", check_type=str, default="uint32_t")
         self.cpp_info.defines = [f"UNITS_BASE_TYPE={base_type}"]
         if namespace:
-            self.cpp_info.defines.append(f"UNITS_NAMESPACE={units_namespace}")
+            self.cpp_info.defines.append(f"UNITS_NAMESPACE={namespace}")
 
         self.cpp_info.set_property("cmake_file_name", "units")
         self.cpp_info.set_property("cmake_target_name", "units::units")

--- a/recipes/llnl-units/all/conanfile.py
+++ b/recipes/llnl-units/all/conanfile.py
@@ -2,7 +2,7 @@ import os
 
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain
-from conan.tools.files import copy, rm, rmdir, get
+from conan.tools.files import copy, rmdir, get
 
 
 class UnitsConan(ConanFile):
@@ -62,7 +62,7 @@ class UnitsConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.cache_variables["UNITS_ENABLE_TESTS"] = "OFF"
+        tc.cache_variables["UNITS_ENABLE_TESTS"] = False
         tc.generate()
 
     def build(self):

--- a/recipes/llnl-units/all/conanfile.py
+++ b/recipes/llnl-units/all/conanfile.py
@@ -2,6 +2,7 @@ import os
 
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.build import check_min_cppstd
 from conan.tools.files import copy, rmdir, get
 
 
@@ -35,20 +36,6 @@ class UnitsConan(ConanFile):
         "fPIC": True,
     }
 
-    @property
-    def _min_cppstd(self):
-        return 14
-
-    @property
-    def _compilers_minimum_version(self):
-        return {
-            "apple-clang": "10",
-            "clang": "7",
-            "gcc": "7",
-            "msvc": "191",
-            "Visual Studio": "15",
-        }
-
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -67,6 +54,9 @@ class UnitsConan(ConanFile):
         tc = CMakeToolchain(self)
         tc.cache_variables["UNITS_ENABLE_TESTS"] = False
         tc.generate()
+
+    def validate(self):
+        check_min_cppstd(self, 14)
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/llnl-units/all/conanfile.py
+++ b/recipes/llnl-units/all/conanfile.py
@@ -1,7 +1,7 @@
 import os
 
 from conan import ConanFile
-from conan.tools.cmake import CMake, CMakeToolchain
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, rmdir, get
 
 
@@ -56,6 +56,9 @@ class UnitsConan(ConanFile):
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/llnl-units/config.yml
+++ b/recipes/llnl-units/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.13.1":
+    folder: all
   "0.9.1":
     folder: all

--- a/recipes/llnl-units/config.yml
+++ b/recipes/llnl-units/config.yml
@@ -1,5 +1,3 @@
 versions:
   "0.13.1":
     folder: all
-  "0.9.1":
-    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **llnl-units/0.13.1**

#### Motivation
Building the llnl-units/0.9.1 wasn't working with cmake 4.2, because that version depends on cmake 3.5. 

#### Details
Added version 0.13.1 along with the previous version 0.9.1
close #30019 .


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
