### PR TITLE
sbepp: publish version 1.8.0

### DIFF
--- a/recipes/sbepp/all/conandata.yml
+++ b/recipes/sbepp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.8.0":
+    url: "https://github.com/OleksandrKvl/sbepp/archive/refs/tags/1.8.0.tar.gz"
+    sha256: "6d78cb3fb94a1295ffd1201949c4b4173f873d063d47cc8e6646e029ade9b69e"
   "1.7.0":
     url: "https://github.com/OleksandrKvl/sbepp/archive/refs/tags/1.7.0.tar.gz"
     sha256: "dd6d66f3ccfe8d9ab6069b870608769db80e85f6840a54ccafd8722d3b190a2c"

--- a/recipes/sbepp/all/conanfile.py
+++ b/recipes/sbepp/all/conanfile.py
@@ -63,7 +63,7 @@ class PackageConan(ConanFile):
     def requirements(self):
         if self.options.with_sbeppc:
             # sbepp/<1.1.0 requires fmt and pugixml with hardcoded versions
-            self.requires("fmt/[>=9.1.0]")
+            self.requires("fmt/[>=9.1 <13]")
             self.requires("pugixml/[>=1.14 <2]")
 
     def validate(self):

--- a/recipes/sbepp/all/conanfile.py
+++ b/recipes/sbepp/all/conanfile.py
@@ -63,8 +63,8 @@ class PackageConan(ConanFile):
     def requirements(self):
         if self.options.with_sbeppc:
             # sbepp/<1.1.0 requires fmt and pugixml with hardcoded versions
-            self.requires("fmt/10.2.0")
-            self.requires("pugixml/1.14")
+            self.requires("fmt/[>=9.1.0]")
+            self.requires("pugixml/[>=1.14]")
 
     def validate(self):
         check_min_cppstd(self, self._min_cppstd)

--- a/recipes/sbepp/all/conanfile.py
+++ b/recipes/sbepp/all/conanfile.py
@@ -64,7 +64,7 @@ class PackageConan(ConanFile):
         if self.options.with_sbeppc:
             # sbepp/<1.1.0 requires fmt and pugixml with hardcoded versions
             self.requires("fmt/[>=9.1.0]")
-            self.requires("pugixml/[>=1.14]")
+            self.requires("pugixml/[>=1.14 <2]")
 
     def validate(self):
         check_min_cppstd(self, self._min_cppstd)

--- a/recipes/sbepp/config.yml
+++ b/recipes/sbepp/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.8.0":
+    folder: all
   "1.7.0":
     folder: all


### PR DESCRIPTION

### Summary
Changes to recipe:  **sbepp/1.8.0**

#### Motivation
I'm the author, publishing new version.

#### Details
Beyond simple verison bump, I also used greater-or-equal deps versions. Current ones are quite old and I generally try to allow users to use the lowest possible versions so I think `>= oldest_possible` is a good option. Project uses only basic functionality from both so it's unlikely future releases will break it. Let me know if it's not OK.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
