### PR TITLE
[Arrow] Update xsimd dependency to 14.2.0

### DIFF
--- a/recipes/arrow/all/conanfile.py
+++ b/recipes/arrow/all/conanfile.py
@@ -203,7 +203,7 @@ class ArrowConan(ConanFile):
         if self.options.with_snappy:
             self.requires("snappy/1.1.9")
         if self.options.simd_level != "disabled" or self.options.runtime_simd_level != "disabled":
-            self.requires("xsimd/14.0.0")
+            self.requires("xsimd/14.2.0")
         if self.options.with_zlib:
             self.requires("zlib/[>=1.2.11 <2]")
         if self.options.with_zstd:


### PR DESCRIPTION
### Summary
Changes to recipe:  **arrow/all-versions**

#### Motivation
While updating our internal fork of the conan center index I noticed that arrow couldn't be built anymore, because it's dependency xsimd/14.0.0 has been removed recently.

#### Details
Updates xsimd dependency from 14.0.0 to 14.2.0 (the most recent version).

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
