### PR TITLE
cpptrace: Add an option `disable_cxx20_modules` that can be used to disable support for C++20 modules

### DIFF
--- a/recipes/cpptrace/all/conanfile.py
+++ b/recipes/cpptrace/all/conanfile.py
@@ -20,11 +20,13 @@ class CpptraceConan(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "unwind": ["default", "libunwind"],
+        "disable_cxx20_modules": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "unwind": "default",
+        "disable_cxx20_modules": False,
     }
 
     @property
@@ -68,6 +70,7 @@ class CpptraceConan(ConanFile):
         tc.variables["CPPTRACE_CONAN"] = True
         if self.options.unwind == "libunwind":
             tc.variables["CPPTRACE_UNWIND_WITH_LIBUNWIND"] = True
+        tc.variables["CPPTRACE_DISABLE_CXX_20_MODULES"] = self.options.disable_cxx20_modules
         tc.cache_variables["CPPTRACE_POSITION_INDEPENDENT_CODE"] = self.options.get_safe("fPIC", True)
         tc.generate()
         tc = CMakeDeps(self)

--- a/recipes/cpptrace/all/conanfile.py
+++ b/recipes/cpptrace/all/conanfile.py
@@ -20,13 +20,11 @@ class CpptraceConan(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "unwind": ["default", "libunwind"],
-        "disable_cxx20_modules": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "unwind": "default",
-        "disable_cxx20_modules": False,
     }
 
     @property
@@ -70,7 +68,7 @@ class CpptraceConan(ConanFile):
         tc.variables["CPPTRACE_CONAN"] = True
         if self.options.unwind == "libunwind":
             tc.variables["CPPTRACE_UNWIND_WITH_LIBUNWIND"] = True
-        tc.variables["CPPTRACE_DISABLE_CXX_20_MODULES"] = self.options.disable_cxx20_modules
+        tc.variables["CPPTRACE_DISABLE_CXX_20_MODULES"] = True
         tc.cache_variables["CPPTRACE_POSITION_INDEPENDENT_CODE"] = self.options.get_safe("fPIC", True)
         tc.generate()
         tc = CMakeDeps(self)

--- a/recipes/cpptrace/all/conanfile.py
+++ b/recipes/cpptrace/all/conanfile.py
@@ -68,7 +68,7 @@ class CpptraceConan(ConanFile):
         tc.variables["CPPTRACE_CONAN"] = True
         if self.options.unwind == "libunwind":
             tc.variables["CPPTRACE_UNWIND_WITH_LIBUNWIND"] = True
-        tc.cache_variables["CPPTRACE_DISABLE_CXX_20_MODULES"] = True
+        tc.cache_variables["CPPTRACE_DISABLE_CXX_20_MODULES"] = self.conf.get("tools.cmake.cmaketoolchain:extra_variables", {}).get("CPPTRACE_DISABLE_CXX_20_MODULES", True)
         tc.cache_variables["CPPTRACE_POSITION_INDEPENDENT_CODE"] = self.options.get_safe("fPIC", True)
         tc.generate()
         tc = CMakeDeps(self)

--- a/recipes/cpptrace/all/conanfile.py
+++ b/recipes/cpptrace/all/conanfile.py
@@ -68,7 +68,7 @@ class CpptraceConan(ConanFile):
         tc.variables["CPPTRACE_CONAN"] = True
         if self.options.unwind == "libunwind":
             tc.variables["CPPTRACE_UNWIND_WITH_LIBUNWIND"] = True
-        tc.variables["CPPTRACE_DISABLE_CXX_20_MODULES"] = True
+        tc.cache_variables["CPPTRACE_DISABLE_CXX_20_MODULES"] = True
         tc.cache_variables["CPPTRACE_POSITION_INDEPENDENT_CODE"] = self.options.get_safe("fPIC", True)
         tc.generate()
         tc = CMakeDeps(self)


### PR DESCRIPTION

### Summary
Changes to recipe:  **cpptrace/all**

fix #29826
close #29825

#### Motivation
`cpptrace` added support for C++20 modules as of 1.0.0, which is not supported by CMake with a default generator such as Unix Makefiles:

```
-- Configuring done (2.0s)
CMake Error in CMakeLists.txt:
  The target named "cpptrace-lib" has C++ sources that may use modules, but
  modules are not supported by this generator:

    Unix Makefiles

  Modules are supported only by Ninja, Ninja Multi-Config, and Visual Studio
  generators for VS 17.4 and newer.  See the cmake-cxxmodules(7) manual for
  details.  Use the CMAKE_CXX_SCAN_FOR_MODULES variable to enable or disable
  scanning.


-- Generating done (0.0s)
CMake Generate step failed.  Build files cannot be regenerated correctly.

cpptrace/1.0.4: ERROR: 
Package 'a7f9d1c2d9f9c263a1a95bfdd40a58a897a9054f' build failed
cpptrace/1.0.4: WARN: Build folder /home/ubuntu/.conan2/p/b/cpptr7ef55f475a6a0/b/build/Debug
ERROR: cpptrace/1.0.4: Error in build() method, line 78
	cmake.configure()
	ConanException: Error 1 while executing
```

Fortunately, the upstream author provides a CMake option [`CPPTRACE_DISABLE_CXX_20_MODULES`](https://github.com/jeremy-rifkin/cpptrace/blob/3db8da80111171c219ab5839905771386bee06b3/cmake/OptionVariables.cmake#L189) that we can use to disable support for C++20 modules. By default, this option is set to `OFF`, meaning that C++20 modules are enabled if the compiler supports them. Note that this is done in an automatic configuration step here: https://github.com/jeremy-rifkin/cpptrace/blob/3db8da80111171c219ab5839905771386bee06b3/cmake/Autoconfig.cmake#L30.

Instead of asking the downstream package consumers to install Ninja and modify their build scripts, this PR adds an option `disable_cxx20_modules` to the recipe. By default, this option is set to `False` to be consistent with the default behavior in `cpptrace`'s CMake file.

As such, this PR resolves the issue https://github.com/conan-io/conan-center-index/issues/29826 and offers a better way than the approach proposed in PR https://github.com/conan-io/conan-center-index/pull/29825.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
