### PR TITLE
qt: fix missing QtInstallPaths.cmake in build modules

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -886,6 +886,8 @@ class QtConan(ConanFile):
         filecontents += f"set(QT_VERSION_PATCH {ver.patch})\n"
         if self.settings.os == "Macos":
             filecontents += 'set(__qt_internal_cmake_apple_support_files_path "${CMAKE_CURRENT_LIST_DIR}/../../../lib/cmake/Qt6/macos")\n'
+        if self.settings.os == "Windows":
+            filecontents += 'set(__qt_internal_cmake_windows_support_files_path "${CMAKE_CURRENT_LIST_DIR}/../../../lib/cmake/Qt6/windows")\n'
         targets = ["moc", "qlalr", "rcc", "tracegen", "cmake_automoc_parser", "qmake", "qtpaths", "syncqt", "tracepointgen"]
         disabled_features = str(self.options.disabled_features).split()
         if self.options.with_dbus:

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -1650,6 +1650,10 @@ class QtConan(ConanFile):
                 if os.path.isfile(module):
                     _add_build_module(component_name, module)
 
+                module = os.path.join("lib", "cmake", m, "QtInstallPaths.cmake")
+                if os.path.isfile(module):
+                    _add_build_module(component_name, module)
+
                 for helper_modules in glob.glob(os.path.join(self.package_folder, "lib", "cmake", m, "QtPublic*Helpers.cmake")):
                     _add_build_module(component_name, helper_modules)
                 for helper_modules in glob.glob(os.path.join(self.package_folder, "lib", "cmake", m, "Qt6QmlPublic*Helpers.cmake")):


### PR DESCRIPTION
### Summary
Changes to recipe:  qt/6.x.x

#### Motivation
* Fix #27921, by ensuring the variables set by `QtInstallPaths.cmake` are included during a `find_package(Qt6)` (see https://github.com/qt/qtbase/commit/018504f4f3adcea8eae69c068ee9012445adb5ae)
* Fix https://github.com/conan-io/conan-center-index/issues/30474, by ensuring `__qt_internal_cmake_windows_support_files_path` is correctly set (only a regression since 6.11.1, as per https://github.com/qt/qtbase/commit/4b0e7438ec89f1a6c6d7ed4688ebbb9c58c55ec3)

#### Details
Since Qt 6.8.0, QtInstallPaths.cmake is included directly from the original QtConfig.cmake file instead of indirectly from corelib/Qt6CoreConfigExtras.cmake.
This change correspondingly causes it to be included by the Conan-generated Qt6Config.cmake file by adding it to the list of build modules.

For `QtInstallPaths.cmake`, this fixes warning during `find_package(Qt6`)
```
-- Conan: Including build module from 'C:/j/b/qt9c86a20765351/p/lib/cmake/Qt6Core/Qt6CoreConfigExtras.cmake'
CMake Warning at C:/j/b/qt9c86a20765351/p/lib/cmake/Qt6Core/Qt6CoreMacros.cmake:3300 (message):
  No qtpaths executable found for deployment purposes.  Candidates searched:

      //qtpaths.exe
```

For `__qt_internal_cmake_windows_support_files_path`,  this fixes the following error during a call to `qt_add_executable()`on Windows:

```
CMake Error: File /app.exe.manifest.in does not exist.
CMake Error at D:/.conan2/p/qtb94d66b71210d/p/lib/cmake/Qt6/QtPublicWindowsHelpers.cmake:120 (configure_file):
  configure_file Problem configuring file
Call Stack (most recent call first):
  D:/.conan2/p/qtb94d66b71210d/p/lib/cmake/Qt6Core/Qt6CoreMacros.cmake:835 (_qt_internal_finalize_windows_app)
  D:/.conan2/p/qtb94d66b71210d/p/lib/cmake/Qt6Core/Qt6CoreMacros.cmake:898 (_qt_internal_finalize_executable)
  D:/.conan2/p/qtb94d66b71210d/p/lib/cmake/Qt6Core/Qt6CoreMacros.cmake:942:EVAL:1 (qt6_finalize_target)
  CMakeLists.txt:DEFERRED

-- Configuring incomplete, errors occurred!
```

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
