### PR TITLE
openimageio: Add version 3.1.13.1

### DIFF
--- a/recipes/openimageio/all/conandata.yml
+++ b/recipes/openimageio/all/conandata.yml
@@ -1,12 +1,12 @@
 sources:
-  "3.1.12.0":
-    url: "https://github.com/AcademySoftwareFoundation/OpenImageIO/releases/download/v3.1.12.0/OpenImageIO-3.1.12.0.tar.gz"
-    sha256: "704511376faf32767cdcd9aa9a6d0be2b03b91f849ad9008227dc9f0e14bc265"
+  "3.1.13.1":
+    url: "https://github.com/AcademySoftwareFoundation/OpenImageIO/releases/download/v3.1.13.1/OpenImageIO-3.1.13.1.tar.gz"
+    sha256: "b0d81f4f041fd72f034bd2a6c5ad9db1880008f67af101233cf3992f9e59217f"
   "2.5.19.1":
     url: "https://github.com/AcademySoftwareFoundation/OpenImageIO/archive/refs/tags/v2.5.19.1.tar.gz"
     sha256: "adb73f270f2eaae81c3c7cde311239944ae9faf6d206552da4ee12d746628b26"
 patches:
-  "3.1.12.0":
-    - patch_file: "patches/3.1.12.0-conan-fixes.patch"
+  "3.1.13.1":
+    - patch_file: "patches/3.1.13.1-conan-fixes.patch"
   "2.5.19.1":
     - patch_file: "patches/2.5.19.1-conan-fixes.patch"

--- a/recipes/openimageio/all/conanfile.py
+++ b/recipes/openimageio/all/conanfile.py
@@ -104,7 +104,7 @@ class OpenImageIOConan(ConanFile):
         self.requires("pugixml/1.14")
         self.requires("libsquish/1.15")
         self.requires("tsl-robin-map/1.2.1")
-        self.requires("fmt/10.2.1", transitive_headers=True)
+        self.requires("fmt/[>=10.2.1 <13]", transitive_headers=True)
 
         # Optional libraries
         if self.options.with_libpng:

--- a/recipes/openimageio/all/patches/3.1.13.1-conan-fixes.patch
+++ b/recipes/openimageio/all/patches/3.1.13.1-conan-fixes.patch
@@ -1,8 +1,8 @@
 diff --git CMakeLists.txt CMakeLists.txt
-index 4e9f4e7e4..c44cb8573 100644
+index 81565b47a..8df414e47 100644
 --- CMakeLists.txt
 +++ CMakeLists.txt
-@@ -287,7 +287,7 @@ if (OIIO_BUILD_TOOLS AND NOT BUILD_OIIOUTIL_ONLY)
+@@ -293,7 +293,7 @@ if (OIIO_BUILD_TOOLS AND NOT BUILD_OIIOUTIL_ONLY)
      add_subdirectory (src/iinfo)
      add_subdirectory (src/maketx)
      add_subdirectory (src/oiiotool)

--- a/recipes/openimageio/config.yml
+++ b/recipes/openimageio/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "3.1.12.0":
+  "3.1.13.1":
     folder: all
   "2.5.19.1":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **openimageio/3.1.13.1**

#### Motivation
Usual monthly update with several bugfixes including some overflow issues and small additions.

#### Details
* https://github.com/AcademySoftwareFoundation/OpenImageIO/releases/tag/v3.1.13.1
* https://github.com/AcademySoftwareFoundation/OpenImageIO/compare/v3.1.12.0...v3.1.13.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
