### PR TITLE
(kcp) add version 1.7.1

### DIFF
--- a/recipes/kcp/all/conandata.yml
+++ b/recipes/kcp/all/conandata.yml
@@ -1,10 +1,4 @@
 sources:
-  "1.5":
-    url: "https://github.com/skywind3000/kcp/archive/1.5.tar.gz"
-    sha256: "14c1dfb3485cab635299a698f35db261ab7e74505efd0ec579b71fc7af0dff06"
-  "1.7":
-    url: "https://github.com/skywind3000/kcp/archive/1.7.tar.gz"
-    sha256: "b4d26994d95599ab0c44e1f93002f9fda275094a879d66c192d79d596529199e"
   "1.7.1":
     url: "https://github.com/skywind3000/kcp/archive/refs/tags/1.7.1.tar.gz"
     sha256: "41cb85b2b4c2ea5f534b785c88fe24d86c6aaca62c3ef181d18bf1db3da6758d"

--- a/recipes/kcp/all/conandata.yml
+++ b/recipes/kcp/all/conandata.yml
@@ -5,3 +5,6 @@ sources:
   "1.7":
     url: "https://github.com/skywind3000/kcp/archive/1.7.tar.gz"
     sha256: "b4d26994d95599ab0c44e1f93002f9fda275094a879d66c192d79d596529199e"
+  "1.7.1":
+    url: "https://github.com/skywind3000/kcp/archive/refs/tags/1.7.1.tar.gz"
+    sha256: "41cb85b2b4c2ea5f534b785c88fe24d86c6aaca62c3ef181d18bf1db3da6758d"

--- a/recipes/kcp/all/conanfile.py
+++ b/recipes/kcp/all/conanfile.py
@@ -3,8 +3,7 @@ import os
 from conan import ConanFile
 from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, export_conandata_patches, get, load, rmdir, replace_in_file
-from conan.tools.scm import Version
+from conan.tools.files import copy, export_conandata_patches, get, rmdir
 
 required_conan_version = ">=1.53.0"
 
@@ -58,14 +57,7 @@ class KcpConan(ConanFile):
         tc = CMakeDeps(self)
         tc.generate()
 
-    def _patch_sources(self):
-        # Fix shared builds on Windows
-        replace_in_file(self, cmakelists,
-                        "ARCHIVE DESTINATION",
-                        "RUNTIME DESTINATION bin\nARCHIVE DESTINATION")
-
     def build(self):
-        self._patch_sources()
         cmake = CMake(self)
         cmake.configure()
         cmake.build()

--- a/recipes/kcp/all/conanfile.py
+++ b/recipes/kcp/all/conanfile.py
@@ -3,7 +3,8 @@ import os
 from conan import ConanFile
 from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, export_conandata_patches, get, rmdir, replace_in_file
+from conan.tools.files import copy, export_conandata_patches, get, load, rmdir, replace_in_file
+from conan.tools.scm import Version
 
 required_conan_version = ">=1.53.0"
 
@@ -46,6 +47,10 @@ class KcpConan(ConanFile):
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
+    def build_requirements(self):
+        if Version(self.version) >= "1.7.1":
+            self.tool_requires("cmake/[>=4 <5]")
+
     def generate(self):
         tc = CMakeToolchain(self)
         tc.variables["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = True
@@ -55,12 +60,15 @@ class KcpConan(ConanFile):
         tc.generate()
 
     def _patch_sources(self):
+        cmakelists = os.path.join(self.source_folder, "CMakeLists.txt")
+        contents = load(self, cmakelists)
         # Fix shared builds on Windows
-        replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
-                        " STATIC", "")
-        replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
-                        "ARCHIVE DESTINATION",
-                        "RUNTIME DESTINATION bin\nARCHIVE DESTINATION")
+        if " STATIC" in contents:
+            replace_in_file(self, cmakelists, " STATIC", "")
+        if "RUNTIME DESTINATION" not in contents:
+            replace_in_file(self, cmakelists,
+                            "ARCHIVE DESTINATION",
+                            "RUNTIME DESTINATION bin\nARCHIVE DESTINATION")
 
     def build(self):
         self._patch_sources()

--- a/recipes/kcp/all/conanfile.py
+++ b/recipes/kcp/all/conanfile.py
@@ -48,8 +48,7 @@ class KcpConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def build_requirements(self):
-        if Version(self.version) >= "1.7.1":
-            self.tool_requires("cmake/[>=4 <5]")
+        self.tool_requires("cmake/[>=4 <5]")
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -60,15 +59,10 @@ class KcpConan(ConanFile):
         tc.generate()
 
     def _patch_sources(self):
-        cmakelists = os.path.join(self.source_folder, "CMakeLists.txt")
-        contents = load(self, cmakelists)
         # Fix shared builds on Windows
-        if " STATIC" in contents:
-            replace_in_file(self, cmakelists, " STATIC", "")
-        if "RUNTIME DESTINATION" not in contents:
-            replace_in_file(self, cmakelists,
-                            "ARCHIVE DESTINATION",
-                            "RUNTIME DESTINATION bin\nARCHIVE DESTINATION")
+        replace_in_file(self, cmakelists,
+                        "ARCHIVE DESTINATION",
+                        "RUNTIME DESTINATION bin\nARCHIVE DESTINATION")
 
     def build(self):
         self._patch_sources()

--- a/recipes/kcp/all/conanfile.py
+++ b/recipes/kcp/all/conanfile.py
@@ -47,7 +47,7 @@ class KcpConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def build_requirements(self):
-        self.tool_requires("cmake/[>=4 <5]")
+        self.tool_requires("cmake/[>=4]")
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/recipes/kcp/config.yml
+++ b/recipes/kcp/config.yml
@@ -1,5 +1,3 @@
 versions:
-  "1.5":
-    folder: all
-  "1.7":
+  "1.7.1":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  `kcp/1.7.1`

#### Motivation
Add upstream version `1.7.1` to the `kcp` recipe.

Upstream `1.7.1` changed its `CMakeLists.txt` and now requires CMake 4.x, so the recipe needs to express that build requirement explicitly for this version.

#### Details
- add `1.7.1` source entry and sha256 to `conandata.yml`
- make `_patch_sources()` conditional on the actual `CMakeLists.txt` contents so older patching logic is preserved for previous versions and not applied unnecessarily to `1.7.1`
- add a conditional build requirement for `cmake/[>=4]` for `kcp/1.7.1+` https://github.com/skywind3000/kcp/blob/1.7.1/CMakeLists.txt#L1

Local validation:
- `conan create recipes/kcp/all --version=1.7 -b missing`
- `conan create recipes/kcp/all --version=1.7.1 -b missing`

Both versions build successfully and their `test_package` passes locally.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
