### PR TITLE
add NFIQ2 package

### DIFF
--- a/recipes/nfiq2/all/CMakeLists.txt
+++ b/recipes/nfiq2/all/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.15)
+project(nfiq2_conan_root LANGUAGES CXX)
+set(SUPERBUILD_ROOT_PATH "${CMAKE_CURRENT_SOURCE_DIR}")
+set(FRFXLL_PATH "${CMAKE_CURRENT_SOURCE_DIR}/fingerjetfxose/FingerJetFXOSE/libFRFXLL")
+add_subdirectory(fingerjetfxose/FingerJetFXOSE/libFRFXLL/src)
+add_subdirectory(NFIQ2/NFIQ2Algorithm)

--- a/recipes/nfiq2/all/conandata.yml
+++ b/recipes/nfiq2/all/conandata.yml
@@ -1,0 +1,17 @@
+patches:
+  "2.3.0":
+    - patch_file: "patches/0001-2.3.0-nfiq2algorithm-cmake-conan.patch"
+      patch_description: "Adapt the algorithm build to Conan by using CMakeDeps for OpenCV, removing superbuild-only include paths, linking the FingerJet static library as a target, defaulting the CLI to off and random-forest embedding to on, appending system libraries required for the static library, and using default install() rules instead of the upstream install_staging component."
+      patch_type: "conan"
+
+sources:
+  "2.3.0":
+    nfiq2:
+      url: "https://github.com/usnistgov/nfiq2/archive/refs/tags/v2.3.0.tar.gz"
+      sha256: "0a77239154b91d148cd49d5daae5261a8107295e85ecd122f02e798d49ee729f"
+    fingerjetfxose:
+      url: "https://github.com/FingerJetFXOSE/FingerJetFXOSE/archive/d67f329.tar.gz"
+      sha256: "1c51c2af7af64f87c504687a8bce7c92e0c69f608ba0d09bf1c773e1e1d1ab69"
+    digestpp:
+      url: "https://github.com/kerukuro/digestpp/archive/873b5b.tar.gz"
+      sha256: "4bb29c7d99597216669d0031cad59c6477873d8795145e1ec88e4d42eb839594"

