### PR TITLE
cyclonedds: add version 11.0.1

### DIFF
--- a/recipes/cyclonedds/all/conandata.yml
+++ b/recipes/cyclonedds/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "11.0.1":
+    url: "https://github.com/eclipse-cyclonedds/cyclonedds/archive/11.0.1.tar.gz"
+    sha256: "c25d46075ad6b5cee564bda9e5f49509e9a6dbb1a8b858e708eb360d335cf973"
   "0.10.5":
     url: "https://github.com/eclipse-cyclonedds/cyclonedds/archive/0.10.5.tar.gz"
     sha256: "ec3ec898c52b02f939a969cd1a276e219420e5e8419b21cea276db35b4821848"
@@ -12,6 +15,10 @@ sources:
     url: "https://github.com/eclipse-cyclonedds/cyclonedds/archive/refs/tags/0.10.2.tar.gz"
     sha256: "bc84e137e0c8a055b8cd97fbeafec94e36de1b0c2e88800896a82384fd867ae5"
 patches:
+  "11.0.1":
+    - patch_file: "patches/11.0.1-0001-fix-find-iceoryx.patch"
+      patch_description: "Fix cmake find for iceoryx package"
+      patch_type: "conan"
   "0.10.5":
     - patch_file: "patches/0.10.2-0001-fix-find-iceoryx.patch"
       patch_description: "Fix cmake find for iceoryx package"

--- a/recipes/cyclonedds/all/conanfile.py
+++ b/recipes/cyclonedds/all/conanfile.py
@@ -82,7 +82,7 @@ class CycloneDDSConan(ConanFile):
             self.requires("openssl/[>=1.1 <4]")
 
     def validate(self):
-        if self.options.enable_security and not self.options.shared:
+        if Version(self.version) < "11" and self.options.enable_security and not self.options.shared:
             raise ConanInvalidConfiguration(f"{self.ref} currently do not support"\
                                             "static build and security on")
         if self.settings.compiler.get_safe("cppstd"):
@@ -110,7 +110,10 @@ class CycloneDDSConan(ConanFile):
         tc.cache_variables["ENABLE_LTO"] = False
         # variables which effects build
         tc.variables["ENABLE_SSL"] = self.options.with_ssl
-        tc.variables["ENABLE_SHM"] = self.options.with_shm
+        if Version(self.version) >= "11":
+            tc.variables["ENABLE_ICEORYX"] = self.options.with_shm
+        else:
+            tc.variables["ENABLE_SHM"] = self.options.with_shm
         tc.variables["ENABLE_SECURITY"] = self.options.enable_security
         tc.variables["ENABLE_TYPE_DISCOVERY"] = self.options.enable_discovery
         tc.variables["ENABLE_TOPIC_DISCOVERY"] = self.options.enable_discovery

--- a/recipes/cyclonedds/all/patches/11.0.1-0001-fix-find-iceoryx.patch
+++ b/recipes/cyclonedds/all/patches/11.0.1-0001-fix-find-iceoryx.patch
@@ -1,0 +1,16 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 8a7b3e01..f4c2a3d5 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -134,9 +134,8 @@
+   else()
+     set(iceoryx_required QUIET)
+   endif()
+-  find_package(iceoryx_hoofs ${iceoryx_required})
+-  find_package(iceoryx_posh ${iceoryx_required})
+-  if(${iceoryx_hoofs_FOUND} AND ${iceoryx_posh_FOUND})
++  find_package(iceoryx ${iceoryx_required})
++  if(${iceoryx_FOUND})
+     set(ENABLE_ICEORYX "ON")
+   else()
+     set(ENABLE_ICEORYX "OFF")

--- a/recipes/cyclonedds/config.yml
+++ b/recipes/cyclonedds/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "11.0.1":
+    folder: all
   "0.10.5":
     folder: all
   "0.10.4":


### PR DESCRIPTION
### Summary
Changes to recipe:  **cyclonedds/11.0.1**

#### Motivation
Version 11.0.1 is newly released by the upstream project and not yet available as a recipe. Closes [#29959](https://github.com/conan-io/conan-center-index/issues/29959).

#### Details
Added 11.0.1 to config.yml and conandata.yml
Added new patch 11.0.1-0001-fix-find-iceoryx.patch: upstream changed the iceoryx integration from find_package(iceoryx_binding_c) to separate find_package(iceoryx_hoofs) + find_package(iceoryx_posh) calls; the patch redirects these to find_package(iceoryx) to match the cmake file name exposed by the CCI iceoryx package
Updated generate() to set ENABLE_ICEORYX directly for 11.0.1+ instead of the now-deprecated ENABLE_SHM
Updated validate() to allow enable_security=True with static builds for 11.0.1+: security plugins were shared-library-only in 0.10.x but now support static builds via OBJECT library linking in 11.0.1


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
