### PR TITLE
ZeroMQ: Add options to depend on GnuTLS and libbsd

### DIFF
--- a/recipes/zeromq/all/conanfile.py
+++ b/recipes/zeromq/all/conanfile.py
@@ -25,8 +25,9 @@ class ZeroMQConan(ConanFile):
         "with_norm": [True, False],
         "poller": [None, "kqueue", "epoll", "devpoll", "pollset", "poll", "select"],
         "with_draft_api": [True, False],
-        "with_websocket": [True, False],
+        "with_websocket": [False, "plain", "secure"],
         "with_radix_tree": [True, False],
+        "with_libbsd": [True, False]
     }
     default_options = {
         "shared": False,
@@ -37,6 +38,7 @@ class ZeroMQConan(ConanFile):
         "with_draft_api": False,
         "with_websocket": False,
         "with_radix_tree": False,
+        "with_libbsd": True
     }
 
     def export_sources(self):
@@ -58,11 +60,19 @@ class ZeroMQConan(ConanFile):
             self.requires("libsodium/[~1.0.20]")
         if self.options.with_norm:
             self.requires("norm/1.5.9")
+        if self.options.with_websocket == "secure":
+            self.requires("gnutls/[~3.8.7]")
+        if self.options.with_libbsd:
+            self.requires("libbsd/[~0.10.0]")
 
     def validate(self):
         if self.settings.os == "Windows" and self.options.with_norm:
             raise ConanInvalidConfiguration(
                 "Norm and ZeroMQ are not compatible on Windows yet"
+            )
+        if self.settings.os == "Windows" and self.options.with_libbsd:
+            raise ConanInvalidConfiguration(
+                "libbsd cannot be used on Windows yet"
             )
 
     def source(self):
@@ -82,8 +92,9 @@ class ZeroMQConan(ConanFile):
         tc.variables["WITH_DOC"] = False
         tc.variables["WITH_NORM"] = self.options.with_norm
         tc.variables["ENABLE_DRAFTS"] = self.options.with_draft_api
-        tc.variables["ENABLE_WS"] = self.options.with_websocket
+        tc.variables["ENABLE_WS"] = self.options.with_websocket != None
         tc.variables["ENABLE_RADIX_TREE"] = self.options.with_radix_tree
+        tc.variables["WITH_LIBBSD"] = self.options.with_libbsd
         if self.options.poller:
             tc.variables["POLLER"] = self.options.poller
         if is_msvc(self):
@@ -143,8 +154,10 @@ class ZeroMQConan(ConanFile):
             self.cpp_info.components["libzmq"].defines.append("ZMQ_STATIC")
         if self.options.with_draft_api:
             self.cpp_info.components["libzmq"].defines.append("ZMQ_BUILD_DRAFT_API")
-        if self.options.with_websocket and self.settings.os != "Windows":
-            self.cpp_info.components["libzmq"].system_libs.append("bsd")
+        if self.options.with_libbsd:
+            self.cpp_info.components["libzmq"].requires.append("libbsd::libbsd")
+        if self.options.with_websocket == "secure":
+            self.cpp_info.components["libzmq"].requires.append("gnutls::gnutls")
 
         self.cpp_info.components["libzmq"].set_property("cmake_target_name", self._libzmq_target)
         if self.options.encryption == "libsodium":

--- a/recipes/zeromq/all/conanfile.py
+++ b/recipes/zeromq/all/conanfile.py
@@ -92,7 +92,7 @@ class ZeroMQConan(ConanFile):
         tc.variables["WITH_DOC"] = False
         tc.variables["WITH_NORM"] = self.options.with_norm
         tc.variables["ENABLE_DRAFTS"] = self.options.with_draft_api
-        tc.variables["ENABLE_WS"] = self.options.with_websocket != None
+        tc.variables["ENABLE_WS"] = self.options.with_websocket != False
         tc.variables["ENABLE_RADIX_TREE"] = self.options.with_radix_tree
         tc.variables["WITH_LIBBSD"] = self.options.with_libbsd
         if self.options.poller:

--- a/recipes/zeromq/all/conanfile.py
+++ b/recipes/zeromq/all/conanfile.py
@@ -25,7 +25,8 @@ class ZeroMQConan(ConanFile):
         "with_norm": [True, False],
         "poller": [None, "kqueue", "epoll", "devpoll", "pollset", "poll", "select"],
         "with_draft_api": [True, False],
-        "with_websocket": [False, "plain", "secure"],
+        "with_websocket": [True, False],
+        "with_tls": [True, False],
         "with_radix_tree": [True, False],
         "with_libbsd": [True, False]
     }
@@ -37,6 +38,7 @@ class ZeroMQConan(ConanFile):
         "poller": None,
         "with_draft_api": False,
         "with_websocket": False,
+        "with_tls": False,
         "with_radix_tree": False,
         "with_libbsd": True
     }
@@ -60,10 +62,8 @@ class ZeroMQConan(ConanFile):
             self.requires("libsodium/[~1.0.20]")
         if self.options.with_norm:
             self.requires("norm/1.5.9")
-        if self.options.with_websocket == "secure":
-            self.requires("gnutls/[~3.8.7]")
-        if self.options.with_libbsd:
-            self.requires("libbsd/[~0.10.0]")
+        if self.options.with_tls:
+            self.requires("gnutls/3.8.7")
 
     def validate(self):
         if self.settings.os == "Windows" and self.options.with_norm:
