### PR TITLE
[m4] Backport GCC15 support for 1.4.19

### DIFF
--- a/recipes/m4/all/conanfile.py
+++ b/recipes/m4/all/conanfile.py
@@ -5,6 +5,7 @@ from conan.tools.files import apply_conandata_patches, copy, export_conandata_pa
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.layout import basic_layout
 from conan.tools.microsoft import is_msvc, unix_path
+from conan.tools.scm import Version
 import os
 import shutil
 
@@ -58,6 +59,10 @@ class M4Conan(ConanFile):
             ])
             if self.settings.build_type in ("Debug", "RelWithDebInfo"):
                 tc.extra_ldflags.append("-PDB")
+        elif self.version == "1.4.19" and self.settings.compiler == "gcc" and Version(self.settings.compiler) >= "15":
+            # FIXME: https://savannah.gnu.org/support/?func=detailitem&item_id=111150
+            # WORKAROUND: https://lists.buildroot.org/pipermail/buildroot/2025-May/777741.html
+            tc.extra_cflags.append("-std=gnu17")
 
         if cross_building(self) and is_msvc(self):
             triplet_arch_windows = {"x86_64": "x86_64", "x86": "i686", "armv8": "aarch64"}


### PR DESCRIPTION
### Summary
Changes to recipe:  **m4/1.4.19**

#### Motivation

close #29220
fixes #29184

#### Details

This PR is a simplification of #29220: Change only m4 to avoid rebuilding all extra packages. The m4 1.4.19 is still used in ConanCenterIndex and will have a lower impact if only changing it. 

When building M4 1.4.19 using GCC15, some errors can be found, like:

```
src/lib/gl_list.h:755:40: error: expected identifier or '(' before 'gl_list_node_t'
  755 | GL_LIST_INLINE _GL_ATTRIBUTE_NODISCARD gl_list_node_t
```

The full build log with several errors can be checked here: [m4-1.4.19-linux-amd64-gcc15-release.log](https://github.com/user-attachments/files/24324916/m4-1.4.19-linux-amd64-gcc15-release.log)

Disabling warnings is not enough, as this error is related to the gnulib copied in m4, which does not support C23 (the default C and C++ standard for GCC15: [gcc.gnu.org/gcc-15/changes.html#c](https://gcc.gnu.org/gcc-15/changes.html#c)). As a workaround, we keep C17 for GCC15 and it works just fine:

[m4-1.4.19-linux-amd64-gcc15-cstd17-release.log](https://github.com/user-attachments/files/27119922/m4-1.4.19-linux-amd64-gcc15-cstd17-release.log)


The case was officially reported before: [savannah.gnu.org/support?111150](https://savannah.gnu.org/support/?111150), and it was fixed in 1.4.20 as a new release gnulib was incorporated into the project: [lists.gnu.org/archive/html/m4-announce/2025-05/msg00000.html](https://lists.gnu.org/archive/html/m4-announce/2025-05/msg00000.html). Bringing a new gnulib version as a backport is not viable, but the Buildroot project had a good insight by keeping C17 for compatibility: [lists.buildroot.org/pipermail/buildroot/2025-May/777741.html](https://lists.buildroot.org/pipermail/buildroot/2025-May/777741.html)

This bug is affecting only 1.4.19, the versions 1.4.18 and 1.4.20 can be built using GCC15 without errors:

* [m4-1.4.18-linux-amd64-gcc15-release.log](https://github.com/user-attachments/files/24325076/m4-1.4.18-linux-amd64-gcc15-release.log)
* [m4-1.4.20-linux-amd64-gcc15-release.log](https://github.com/user-attachments/files/24325077/m4-1.4.20-linux-amd64-gcc15-release.log)

To avoid future conflicts and to keep aligned with the latest version available, this PR also updates all recipes in ConanCenterIndex that are consuming the package for m4 to use version ranges.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
