### PR TITLE
libavif: add 1.4.1 and specify codecs as "SYSTEM"

### DIFF
--- a/recipes/libavif/all/conandata.yml
+++ b/recipes/libavif/all/conandata.yml
@@ -1,8 +1,15 @@
 sources:
+  "1.4.1":
+    url: "https://github.com/AOMediaCodec/libavif/archive/refs/tags/v1.4.1.tar.gz"
+    sha256: "d4aea31a4becb3273ba7968221be2e48148ba05eb8a68d14e671963e17785648"
   "1.3.0":
     url: "https://github.com/AOMediaCodec/libavif/archive/refs/tags/v1.3.0.tar.gz"
     sha256: "0a545e953cc049bf5bcf4ee467306a2f113a75110edf59e61248873101cd26c1"
 patches:
+  "1.4.1":
+    - patch_file: patches/1.4.1-0001-disable-developer-only-codepaths.patch
+      patch_description: "disable compiler options for develop"
+      patch_type: "portability"
   "1.3.0":
     - patch_file: patches/1.3.0-0001-disable-developer-only-codepaths.patch
       patch_description: "disable compiler options for develop"

--- a/recipes/libavif/all/conanfile.py
+++ b/recipes/libavif/all/conanfile.py
@@ -71,8 +71,8 @@ class LibAVIFConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.cache_variables["AVIF_ENABLE_WERROR"] = False
-        tc.cache_variables["AVIF_CODEC_AOM"] = True
-        tc.cache_variables["AVIF_CODEC_DAV1D"] = self.options.with_decoder == "dav1d"
+        tc.cache_variables["AVIF_CODEC_AOM"] = "SYSTEM"
+        tc.cache_variables["AVIF_CODEC_DAV1D"] = "SYSTEM" if self.options.with_decoder == "dav1d" else "OFF"
         tc.cache_variables["AVIF_CODEC_AOM_DECODE"] = self.options.with_decoder == "aom"
         tc.cache_variables["LIBYUV_VERSION"] = str(self.dependencies["libyuv"].ref.version)
         if "with_ycgco_r" in self.options:

--- a/recipes/libavif/all/conanfile.py
+++ b/recipes/libavif/all/conanfile.py
@@ -62,7 +62,7 @@ class LibAVIFConan(ConanFile):
             self.requires("dav1d/[>=1.4 <2]")
 
     def build_requirements(self):
-        self.tool_requires("cmake/[>=3.19]")
+        self.tool_requires("cmake/[>=3.22]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/libavif/all/patches/1.4.1-0001-disable-developer-only-codepaths.patch
+++ b/recipes/libavif/all/patches/1.4.1-0001-disable-developer-only-codepaths.patch
@@ -1,0 +1,35 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index cda82b013..7a56806bc 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -141,11 +141,13 @@ set_local_or_system_option(
+ # Whether the libavif library uses c++ indirectly (e.g. through linking to libyuv).
+ set(AVIF_LIB_USE_CXX OFF)
+ 
++if(0)
+ if(APPLE)
+     set(XCRUN xcrun)
+ else()
+     set(XCRUN)
+ endif()
++endif()
+ 
+ # This is also needed to get shared libraries (e.g. pixbufloader-avif) to compile against a static libavif.
+ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+@@ -267,6 +269,8 @@ check_avif_option(AVIF_LIBXML2 TARGET LibXml2::LibXml2 PKG_NAME LibXml2)
+ 
+ # ---------------------------------------------------------------------------------------
+ 
++add_library(avif_enable_warnings INTERFACE)
++if(0)
+ # Enable all warnings
+ include(CheckCCompilerFlag)
+ # avif_enable_warnings is a CMake interface library. It has no source files.
+@@ -322,6 +326,7 @@ elseif(CMAKE_C_COMPILER_ID MATCHES "GNU")
+ else()
+     message(FATAL_ERROR "libavif: Unknown compiler, bailing out")
+ endif()
++endif()
+ 
+ if(AVIF_ENABLE_WERROR)
+     # Warnings as errors

--- a/recipes/libavif/all/test_package/test_package.c
+++ b/recipes/libavif/all/test_package/test_package.c
@@ -6,7 +6,8 @@ int main(int argc, char const* argv[])
   (void)argc;
   (void)argv;
 
-  avifFree(NULL);
+  if (!avifCodecName(AVIF_CODEC_CHOICE_AUTO, AVIF_CODEC_FLAG_CAN_DECODE))
+    return 1;
 
   return 0;
 }

--- a/recipes/libavif/all/test_package/test_package.c
+++ b/recipes/libavif/all/test_package/test_package.c
@@ -1,13 +1,17 @@
 #include <avif/avif.h>
 #include <stddef.h>
+#include <stdio.h>
 
 int main(int argc, char const* argv[])
 {
   (void)argc;
   (void)argv;
 
-  if (!avifCodecName(AVIF_CODEC_CHOICE_AUTO, AVIF_CODEC_FLAG_CAN_DECODE))
+  if (!avifCodecName(AVIF_CODEC_CHOICE_AUTO, AVIF_CODEC_FLAG_CAN_DECODE)) {
+    printf("No decoder available - there should be at least one. Was libavif "
+           "compiled without any codec?\n");
     return 1;
+  }
 
   return 0;
 }

--- a/recipes/libavif/config.yml
+++ b/recipes/libavif/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.4.1":
+    folder: all
   "1.3.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **libavif/1.4.1**

#### Motivation

- Adds latest version 1.4.1
- Changes how the codecs are enabled in CMake (in both 1.4.1 and 1.3.0)

#### Details

I don't know how this went unnoticed, but the libavif package did not build with support for any en-/decoder. So trying to use the library would always fail. The codecs need to be specified as "SYSTEM" (see https://github.com/AOMediaCodec/libavif/tree/v1.4.1#codec-dependencies). I updated the example to make sure there's at least a decoder available.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