@@ -94,7 +94,9 @@ class ZeroMQConan(ConanFile):
         tc.variables["ENABLE_DRAFTS"] = self.options.with_draft_api
         tc.variables["ENABLE_WS"] = self.options.with_websocket != False
         tc.variables["ENABLE_RADIX_TREE"] = self.options.with_radix_tree
-        tc.variables["WITH_LIBBSD"] = self.options.with_libbsd
+        tc.variables["WITH_LIBBSD"] = False
+        tc.variables["WITH_TLS"] = self.options.with_tls
+        tc.variables["CMAKE_REQUIRE_FIND_PACKAGE_GnuTLS"] = self.options.with_tls
         if self.options.poller:
             tc.variables["POLLER"] = self.options.poller
         if is_msvc(self):
@@ -154,9 +156,7 @@ class ZeroMQConan(ConanFile):
             self.cpp_info.components["libzmq"].defines.append("ZMQ_STATIC")
         if self.options.with_draft_api:
             self.cpp_info.components["libzmq"].defines.append("ZMQ_BUILD_DRAFT_API")
-        if self.options.with_libbsd:
-            self.cpp_info.components["libzmq"].requires.append("libbsd::libbsd")
-        if self.options.with_websocket == "secure":
+        if self.options.with_tls:
             self.cpp_info.components["libzmq"].requires.append("gnutls::gnutls")
 
         self.cpp_info.components["libzmq"].set_property("cmake_target_name", self._libzmq_target)

--- a/recipes/zeromq/all/conanfile.py
+++ b/recipes/zeromq/all/conanfile.py
@@ -88,9 +88,9 @@ class ZeroMQConan(ConanFile):
         tc.variables["ENABLE_DRAFTS"] = self.options.with_draft_api
         tc.variables["ENABLE_WS"] = self.options.with_websocket
         tc.variables["ENABLE_RADIX_TREE"] = self.options.with_radix_tree
-        tc.variables["WITH_LIBBSD"] = False
-        tc.variables["WITH_TLS"] = self.options.with_tls
-        tc.variables["CMAKE_REQUIRE_FIND_PACKAGE_GnuTLS"] = self.options.with_tls
+        tc.cache_variables["WITH_LIBBSD"] = False
+        tc.cache_variables["WITH_TLS"] = self.options.with_tls
+        tc.cache_variables["CMAKE_REQUIRE_FIND_PACKAGE_GnuTLS"] = self.options.with_tls
         if self.options.poller:
             tc.variables["POLLER"] = self.options.poller
         if is_msvc(self):

--- a/recipes/zeromq/all/conanfile.py
+++ b/recipes/zeromq/all/conanfile.py
@@ -26,9 +26,8 @@ class ZeroMQConan(ConanFile):
         "poller": [None, "kqueue", "epoll", "devpoll", "pollset", "poll", "select"],
         "with_draft_api": [True, False],
         "with_websocket": [True, False],
-        "with_tls": [True, False],
         "with_radix_tree": [True, False],
-        "with_libbsd": [True, False]
+        "with_tls": [True, False],
     }
     default_options = {
         "shared": False,
@@ -40,7 +39,6 @@ class ZeroMQConan(ConanFile):
         "with_websocket": False,
         "with_tls": False,
         "with_radix_tree": False,
-        "with_libbsd": True
     }
 
     def export_sources(self):
@@ -70,10 +68,6 @@ class ZeroMQConan(ConanFile):
             raise ConanInvalidConfiguration(
                 "Norm and ZeroMQ are not compatible on Windows yet"
             )
-        if self.settings.os == "Windows" and self.options.with_libbsd:
-            raise ConanInvalidConfiguration(
-                "libbsd cannot be used on Windows yet"
-            )
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -92,7 +86,7 @@ class ZeroMQConan(ConanFile):
         tc.variables["WITH_DOC"] = False
         tc.variables["WITH_NORM"] = self.options.with_norm
         tc.variables["ENABLE_DRAFTS"] = self.options.with_draft_api
-        tc.variables["ENABLE_WS"] = self.options.with_websocket != False
+        tc.variables["ENABLE_WS"] = self.options.with_websocket
         tc.variables["ENABLE_RADIX_TREE"] = self.options.with_radix_tree
         tc.variables["WITH_LIBBSD"] = False
         tc.variables["WITH_TLS"] = self.options.with_tls

--- a/recipes/zeromq/all/conanfile.py
+++ b/recipes/zeromq/all/conanfile.py
@@ -61,7 +61,7 @@ class ZeroMQConan(ConanFile):
         if self.options.with_norm:
             self.requires("norm/1.5.9")
         if self.options.with_tls:
-            self.requires("gnutls/3.8.7")
+            self.requires("gnutls/[>=3.8.7 <4]")
 
     def validate(self):
         if self.settings.os == "Windows" and self.options.with_norm:


### PR DESCRIPTION
### Summary
Changes to recipe:  **zeromq/4.3.5**

#### Motivation

Current zeromq recipe does not include gnutls as dependency, so the zeromq wss(websocket-secure) transport is unavailable. Also it uses libbsd as a system dependency (if websocket is enabled), which results in build failure on systems that do not have it by default (Rocky Linux 8 in my case).

#### Details

- Modified option `with_websocket` to allow 3 values: `False`, `plain` and `secure`. With `secure` it will depend on gnutls, and wss transport will be built.
- Added option `with_libbsd`. If enabled, it will depend on libbsd in conan, instead of using system library.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan
---