### PR TITLE
openimageio: Bump fmt dependency to use a range and allow 12.1.0

### DIFF
--- a/recipes/openimageio/all/conanfile.py
+++ b/recipes/openimageio/all/conanfile.py
@@ -104,7 +104,7 @@ class OpenImageIOConan(ConanFile):
         self.requires("pugixml/1.14")
         self.requires("libsquish/1.15")
         self.requires("tsl-robin-map/1.2.1")
-        self.requires("fmt/10.2.1", transitive_headers=True)
+        self.requires("fmt/[>=10.2.1 <13]", transitive_headers=True)
 
         # Optional libraries
         if self.options.with_libpng:


### PR DESCRIPTION
### Summary
Changes to recipe:  **openimageio/all**

#### Motivation
On current macOS (macOS 26), fmt 10.2.1 doesn't build anymore with some compilation errors when C++ standard is set to 20 in the profile. (On another machine at the moment, so I can't drop the log but can provide it if needed.) Just popped up as I updated to 26 last weekend. Is fine on macOS 15 with C++ 20.

#### Details
I checked if other recipes use fmt with ranges and several are using a range that is capped at `<13` so I followed that and kept the lowest version to what we have right now.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
