### PR TITLE
libnice: publish version 0.1.23

### DIFF
--- a/recipes/libdatachannel/all/conanfile.py
+++ b/recipes/libdatachannel/all/conanfile.py
@@ -49,7 +49,7 @@ class libdatachannelConan(ConanFile):
         self.requires("usrsctp/0.9.5.0")
         self.requires("libsrtp/2.6.0")
         if self.options.with_nice:
-            self.requires("libnice/0.1.21")
+            self.requires("libnice/0.1.23")
         self.requires("libjuice/1.7.0", transitive_headers=True, transitive_libs=True)
 
     def validate(self):

--- a/recipes/libnice/all/conandata.yml
+++ b/recipes/libnice/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   0.1.21:
     url: https://libnice.freedesktop.org/releases/libnice-0.1.21.tar.gz
     sha256: 72e73a2acf20f59093e21d5601606e405873503eb35f346fa621de23e99b3b39
+  0.1.23:
+    url: https://libnice.freedesktop.org/releases/libnice-0.1.23.tar.gz
+    sha256: 618fc4e8de393b719b1641c1d8eec01826d4d39d15ade92679d221c7f5e4e70d

--- a/recipes/libnice/all/conandata.yml
+++ b/recipes/libnice/all/conandata.yml
@@ -1,7 +1,4 @@
 sources:
-  0.1.21:
-    url: https://libnice.freedesktop.org/releases/libnice-0.1.21.tar.gz
-    sha256: 72e73a2acf20f59093e21d5601606e405873503eb35f346fa621de23e99b3b39
   0.1.23:
     url: https://libnice.freedesktop.org/releases/libnice-0.1.23.tar.gz
     sha256: 618fc4e8de393b719b1641c1d8eec01826d4d39d15ade92679d221c7f5e4e70d

--- a/recipes/libnice/config.yml
+++ b/recipes/libnice/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.1.23":
+    folder: all
   "0.1.21":
     folder: all

--- a/recipes/libnice/config.yml
+++ b/recipes/libnice/config.yml
@@ -1,5 +1,3 @@
 versions:
   "0.1.23":
     folder: all
-  "0.1.21":
-    folder: all


### PR DESCRIPTION
### Summary
Add version:  **libnice/0.1.23**

#### Motivation
The GStreamer 1.28 *webrtc* plugin requires libnice >= 0.1.23

#### Details

- https://libnice.freedesktop.org/

Tested with:

- Windows MSVC 17 x86_64
- Ubuntu 24.04 GCC 13 x86_64

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
