### PR TITLE
fix: pcl ignoring conan CXX flags

### DIFF
--- a/recipes/pcl/all/conanfile.py
+++ b/recipes/pcl/all/conanfile.py
@@ -534,6 +534,10 @@ class PclConan(ConanFile):
         replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
                         'if("${CMAKE_CXX_FLAGS}" STREQUAL "")',
                         'if(1)')
+        # fix ignoring conan cxx flags
+        replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
+                        'set(CMAKE_CXX_FLAGS "',
+                        'string(APPEND CMAKE_CXX_FLAGS " ')
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
This fixes #29597, where pcl linked libstdc++ instead of libc++ with clang, when libc++ was actually specified in the conan profile.


### Summary
Changes to recipe:  **pcl**

#### Motivation
PCL cmake uses set(CMAKE_CXX_FLAGS "myflag") which ignores conan cxx flags being set. This fixes #29597, which was introduced by #28429.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
