### PR TITLE
opencl-headers: add version 2025.07.22

### DIFF
--- a/recipes/opencl-headers/all/conandata.yml
+++ b/recipes/opencl-headers/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2025.07.22":
+    url: "https://github.com/KhronosGroup/OpenCL-Headers/archive/refs/tags/v2025.07.22.tar.gz"
+    sha256: "98f0a3ea26b4aec051e533cb1750db2998ab8e82eda97269ed6efe66ec94a240"
   "2023.12.14":
     url: "https://github.com/KhronosGroup/OpenCL-Headers/archive/refs/tags/v2023.12.14.tar.gz"
     sha256: "407d5e109a70ec1b6cd3380ce357c21e3d3651a91caae6d0d8e1719c69a1791d"

--- a/recipes/opencl-headers/all/conanfile.py
+++ b/recipes/opencl-headers/all/conanfile.py
@@ -66,9 +66,3 @@ class OpenclHeadersConan(ConanFile):
         self.cpp_info.set_property("pkg_config_name", "OpenCL-Headers")
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
-
-        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
-        self.cpp_info.filenames["cmake_find_package"] = "OpenCLHeaders"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "OpenCLHeaders"
-        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
-        self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]

--- a/recipes/opencl-headers/all/conanfile.py
+++ b/recipes/opencl-headers/all/conanfile.py
@@ -66,3 +66,9 @@ class OpenclHeadersConan(ConanFile):
         self.cpp_info.set_property("pkg_config_name", "OpenCL-Headers")
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
+
+        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
+        self.cpp_info.filenames["cmake_find_package"] = "OpenCLHeaders"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "OpenCLHeaders"
+        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
+        self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]

--- a/recipes/opencl-headers/config.yml
+++ b/recipes/opencl-headers/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2025.07.22":
+    folder: all
   "2023.12.14":
     folder: all
   "2023.04.17":


### PR DESCRIPTION
### Summary
Changes to recipe: **opencl-headers/2025.07.22**

#### Motivation
Add new version `2025.07.22` of `opencl-headers` to keep up with the latest
upstream release from the Khronos Group.

#### Details
- Added version `2025.07.22` to `config.yml`
- Added source URL and SHA256 checksum to `conandata.yml`
- Removed deprecated Conan 1.x features from `package_info()`:
  - Removed `cpp_info.filenames["cmake_find_package"]`
  - Removed `cpp_info.filenames["cmake_find_package_multi"]`
  - Removed `cpp_info.build_modules["cmake_find_package"]`
  - Removed `cpp_info.build_modules["cmake_find_package_multi"]`
- Tested locally on macOS (Apple Silicon, apple-clang 17, armv8, Release)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
