### PR TITLE
opencl-clhpp-headers: add version v2025.07.22

### DIFF
--- a/recipes/opencl-clhpp-headers/all/conandata.yml
+++ b/recipes/opencl-clhpp-headers/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2025.07.22":
+    url: "https://github.com/KhronosGroup/OpenCL-CLHPP/archive/refs/tags/v2025.07.22.tar.gz"
+    sha256: "c1031afde6e9eb042e6fcfbc17078f4b437a7e8d55482a1ca6e0fa762d262a89"
   "2023.12.14":
     url: "https://github.com/KhronosGroup/OpenCL-CLHPP/archive/refs/tags/v2023.12.14.tar.gz"
     sha256: "9106700634e79cfa0935ebd67197f64689ced24c42da702acf18fa8435bd8a82"

--- a/recipes/opencl-clhpp-headers/config.yml
+++ b/recipes/opencl-clhpp-headers/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2025.07.22":
+    folder: all
   "2023.12.14":
     folder: all
   "2023.04.17":


### PR DESCRIPTION
### Summary
Changes to recipe:  **opencl-clhpp-headers/2025.07.22**

#### Motivation
The new version 2025.07.22 was not yet available in the current recipe. This update ensures Conan users can access the most recent upstream release.

#### Details
- Added new upstream release 2025.07.22
- Updated `conandata.yml` with corresponding URL and SHA256 checksum
- Updated `config.yml`

---

- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---

Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!