--- a/recipes/nfiq2/all/conanfile.py
+++ b/recipes/nfiq2/all/conanfile.py
@@ -1,0 +1,66 @@
+from conan import ConanFile
+from conan.tools.cmake import cmake_layout, CMake, CMakeToolchain, CMakeDeps
+from conan.tools.files import get, apply_conandata_patches, export_conandata_patches, copy
+import os
+
+
+class Nfiq2Conan(ConanFile):
+    name = "nfiq2"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/usnistgov/nfiq2"
+    topics = ("NIST", "fingerprint", "biometrics", "quality")
+    license = "NIST-PD"
+    description = ("NIST Fingerprint Image Quality 2 open source software that links "
+                     "fingerprint image quality to operational recognition performance.")
+    settings = "os", "arch", "compiler", "build_type"
+    options = {"fPIC": [True, False]}
+    default_options = {"fPIC": True}
+    package_type = "static-library"
+
+    def export_sources(self):
+        export_conandata_patches(self)
+        copy(self, "CMakeLists.txt", src=self.recipe_folder, dst=self.export_sources_folder)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("opencv/4.10.0")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version]["nfiq2"], strip_root=True)
+        get(self, **self.conan_data["sources"][self.version]["fingerjetfxose"],
+            destination=os.path.join(self.source_folder, "fingerjetfxose"), strip_root=True)
+        get(self, **self.conan_data["sources"][self.version]["digestpp"],
+            destination=os.path.join(self.source_folder, "digestpp"), strip_root=True)
+        copy(self, "CMakeLists.txt", src=self.export_sources_folder, dst=self.source_folder)
+
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
+        tc = CMakeToolchain(self)
+        tc.generate()
+
+    def build(self):
+        apply_conandata_patches(self)
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["nfiq2", "FRFXLL_static"]
+        self.cpp_info.set_property("cmake_file_name", "nfiq2")
+        self.cpp_info.set_property("cmake_target_name", "nfiq2::nfiq2")
+        self.cpp_info.requires = ["opencv::opencv"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs = ["pthread", "dl"]
+        elif self.settings.os == "Windows":
+            self.cpp_info.system_libs = ["ws2_32"]

--- a/recipes/nfiq2/all/patches/0001-2.3.0-nfiq2algorithm-cmake-conan.patch
+++ b/recipes/nfiq2/all/patches/0001-2.3.0-nfiq2algorithm-cmake-conan.patch
@@ -1,0 +1,96 @@
+--- a/NFIQ2/NFIQ2Algorithm/CMakeLists.txt
++++ b/NFIQ2/NFIQ2Algorithm/CMakeLists.txt
+@@ -2,6 +2,8 @@
+ 
+ project( nfiq2 )
+ 
++option(BUILD_NFIQ2_CLI "Build the NFIQ2 command-line tool (Conan: needs NFIR/libbiomeval, off)" OFF)
++
+ set (CMAKE_CXX_STANDARD 11)
+ 
+ # FIXME: Prefer static libs on macOS and Windows, since it's "easy" on Linux to
+@@ -36,24 +38,28 @@
+ include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
+ include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")
+ 
+-# add libbiomeval include directories
+-include_directories("${SUPERBUILD_ROOT_PATH}/libbiomeval/src/include")
+-
+ include_directories("${SUPERBUILD_ROOT_PATH}/fingerjetfxose/FingerJetFXOSE/libFRFXLL/include")
+ 
+ include_directories("${SUPERBUILD_ROOT_PATH}/digestpp")
+ 
+-option(EMBED_RANDOM_FOREST_PARAMETERS "Embed random forest parameters in library" OFF)
++option(EMBED_RANDOM_FOREST_PARAMETERS "Embed random forest parameters in library" ON)
+ set(EMBEDDED_RANDOM_FOREST_PARAMETER_FCT "0" CACHE STRING
+     "ANSI/NIST-ITL 1-2011: Update 2015 friction ridge capture technology (FRCT) code for parameters to embed")
+ 
+-set( OpenCV_DIR ${CMAKE_BINARY_DIR}/../../../OpenCV-prefix/src/OpenCV-build)
+-find_package(OpenCV REQUIRED NO_CMAKE_PATH NO_CMAKE_ENVIRONMENT_PATH HINTS ${OpenCV_DIR})
++# Conan: OpenCV from opencv/ recipe (CMakeDeps) instead of superbuild ExternalProject
++find_package(OpenCV REQUIRED CONFIG)
++if(TARGET opencv::opencv)
++	set(_NFIQ2_OPENCV_LIB opencv::opencv)
++else()
++	set(_NFIQ2_OPENCV_LIB ${OpenCV_LIBS})
++	if(OpenCV_INCLUDE_DIRS)
++		include_directories(${OpenCV_INCLUDE_DIRS})
++	elseif(OpenCV_INCLUDE_DIR)
++		include_directories(${OpenCV_INCLUDE_DIR})
++	endif()
++endif()
+ set(OpenCV_SHARED ON)
+-include_directories(${OpenCV_INCLUDE_DIRS})
+ 
+-include_directories("${SUPERBUILD_ROOT_PATH}/NFIR/include")
+-
+ set(SOURCE_FILES
+     "src/nfiq2/nfiq2_cbeff.cpp"
+     "src/nfiq2/nfiq2_data.cpp"
+@@ -113,15 +119,22 @@
+ 	target_compile_definitions(${NFIQ2_STATIC_LIBRARY_TARGET} PUBLIC "NFIQ2_EMBEDDED_RANDOM_FOREST_PARAMETERS_FCT=${EMBEDDED_RANDOM_FOREST_PARAMETER_FCT}")
+ endif()
+ 
+-# FIXME: Change to "${CMAKE_INSTALL_PREFIX}/lib" once FJFX builds
+-# FIXME: are updated.
+-link_directories("${CMAKE_BINARY_DIR}/../../../fingerjetfxose/FingerJetFXOSE/libFRFXLL/src")
+-link_directories("${CMAKE_BINARY_DIR}/../../../fingerjetfxose/FingerJetFXOSE/libFRFXLL/src/$<$<BOOL:${IS_MULTI_CONFIG}>:$<$<CONFIG:Debug>:Debug>$<$<CONFIG:Release>:Release>>")
++# FRFXLL is built in the parent (Conan) project; use the imported target, not hardcoded
++# superbuild link_directories to ../../../fingerjetfxose/...
+ target_link_libraries(${NFIQ2_STATIC_LIBRARY_TARGET} PUBLIC
+ 	FRFXLL_static
+-	${OpenCV_LIBS}
++	${_NFIQ2_OPENCV_LIB}
+ )
+ 
++# Conan: platform libs (upstream only linked these to the CLI; static lib used from apps)
++if(WIN32)
++	target_compile_definitions(${NFIQ2_STATIC_LIBRARY_TARGET} PRIVATE NOMINMAX)
++	target_link_libraries(${NFIQ2_STATIC_LIBRARY_TARGET} PUBLIC ws2_32)
++else()
++	find_package(Threads REQUIRED)
++	target_link_libraries(${NFIQ2_STATIC_LIBRARY_TARGET} PUBLIC Threads::Threads ${CMAKE_DL_LIBS})
++endif()
++
+ if(USE_SANITIZER)
+ 	target_link_libraries(${NFIQ2_STATIC_LIBRARY_TARGET} "asan")
+ endif()
+@@ -240,15 +253,8 @@
+ 	endif()
+ endif(BUILD_NFIQ2_CLI)
+ 
+-install(TARGETS ${NFIQ2_STATIC_LIBRARY_TARGET}
++# Conan: install without COMPONENT (default) so `cmake --install` picks up the library
++install(TARGETS ${NFIQ2_STATIC_LIBRARY_TARGET} FRFXLL_static
+     ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+     LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+-    PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+-    COMPONENT install_staging)
+-
+-# FIXME: FingerJet doesn't have an install target
+-install(FILES
+-	${CMAKE_BINARY_DIR}/../../../fingerjetfxose/FingerJetFXOSE/libFRFXLL/src/$<$<BOOL:${IS_MULTI_CONFIG}>:$<$<CONFIG:Debug>:Debug/>$<$<CONFIG:Release>:Release/>>${CMAKE_STATIC_LIBRARY_PREFIX}FRFXLL_static${CMAKE_STATIC_LIBRARY_SUFFIX}
+-	${CMAKE_BINARY_DIR}/../../../fingerjetfxose/FingerJetFXOSE/libFRFXLL/src/$<$<BOOL:${IS_MULTI_CONFIG}>:$<$<CONFIG:Debug>:Debug/>$<$<CONFIG:Release>:Release/>>${CMAKE_SHARED_LIBRARY_PREFIX}FRFXLL${CMAKE_SHARED_LIBRARY_SUFFIX}
+-	DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+-	COMPONENT install_staging)
++    PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")

--- a/recipes/nfiq2/all/test_package/CMakeLists.txt
+++ b/recipes/nfiq2/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(nfiq2 REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE nfiq2::nfiq2)

--- a/recipes/nfiq2/all/test_package/conanfile.py
+++ b/recipes/nfiq2/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+from os import path
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            self.run(path.join(self.cpp.build.bindir, "test_package"), env="conanrun")

--- a/recipes/nfiq2/all/test_package/test_package.cpp
+++ b/recipes/nfiq2/all/test_package/test_package.cpp
@@ -1,0 +1,9 @@
+#include <nfiq2_algorithm.hpp>
+
+int main() {
+    NFIQ2::Algorithm nfiq2;
+    if (!nfiq2.isInitialized() || !nfiq2.isEmbedded()) {
+        return 1;
+    }
+    return 0;
+}

--- a/recipes/nfiq2/config.yml
+++ b/recipes/nfiq2/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.3.0":
+    folder: all


### PR DESCRIPTION
### Summary
New recipe:  **nfiq2/2.3.0**

#### Motivation
Downstream projects should be able to depend on NFIQ2 through Conan’s dependency graph and get a known-good build (OpenCV resolved via Center, static lib + vendored FRFXLL wired in CMake) instead of everyone cloning NIST, re-running their superbuild, and debugging the same integration issues in private scripts.

#### Details
Minimal root CMake + one patch on NFIQ2/NFIQ2Algorithm/CMakeLists.txt (Conan OpenCV, FRFXLL_static, no superbuild-only includes, fixed install, CLI off / embed on, platform link libs on the static target). conandata pins NFIQ2, FingerJet, digestpp; conanfile requires OpenCV, applies patches, exports both static libs. test_package checks the algorithm is initialized and embedded.

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
