### PR TITLE
cairomm: dependency version fix for libsigcpp

### DIFF
--- a/recipes/cairomm/all/conanfile.py
+++ b/recipes/cairomm/all/conanfile.py
@@ -60,7 +60,7 @@ class CairommConan(ConanFile):
         self.requires("cairo/1.18.0", transitive_headers=True, transitive_libs=True)
         self.requires("fontconfig/2.15.0", transitive_headers=True, transitive_libs=True)
         if self._abi_version == "1.16":
-            self.requires("libsigcpp/3.0.7", transitive_headers=True, transitive_libs=True)
+            self.requires("libsigcpp/3.8.0", transitive_headers=True, transitive_libs=True)
         else:
             self.requires("libsigcpp/2.10.8", transitive_headers=True, transitive_libs=True)
 

--- a/recipes/cairomm/all/conanfile.py
+++ b/recipes/cairomm/all/conanfile.py
@@ -60,7 +60,7 @@ class CairommConan(ConanFile):
         self.requires("cairo/1.18.0", transitive_headers=True, transitive_libs=True)
         self.requires("fontconfig/[>=2.15 <3]", transitive_headers=True, transitive_libs=True)
         if self._abi_version == "1.16":
-            self.requires("libsigcpp/[>=3.8.0 <4]", transitive_headers=True, transitive_libs=True)
+            self.requires("libsigcpp/[>=3.0.7 <4]", transitive_headers=True, transitive_libs=True)
         else:
             self.requires("libsigcpp/2.10.8", transitive_headers=True, transitive_libs=True)
 

--- a/recipes/cairomm/all/conanfile.py
+++ b/recipes/cairomm/all/conanfile.py
@@ -60,7 +60,7 @@ class CairommConan(ConanFile):
         self.requires("cairo/1.18.0", transitive_headers=True, transitive_libs=True)
         self.requires("fontconfig/2.15.0", transitive_headers=True, transitive_libs=True)
         if self._abi_version == "1.16":
-            self.requires("libsigcpp/3.8.0", transitive_headers=True, transitive_libs=True)
+            self.requires("libsigcpp/[>=3.8.0 <4]", transitive_headers=True, transitive_libs=True)
         else:
             self.requires("libsigcpp/2.10.8", transitive_headers=True, transitive_libs=True)
 

--- a/recipes/cairomm/all/conanfile.py
+++ b/recipes/cairomm/all/conanfile.py
@@ -58,7 +58,7 @@ class CairommConan(ConanFile):
 
     def requirements(self):
         self.requires("cairo/1.18.0", transitive_headers=True, transitive_libs=True)
-        self.requires("fontconfig/2.15.0", transitive_headers=True, transitive_libs=True)
+        self.requires("fontconfig/[>=2.15 <3]", transitive_headers=True, transitive_libs=True)
         if self._abi_version == "1.16":
             self.requires("libsigcpp/[>=3.8.0 <4]", transitive_headers=True, transitive_libs=True)
         else:


### PR DESCRIPTION
### Summary
Changes to recipe:  **cairomm**

#### Motivation


#### Details
After the fix of https://github.com/conan-io/conan-center-index/pull/29971
cairomm will not building with CMake as the compatibility with CMake < 3.5 has been removed from CMake.

[cairomm.log](https://github.com/user-attachments/files/26937549/cairomm.log)
This is the log I get from making with libsigcpp/3.0.7

This fix will help you with this.

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
