### PR TITLE
wxwidgets: provide i18n message catalogs

### DIFF
--- a/recipes/wxwidgets/all/conanfile.py
+++ b/recipes/wxwidgets/all/conanfile.py
@@ -101,7 +101,7 @@ class wxWidgetsConan(ConanFile):
     def build_requirements(self):
         self.tool_requires("ninja/[>=1.10.2 <2]")
         self.tool_requires("cmake/[>=3.17 <4]")
-        self.tool_requires("gettext/0.26")
+        self.tool_requires("gettext/[>=0.22 <1]")
 
     def requirements(self):
         if self.settings.os == "Linux":
@@ -157,6 +157,7 @@ class wxWidgetsConan(ConanFile):
         tc.cache_variables["wxBUILD_SAMPLES"] = "OFF"
         tc.cache_variables["wxBUILD_TESTS"] = "OFF"
         tc.cache_variables["wxBUILD_DEMOS"] = "OFF"
+        tc.cache_variables["wxBUILD_LOCALES"] = "ON"
         tc.cache_variables["wxBUILD_INSTALL"] = True
         if self.settings.compiler == "clang":
             tc.cache_variables["wxBUILD_PRECOMP"] = "OFF"
@@ -258,7 +259,7 @@ class wxWidgetsConan(ConanFile):
         cmake = CMake(self)
         cmake.install()
         # remove cmake files
-        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        # rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
         # copy setup.h
         copy(self, pattern="*setup.h",
              src=os.path.join(self.build_folder, "lib"),

--- a/recipes/wxwidgets/all/conanfile.py
+++ b/recipes/wxwidgets/all/conanfile.py
@@ -259,7 +259,7 @@ class wxWidgetsConan(ConanFile):
         cmake = CMake(self)
         cmake.install()
         # remove cmake files
-        # rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
         # copy setup.h
         copy(self, pattern="*setup.h",
              src=os.path.join(self.build_folder, "lib"),

--- a/recipes/wxwidgets/all/conanfile.py
+++ b/recipes/wxwidgets/all/conanfile.py
@@ -289,6 +289,7 @@ class wxWidgetsConan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "wxWidgets")
         self.cpp_info.set_property("cmake_target_name", "wxWidgets::wxWidgets")
         self.cpp_info.set_property("pkg_config_name", "wxwidgets")
+        self.conf_info.define("user.wxwidgets:locales", os.path.join(self.package_folder, "share", "locale"))
 
         _version = Version(self.version)
         version_suffix_major_minor = f"-{_version.major}.{_version.minor}"

--- a/recipes/wxwidgets/all/conanfile.py
+++ b/recipes/wxwidgets/all/conanfile.py
@@ -101,6 +101,7 @@ class wxWidgetsConan(ConanFile):
     def build_requirements(self):
         self.tool_requires("ninja/[>=1.10.2 <2]")
         self.tool_requires("cmake/[>=3.17 <4]")
+        self.tool_requires("gettext/0.26")
 
     def requirements(self):
         if self.settings.os == "Linux":


### PR DESCRIPTION
wxWidgets needs gettext to build its standard message catalogs. When missing these, messages/dialogs from the lib itself are not translated, i.e. always in English, which is a clear functional regression for languages other than English.


### Summary
Changes to recipe:  **wxwidgets**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
wxWidgets needs gettext to build its standard message catalogs. When missing these, messages/dialogs from the lib itself are not translated, i.e. always in English, which is a clear functional regression for languages other than English.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
Adds gettext tool_requires.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
