### PR TITLE
zserio: Add new Zserio release 2.18.1

### DIFF
--- a/recipes/zserio/all/conandata.yml
+++ b/recipes/zserio/all/conandata.yml
@@ -1,4 +1,14 @@
 sources:
+  "2.18.1":
+    runtime:
+      url: "https://github.com/ndsev/zserio/releases/download/v2.18.1/zserio-2.18.1-runtime-libs.zip"
+      sha256: "abe269ce851fcef2f0284744bc895ddbd014c9158b3c703e634c67c76f650fb4"
+    compiler:
+      url: "https://github.com/ndsev/zserio/releases/download/v2.18.1/zserio-2.18.1-bin.zip"
+      sha256: "9e92bbd8d8a5a1bfea14f9e52e7e4b36d46a80f7b81c24c3202ddeef28e0ec66"
+    license:
+      url: "https://raw.githubusercontent.com/ndsev/zserio/v2.18.1/LICENSE"
+      sha256: "d91fb189ae307416d1131b76a9c7e28c657f0a03641340c76ac994fc8119bc46"
   "2.18.0":
     runtime:
       url: "https://github.com/ndsev/zserio/releases/download/v2.18.0/zserio-2.18.0-runtime-libs.zip"

--- a/recipes/zserio/config.yml
+++ b/recipes/zserio/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.18.1":
+    folder: all
   "2.18.0":
     folder: all
   "2.17.0":


### PR DESCRIPTION
### Summary
Changes to recipe: Added new version 2.18.1

#### Motivation
Update because of new Zserio patch release 2.18.1.

#### Details
No further changes just update because of new Zserio patch release 2.18.1.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
