### PR TITLE
libssh: Add versions v0.11.4 and v0.12.0

### DIFF
--- a/recipes/libssh/all/conandata.yml
+++ b/recipes/libssh/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "0.12.0":
     url: "https://www.libssh.org/files/0.12/libssh-0.12.0.tar.xz"
     sha256: "1a6af424d8327e5eedef4e5fe7f5b924226dd617ac9f3de80f217d82a36a7121"
+  "0.11.4":
+    url: "https://www.libssh.org/files/0.11/libssh-0.11.4.tar.xz"
+    sha256: "002ac320e3d66c9e100ec6576e3e84aa0c48949efde3bf5b40a2802992297701"

--- a/recipes/libssh/all/conandata.yml
+++ b/recipes/libssh/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
-  "0.11.3":
-    url: "https://www.libssh.org/files/0.11/libssh-0.11.3.tar.xz"
-    sha256: "7d8a1361bb094ec3f511964e78a5a4dba689b5986e112afabe4f4d0d6c6125c3"
+  "0.12.0":
+    url: "https://www.libssh.org/files/0.12/libssh-0.12.0.tar.xz"
+    sha256: "1a6af424d8327e5eedef4e5fe7f5b924226dd617ac9f3de80f217d82a36a7121"
+  "0.11.4":
+    url: "https://www.libssh.org/files/0.11/libssh-0.11.4.tar.xz"
+    sha256: "002ac320e3d66c9e100ec6576e3e84aa0c48949efde3bf5b40a2802992297701"

--- a/recipes/libssh/all/conandata.yml
+++ b/recipes/libssh/all/conandata.yml
@@ -2,6 +2,3 @@ sources:
   "0.12.0":
     url: "https://www.libssh.org/files/0.12/libssh-0.12.0.tar.xz"
     sha256: "1a6af424d8327e5eedef4e5fe7f5b924226dd617ac9f3de80f217d82a36a7121"
-  "0.11.4":
-    url: "https://www.libssh.org/files/0.11/libssh-0.11.4.tar.xz"
-    sha256: "002ac320e3d66c9e100ec6576e3e84aa0c48949efde3bf5b40a2802992297701"

--- a/recipes/libssh/config.yml
+++ b/recipes/libssh/config.yml
@@ -1,5 +1,3 @@
 versions:
   "0.12.0":
     folder: all
-  "0.11.4":
-    folder: all

--- a/recipes/libssh/config.yml
+++ b/recipes/libssh/config.yml
@@ -1,3 +1,5 @@
 versions:
-  "0.11.3":
+  "0.12.0":
+    folder: all
+  "0.11.4":
     folder: all

--- a/recipes/libssh/config.yml
+++ b/recipes/libssh/config.yml
@@ -1,3 +1,5 @@
 versions:
   "0.12.0":
     folder: all
+  "0.11.4":
+    folder: all


### PR DESCRIPTION
### Summary
Add versions  **libssh/0.11.4** and **libssh/0.12.0**

#### Motivation
They fixed a couple issues: https://www.libssh.org/2026/02/10/libssh-0-12-0-and-0-11-4-security-releases/


#### Details
I added the two versions mentioned above and removed v0.11.3.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
