### PR TITLE
[leptonica] Fix Conan patch for disabled options

### DIFF
--- a/recipes/leptonica/all/conanfile.py
+++ b/recipes/leptonica/all/conanfile.py
@@ -120,28 +120,28 @@ class LeptonicaConan(ConanFile):
         ## zlib
         replace_in_file(self, cmakelists_src, "${ZLIB_LIBRARIES}", "ZLIB::ZLIB")
         if not self.options.with_zlib:
-            replace_in_file(self, cmakelists_src, "if (ZLIB_LIBRARIES)", "if(0)")
-            replace_in_file(self, cmake_configure, "if (ZLIB_FOUND)", "if(0)")
+            replace_in_file(self, cmakelists_src, "(ZLIB_LIBRARIES)", "(0)")
+            replace_in_file(self, cmake_configure, "(ZLIB_FOUND)", "(0)")
         ## giflib
         replace_in_file(self, cmakelists_src, "${GIF_LIBRARIES}", "GIF::GIF")
         if not self.options.with_gif:
-            replace_in_file(self, cmakelists_src, "if (GIF_LIBRARIES)", "if(0)")
-            replace_in_file(self, cmake_configure, "if (GIF_FOUND)", "if(0)")
+            replace_in_file(self, cmakelists_src, "(GIF_LIBRARIES)", "(0)")
+            replace_in_file(self, cmake_configure, "(GIF_FOUND)", "(0)")
         ## libjpeg
         replace_in_file(self, cmakelists_src, "${JPEG_LIBRARIES}", "JPEG::JPEG")
         if not self.options.with_jpeg:
-            replace_in_file(self, cmakelists_src, "if (JPEG_LIBRARIES)", "if(0)")
-            replace_in_file(self, cmake_configure, "if (JPEG_FOUND)", "if(0)")
+            replace_in_file(self, cmakelists_src, "(JPEG_LIBRARIES)", "(0)")
+            replace_in_file(self, cmake_configure, "(JPEG_FOUND)", "(0)")
         ## libpng
         replace_in_file(self, cmakelists_src, "${PNG_LIBRARIES}", "PNG::PNG")
         if not self.options.with_png:
-            replace_in_file(self, cmakelists_src, "if (PNG_LIBRARIES)", "if(0)")
-            replace_in_file(self, cmake_configure, "if (PNG_FOUND)", "if(0)")
+            replace_in_file(self, cmakelists_src, "(PNG_LIBRARIES)", "(0)")
+            replace_in_file(self, cmake_configure, "(PNG_FOUND)", "(0)")
         ## libtiff
         replace_in_file(self, cmakelists_src, "${TIFF_LIBRARIES}", "TIFF::TIFF")
         if not self.options.with_tiff:
-            replace_in_file(self, cmakelists_src, "if (TIFF_LIBRARIES)", "if(0)")
-            replace_in_file(self, cmake_configure, "if (TIFF_FOUND)", "if(0)")
+            replace_in_file(self, cmakelists_src, "(TIFF_LIBRARIES)", "(0)")
+            replace_in_file(self, cmake_configure, "(TIFF_FOUND)", "(0)")
 
         # Remove detection of fmemopen() on macOS < 10.13
         # CheckFunctionExists will find it in the link library.


### PR DESCRIPTION
### Summary
Changes to recipe:  **leptonica/1.87.0**

#### Motivation


The newer version passed by a reformat, which made the previous `_patch_sources` invalid due the spaces between `if (...` in the CMake files. This PR fixed that patch by simplifying the `replace_in_file`

fixes #30106
/cc @xconverge

#### Details

As this rule can be benefitial to the upstream as well, I sent a PR suggesting to use options `ENABLE_` as source to truth when consuming dependencies: https://github.com/DanBloomberg/leptonica/pull/791

As the CI does not run with those disabled options, I made a local build using this proposed patch: [leptonica-1.87.0-osx-armv8-clang21-release-static-minimal-patched.log](https://github.com/user-attachments/files/27437104/leptonica-1.87.0-osx-armv8-clang21-release-static-minimal-patched.log)

The current error, without this patch, can be found in the issue with a build log. 

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
