### PR TITLE
mold: Add version 2.41.0

### DIFF
--- a/recipes/mold/all/conandata.yml
+++ b/recipes/mold/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.41.0":
+    url: "https://github.com/rui314/mold/archive/refs/tags/v2.41.0.tar.gz"
+    sha256: "0a61abac85d818437b425df856822e9d6e9982baeae5a93bcb02fe6c0060c61a"
   "2.40.1":
     url: "https://github.com/rui314/mold/archive/refs/tags/v2.40.1.tar.gz"
     sha256: "d1ce09a69941f8158604c3edcc96c7178231e7dba2da66b20f5ef6e112c443b7"
@@ -30,6 +33,10 @@ sources:
     url: "https://github.com/rui314/mold/archive/refs/tags/v1.11.0.tar.gz"
     sha256: "99318eced81b09a77e4c657011076cc8ec3d4b6867bd324b8677974545bc4d6f"
 patches:
+  "2.41.0":
+    - patch_file: "patches/2.40.1/0001-patch-enforce-c-11-for-tbb.patch"
+      patch_description: "Fix bundled oneTBB build by enforcing C++11 standard"
+      patch_type: "conan"
   "2.40.1":
     - patch_file: "patches/2.40.1/0001-patch-enforce-c-11-for-tbb.patch"
       patch_description: "Fix bundled oneTBB build by enforcing C++11 standard"

--- a/recipes/mold/config.yml
+++ b/recipes/mold/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.41.0":
+    folder: all
   "2.40.1":
     folder: all
   "2.36.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **mold/2.41.0**

#### Motivation

Adds the latest version. In particular, 2.41.0 is currently the only version compatible with GCC 16.1 (https://github.com/rui314/mold/pull/1546).

#### Details
Simply added the new source. Previous TBB patch still applies.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
