### PR TITLE
[package] hical/2.6.6

### DIFF
--- a/recipes/hical/all/conandata.yml
+++ b/recipes/hical/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2.6.6":
+    url: "https://github.com/Hical61/Hical/archive/refs/tags/v2.6.6.tar.gz"
+    sha256: "74b1c473df23e03f53ba5bb7e6cafa393cbca8a241e48633b2171f1c75027b5f"

--- a/recipes/hical/all/conanfile.py
+++ b/recipes/hical/all/conanfile.py
@@ -1,0 +1,82 @@
+import os
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
+from conan.tools.files import get, copy, rmdir
+from conan.tools.build import check_min_cppstd
+
+
+class HicalConan(ConanFile):
+    name = "hical"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/Hical61/Hical"
+    description = "Modern C++20/C++26 high-performance web framework based on Boost.Asio/Beast"
+    topics = ("web-framework", "http", "websocket", "boost-asio", "coroutine", "cpp20", "cpp26")
+    package_type = "static-library"
+
+    settings = "os", "compiler", "build_type", "arch"
+    options = {
+        "fPIC": [True, False],
+        "with_reflection": [True, False],
+        "with_database": [True, False],
+    }
+    default_options = {
+        "fPIC": True,
+        "with_reflection": False,
+        "with_database": False,
+    }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def validate(self):
+        check_min_cppstd(self, 20)
+        if self.options.with_reflection:
+            check_min_cppstd(self, 26)
+
+    def requirements(self):
+        self.requires("boost/[>=1.82.0]", transitive_headers=True, transitive_libs=True)
+        self.requires("openssl/[>=1.1.0]", transitive_headers=True, transitive_libs=True)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
+
+        tc = CMakeToolchain(self)
+        tc.variables["HICAL_BUILD_TESTS"] = False
+        tc.variables["HICAL_BUILD_EXAMPLES"] = False
+        tc.variables["HICAL_ENABLE_REFLECTION"] = bool(self.options.with_reflection)
+        tc.variables["HICAL_WITH_DATABASE"] = bool(self.options.with_database)
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder,
+             dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "hical")
+        self.cpp_info.set_property("cmake_target_name", "hical::hical_core")
+
+        self.cpp_info.libs = ["hical_core"]
+
+        if self.settings.os == "Windows":
+            self.cpp_info.system_libs.extend(["ws2_32", "mswsock"])
+
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("pthread")

--- a/recipes/hical/all/test_package/CMakeLists.txt
+++ b/recipes/hical/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.20)
+project(PackageTest CXX)
+
+find_package(hical REQUIRED)
+
+add_executable(example src/example.cpp)
+target_link_libraries(example PRIVATE hical::hical_core)
+target_compile_features(example PRIVATE cxx_std_20)

--- a/recipes/hical/all/test_package/conanfile.py
+++ b/recipes/hical/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+import os
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import can_run
+
+
+class HicalTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindir, "example")
+            self.run(cmd, env="conanrun")

--- a/recipes/hical/all/test_package/src/example.cpp
+++ b/recipes/hical/all/test_package/src/example.cpp
@@ -1,0 +1,12 @@
+#include <hical/core/Router.h>
+#include <iostream>
+
+int main()
+{
+    hical::Router router;
+    router.get("/test", [](const hical::HttpRequest&) -> hical::HttpResponse {
+        return hical::HttpResponse::ok("test");
+    });
+    std::cout << "Hical package test OK" << std::endl;
+    return 0;
+}

--- a/recipes/hical/config.yml
+++ b/recipes/hical/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.6.6":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe: **hical/[2.6.6]**

#### Motivation
Initial submission of hical, a modern C++20/C++26 high-performance web framework based on Boost.Asio. Latest release: v2.6.6.

#### Details
- Added `conandata.yml`: version 2.6.6 with source URL and sha256
- Added `config.yml`: version 2.6.6
- Added `conanfile.py`: CMake-based build with options for reflection and database middleware
- Added `test_package/`: basic compile-and-link test
- Rebased on latest upstream master
- Squashed to single commit

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan