### PR TITLE
feat: raygui 4.0

### DIFF
--- a/recipes/raygui/all/conandata.yml
+++ b/recipes/raygui/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "4.0":
+    url: "https://github.com/raysan5/raygui/archive/refs/tags/4.0.tar.gz"
+    sha256: "299c8fcabda68309a60dc858741b76c32d7d0fc533cdc2539a55988cee236812"

--- a/recipes/raygui/all/conanfile.py
+++ b/recipes/raygui/all/conanfile.py
@@ -1,0 +1,42 @@
+from conan import ConanFile
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+import os
+
+required_conan_version = ">=1.53.0"
+
+
+class RayguiConan(ConanFile):
+    name = "raygui"
+    description = "A simple and easy-to-use immediate-mode gui library."
+    license = "Zlib"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/raysan5/raygui"
+    topics = ("gui", "raylib", "header-only")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def requirements(self):
+        self.requires("raylib/[>=5 <7]")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, "raygui.h", src=os.path.join(self.source_folder, "src"), dst=os.path.join(self.package_folder, "include"))
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.requires = ["raylib::raylib"]
+        self.cpp_info.set_property("cmake_file_name", "raygui")
+        self.cpp_info.set_property("cmake_target_name", "raygui::raygui")
+        self.cpp_info.set_property("pkg_config_name", "raygui")

--- a/recipes/raygui/all/test_package/CMakeLists.txt
+++ b/recipes/raygui/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES C)
+
+find_package(raygui REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE raygui::raygui)

--- a/recipes/raygui/all/test_package/conanfile.py
+++ b/recipes/raygui/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/raygui/all/test_package/test_package.c
+++ b/recipes/raygui/all/test_package/test_package.c
@@ -1,0 +1,7 @@
+#define RAYGUI_IMPLEMENTATION
+#include <raygui.h>
+
+int main(void) {
+    GuiEnable();
+    return 0;
+}

--- a/recipes/raygui/config.yml
+++ b/recipes/raygui/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "4.0":
+    folder: "all"


### PR DESCRIPTION
### Summary

Changes to recipe: raygui/4.0

#### Motivation

This PR adds raygui to Conan Center for version 4.0, which is currently missing. Raygui is a common GUI companion library for raylib, so packaging it improves ecosystem coverage and allows consumers to depend on it directly via Conan.

#### Details

- Added a new recipe at recipes/raygui/all with version mapping in recipes/raygui/config.yml.
- Declared source for 4.0 in conandata.yml with upstream tarball URL and SHA-256.
- Implemented raygui as a header-only package:
  - package_type = "header-library"
  - package_id() cleared for full header-only ID behavior.
  - Packages raygui.h and LICENSE.
- Added dependency on raylib with range raylib/[>=5 <7].
- Exposed Conan/CMake/pkg-config metadata:
  - CMake target: raygui::raygui
  - CMake file name: raygui
  - pkg-config name: raygui
  - Propagates raylib::raylib as requirement.
- Added test package using CMake that:
  - find_package(raygui CONFIG REQUIRED)
  - Links raygui::raygui
  - Compiles and runs a minimal program calling GuiEnable() from raygui.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
