### PR TITLE
ipgeolocation-cpp-sdk: add new recipe

### DIFF
--- a/recipes/ipgeolocation-cpp-sdk/all/conandata.yml
+++ b/recipes/ipgeolocation-cpp-sdk/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.0.0":
+    url: "https://github.com/IPGeolocation/ip-geolocation-api-cpp-sdk/archive/refs/tags/v1.0.0.tar.gz"
+    sha256: "c45a9f537962d43714bb7b778ce6417f012abeff26a361d42464b1795d6df3f3"

--- a/recipes/ipgeolocation-cpp-sdk/all/conanfile.py
+++ b/recipes/ipgeolocation-cpp-sdk/all/conanfile.py
@@ -1,0 +1,100 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, rm, rmdir
+from conan.tools.microsoft import is_msvc
+from conan.tools.scm import Version
+
+import os
+
+
+required_conan_version = ">=2.0.9"
+
+
+class IpGeolocationCppSdkConan(ConanFile):
+    name = "ipgeolocation-cpp-sdk"
+    description = "Official C++ SDK for IPGeolocation.io IP location, ASN, timezone, hostname, abuse, user-agent, and security lookups."
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/IPGeolocation/ip-geolocation-api-cpp-sdk"
+    topics = (
+        "ip-location",
+        "ip-geolocation",
+        "timezone",
+        "asn",
+        "hostname",
+        "abuse",
+        "user-agent",
+        "security",
+    )
+
+    package_type = "static-library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "fPIC": True,
+    }
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "gcc": "7",
+            "clang": "7",
+            "apple-clang": "10",
+            "Visual Studio": "15",
+            "msvc": "191",
+        }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires("libcurl/[>=8 <9]")
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, 17)
+
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler))
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(f"{self.ref} requires a compiler with C++17 support.")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.cache_variables["IPGEOLOCATION_BUILD_TESTS"] = False
+        tc.cache_variables["IPGEOLOCATION_ENABLE_COVERAGE"] = False
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rm(self, "*.pdb", self.package_folder, recursive=True)
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "ipgeolocation")
+        self.cpp_info.set_property("cmake_target_name", "ipgeolocation::ipgeolocation")
+        self.cpp_info.libs = ["ipgeolocation"]
+        self.cpp_info.requires = ["libcurl::curl"]
+
+        if not is_msvc(self) and self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("m")

--- a/recipes/ipgeolocation-cpp-sdk/all/conanfile.py
+++ b/recipes/ipgeolocation-cpp-sdk/all/conanfile.py
@@ -56,7 +56,7 @@ class IpGeolocationCppSdkConan(ConanFile):
         cmake_layout(self)
 
     def requirements(self):
-        self.requires("libcurl/[>=8 <9]")
+        self.requires("libcurl/[>=7.78.0 <9]")
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):

--- a/recipes/ipgeolocation-cpp-sdk/all/test_package/CMakeLists.txt
+++ b/recipes/ipgeolocation-cpp-sdk/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(ipgeolocation REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE ipgeolocation::ipgeolocation)

--- a/recipes/ipgeolocation-cpp-sdk/all/test_package/conanfile.py
+++ b/recipes/ipgeolocation-cpp-sdk/all/test_package/conanfile.py
@@ -1,0 +1,27 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/ipgeolocation-cpp-sdk/all/test_package/test_package.cpp
+++ b/recipes/ipgeolocation-cpp-sdk/all/test_package/test_package.cpp
@@ -1,0 +1,15 @@
+#include <cstdlib>
+#include <iostream>
+#include <ipgeolocation/ipgeolocation.hpp>
+
+
+int main() {
+    ipgeolocation::IpGeolocationClientConfig config;
+    config.api_key = "test-key";
+
+    ipgeolocation::IpGeolocationClient client(config);
+    client.Close();
+
+    std::cout << ipgeolocation::VERSION << '\n';
+    return EXIT_SUCCESS;
+}

--- a/recipes/ipgeolocation-cpp-sdk/config.yml
+++ b/recipes/ipgeolocation-cpp-sdk/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.0.0":
+    folder: all


### PR DESCRIPTION
Adds the initial Conan recipe for the IPGeolocation C++ SDK.

Local validation completed with Conan 2.27.1:
- conan create recipes/ipgeolocation-cpp-sdk/all --version 1.0.0
- test_package passed
- recipe builds from the released v1.0.0 upstream tarball
- The package exposes find_package(ipgeolocation CONFIG REQUIRED) and the ipgeolocation::ipgeolocation target.