### PR TITLE
simdjson: publish version 4.6.3, stop publishing 4.6.2

### DIFF
--- a/recipes/simdjson/all/conandata.yml
+++ b/recipes/simdjson/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "4.6.2":
-    url: "https://github.com/simdjson/simdjson/archive/v4.6.2.tar.gz"
-    sha256: "c240d4bffcccda4fe3a2bba2872718d96fc92e56d2615bfac4f9b2bad89a6386"
+  "4.6.3":
+    url: "https://github.com/simdjson/simdjson/archive/v4.6.3.tar.gz"
+    sha256: "bde0c42f43899c4c5c48be826c09abd22500ed537b89f16b3cced5eec477c263"
   "3.13.0":
     url: "https://github.com/simdjson/simdjson/archive/v3.13.0.tar.gz"
     sha256: "07a1bb3587aac18fd6a10a83fe4ab09f1100ab39f0cb73baea1317826b9f9e0d"

--- a/recipes/simdjson/config.yml
+++ b/recipes/simdjson/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "4.6.2":
+  "4.6.3":
     folder: all
   "3.13.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe: **lib/simdjson**

#### Motivation

New upstream release.

#### Details

Publishes version 4.6.3 and stops publishing 4.6.2.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!