### PR TITLE
libxml2: publish version 2.15.3, stop publishing revs for 2.15.2

### DIFF
--- a/recipes/libxml2/cmake/conandata.yml
+++ b/recipes/libxml2/cmake/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "2.15.2":
-    url: "https://download.gnome.org/sources/libxml2/2.15/libxml2-2.15.2.tar.xz"
-    sha256: "c8b9bc81f8b590c33af8cc6c336dbff2f53409973588a351c95f1c621b13d09d"
+  "2.15.3":
+    url: "https://download.gnome.org/sources/libxml2/2.15/libxml2-2.15.3.tar.xz"
+    sha256: "78262a6e7ac170d6528ebfe2efccdf220191a5af6a6cd61ea4a9a9a5042c7a07"
   "2.14.5":
     url: "https://download.gnome.org/sources/libxml2/2.14/libxml2-2.14.5.tar.xz"
     sha256: "03d006f3537616833c16c53addcdc32a0eb20e55443cba4038307e3fa7d8d44b"

--- a/recipes/libxml2/config.yml
+++ b/recipes/libxml2/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "2.15.2":
+  "2.15.3":
     folder: cmake
   "2.14.5":
     folder: cmake


### PR DESCRIPTION
### Summary
Changes to recipe:  **libxml2/2.15.3**

#### Motivation
Security fixes
[CVE-2026-6732](https://github.com/advisories/GHSA-6rf6-xrp6-223m)

#### Details
https://gitlab.gnome.org/GNOME/libxml2/-/commit/c94eb0210183b9d7cb43f8e7fddc6be55843ef49

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
