### PR TITLE
fix(libxml2): Fix linkage errors on Android

### DIFF
--- a/recipes/libxml2/cmake/conanfile.py
+++ b/recipes/libxml2/cmake/conanfile.py
@@ -146,7 +146,7 @@ class Libxml2Conan(ConanFile):
         self.cpp_info.set_property("cmake_additional_variables_prefixes", ["LIBXML2"])
         self.cpp_info.set_property("pkg_config_name", "libxml-2.0")
 
-        is_unix = self.settings.os in ["Linux", "FreeBSD", "Macos"] or is_apple_os(self)
+        is_unix = self.settings.os in ["Linux", "FreeBSD", "Macos", "Android"] or is_apple_os(self)
 
         if is_unix:
             self.cpp_info.system_libs.append("m")


### PR DESCRIPTION
### Summary
Changes to recipe:  **libxml2**

#### Motivation
libxml2 doesn't link `m` and `dl` on Android, which causes unresolved reference errors such as `fmod`.
This was fixed in older versions of the libxml2 recipe, but seems to have been forgotten during the overhaul:
https://github.com/conan-io/conan-center-index/blob/0f51461e3e5e974d9b7258e7b016d62f20853808/recipes/libxml2/all/conanfile.py#L394-L395
The check for the Android operating system is missing in the new CMake recipe:
https://github.com/conan-io/conan-center-index/blob/0f51461e3e5e974d9b7258e7b016d62f20853808/recipes/libxml2/cmake/conanfile.py#L149-L153

#### Details
This is a simple one-liner PR that adds `Android` to the list of operating systems to check and fixes the error.
```diff
-        is_unix = self.settings.os in ["Linux", "FreeBSD", "Macos"] or is_apple_os(self)
+        is_unix = self.settings.os in ["Linux", "FreeBSD", "Macos", "Android"] or is_apple_os(self)
```

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
