### PR TITLE
zheng-bote: add new package gh-update-checker v1.0.9

### DIFF
--- a/recipes/gh-update-checker/all/conandata.yml
+++ b/recipes/gh-update-checker/all/conandata.yml
@@ -1,0 +1,5 @@
+sources:
+  "1.0.9":
+    url: "https://github.com/zheng-bote/gh-update-checker/archive/v1.0.9.tar.gz"
+    sha256: "ea632e9fe8f2ab0271276c90726b710fcc45c479212b5d3a51f2d6b18ede4039"
+

--- a/recipes/gh-update-checker/all/conanfile.py
+++ b/recipes/gh-update-checker/all/conanfile.py
@@ -1,0 +1,67 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get
+from conan.tools.layout import basic_layout
+import os
+
+
+required_conan_version = ">=2.0"
+
+class GhUpdateCheckerConan(ConanFile):
+    name = "gh-update-checker"
+    version = "1.0.9"
+    package_type = "header-library"
+    license = "LGPL-3.0"
+    author = "ZHENG Robert <robert@hase-zheng.net>"
+    url = "https://github.com/Zheng-Bote/gh-update-checker"
+    description = "Header-only C++23 library to check GitHub release updates"
+    topics = ("Utilities", "GitHub", "Update Checker", "Header-only", "C++23")
+    exports_sources = (
+        "CMakeLists.txt",
+        "cmake/*",
+        "include/*",
+        "tests/*",
+        "examples/*",
+        "LICENSE",
+        "README.md",
+    )
+
+    settings = "os", "compiler", "build_type", "arch"
+
+    requires = (
+        "nlohmann_json/[>=3.12.0 <4]",
+        "cpp-httplib/[>=0.39.0 <1]",
+    )
+
+    default_options = {
+        "cpp-httplib/*:with_openssl": True,
+    }
+
+    generators = ()
+
+    def layout(self):
+        cmake_layout(self)
+
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
+
+        toolchain = CMakeToolchain(self)
+        toolchain.cache_variables["CMAKE_CXX_STANDARD"] = "23"
+        toolchain.cache_variables["CMAKE_CXX_STANDARD_REQUIRED"] = "ON"
+        toolchain.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "gh_update_checker")
+        self.cpp_info.set_property("cmake_target_name", "gh_update_checker::gh_update_checker")
+

--- a/recipes/gh-update-checker/all/test_package/CMakeLists.txt
+++ b/recipes/gh-update-checker/all/test_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.23)
+
+project(gh_update_checker_test_package LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(gh_update_checker REQUIRED CONFIG)
+
+add_executable(gh-update-checker-test src/gh-update-checker.cpp)
+target_link_libraries(gh-update-checker-test PRIVATE gh_update_checker::gh_update_checker)

--- a/recipes/gh-update-checker/all/test_package/conanfile.py
+++ b/recipes/gh-update-checker/all/test_package/conanfile.py
@@ -1,0 +1,24 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+
+class GhUpdateCheckerTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    test_type = "explicit"
+    generators = "CMakeToolchain", "CMakeDeps"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            self.run("./gh-update-checker-test --help", cwd=self.build_folder, env="conanrun")

--- a/recipes/gh-update-checker/config.yml
+++ b/recipes/gh-update-checker/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.0.9":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **recipes/gh-update-checker/v1.0.9**

#### Motivation
Please add a new ConanCenter recipe for `gh-update-checker`, a header-only C++23 library to check a given GitHub repository for release updates

#### Details
This PR adds a new recipe for `gh-update-checker/v1.0.9` based on the Github repository https://github.com/Zheng-Bote/gh-update-checker


Testes with Conan version 2.26.2 on Linux/gcc and Win11/clang

```bash
======== Testing the package: Executing test ========
gh-update-checker/1.0.9 (test package): Running test()
gh-update-checker/1.0.9 (test package): RUN: ./gh-update-checker-test --help
Usage: gh-update-checker <repo-api-url> <local-version>
Example:
  gh-update-checker https://api.github.com/repos/zheng-bote/gh-update-checker/releases/latest v1.0.8
```
```bash
test_package/build/gcc-15-x86_64-23-release/gh-update-checker-test https://api.github.com/repos/zheng-bote/gh-update-checker/releases/latest v1.0.8
Local version:  v1.0.8
Remote version: v1.0.9
Update:         YES
```

```bash
conan list gh-update-checker/1.0.9:*
Local Cache
  gh-update-checker
    gh-update-checker/1.0.9
      revisions
        c8a68096beccb0049160729cf69f2a2f (2026-04-25 10:02:40 UTC)
          packages
            990b6a7248ef98a43b722d6f34acc05eb1e16a98
              info
                settings
                  arch: x86_64
                  build_type: Release
                  compiler: gcc
                  compiler.cppstd: 23
                  compiler.libcxx: libstdc++11
                  compiler.version: 15
                  os: Linux
```

P.S.:
Thanks for your great work!!!

