### PR TITLE
nlopt: publish version 2.10.1, stop publishing revs for 2.6.1

### DIFF
--- a/recipes/nlopt/all/conandata.yml
+++ b/recipes/nlopt/all/conandata.yml
@@ -2,18 +2,3 @@ sources:
   "2.10.1":
     url: "https://github.com/stevengj/nlopt/archive/refs/tags/v2.10.1.tar.gz"
     sha256: "30d13ce16da119db3e987784f7864e35a562ec62c186352fae55cd003e6c58ff"
-  "2.10.0":
-    url: "https://github.com/stevengj/nlopt/archive/refs/tags/v2.10.0.tar.gz"
-    sha256: "506f83a9e778ad4f204446e99509cb2bdf5539de8beccc260a014bd560237be1"
-  "2.9.1":
-    url: "https://github.com/stevengj/nlopt/archive/refs/tags/v2.9.1.tar.gz"
-    sha256: "1e6c33f8cbdc4138d525f3326c231f14ed50d99345561e85285638c49b64ee93"
-  "2.7.1":
-    url: "https://github.com/stevengj/nlopt/archive/refs/tags/v2.7.1.tar.gz"
-    sha256: "db88232fa5cef0ff6e39943fc63ab6074208831dc0031cf1545f6ecd31ae2a1a"
-  "2.7.0":
-    url: "https://github.com/stevengj/nlopt/archive/v2.7.0.tar.gz"
-    sha256: "b881cc2a5face5139f1c5a30caf26b7d3cb43d69d5e423c9d78392f99844499f"
-  "2.6.2":
-    url: "https://github.com/stevengj/nlopt/archive/v2.6.2.tar.gz"
-    sha256: "cfa5981736dd60d0109c534984c4e13c615314d3584cf1c392a155bfe1a3b17e"

--- a/recipes/nlopt/all/conandata.yml
+++ b/recipes/nlopt/all/conandata.yml
@@ -17,6 +17,3 @@ sources:
   "2.6.2":
     url: "https://github.com/stevengj/nlopt/archive/v2.6.2.tar.gz"
     sha256: "cfa5981736dd60d0109c534984c4e13c615314d3584cf1c392a155bfe1a3b17e"
-  "2.6.1":
-    url: "https://github.com/stevengj/nlopt/archive/v2.6.1.tar.gz"
-    sha256: "66d63a505187fb6f98642703bd0ef006fedcae2f9a6d1efa4f362ea919a02650"

--- a/recipes/nlopt/all/conandata.yml
+++ b/recipes/nlopt/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.10.1":
+    url: "https://github.com/stevengj/nlopt/archive/refs/tags/v2.10.1.tar.gz"
+    sha256: "30d13ce16da119db3e987784f7864e35a562ec62c186352fae55cd003e6c58ff"
   "2.10.0":
     url: "https://github.com/stevengj/nlopt/archive/refs/tags/v2.10.0.tar.gz"
     sha256: "506f83a9e778ad4f204446e99509cb2bdf5539de8beccc260a014bd560237be1"

--- a/recipes/nlopt/all/conanfile.py
+++ b/recipes/nlopt/all/conanfile.py
@@ -24,16 +24,20 @@ class NloptConan(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "enable_cxx_routines": [True, False],
+        "enable_luksan": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "enable_cxx_routines": True,
+        "enable_luksan": True,
     }
 
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+        if Version(self.version) < "2.9.0":
+            del self.options.enable_luksan
 
     def configure(self):
         if self.options.shared:
@@ -41,9 +45,15 @@ class NloptConan(ConanFile):
         if not self.options.enable_cxx_routines:
             self.settings.rm_safe("compiler.cppstd")
             self.settings.rm_safe("compiler.libcxx")
+        if not self.options.get_safe("enable_luksan", True):
+            self.license = "MIT"
 
     def layout(self):
         cmake_layout(self, src_folder="src")
+
+    def build_requirements(self):
+        if Version(self.version) >= "2.10.1":
+            self.tool_requires("cmake/[>=3.18]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -56,7 +66,11 @@ class NloptConan(ConanFile):
         tc.variables["NLOPT_OCTAVE"] = False
         tc.variables["NLOPT_MATLAB"] = False
         tc.variables["NLOPT_GUILE"] = False
+        if Version(self.version) >= "2.10.0":
+            tc.variables["NLOPT_JAVA"] = False
         tc.variables["NLOPT_SWIG"] = False
+        if Version(self.version) >= "2.9.0":
+            tc.variables["NLOPT_LUKSAN"] = self.options.enable_luksan
         tc.variables["NLOPT_TESTS"] = False
         tc.variables["WITH_THREADLOCAL"] = True
         tc.generate()
@@ -82,11 +96,12 @@ class NloptConan(ConanFile):
             {"subdir": "cobyla", "license_name": "COPYRIGHT"},
             {"subdir": "direct", "license_name": "COPYING"  },
             {"subdir": "esch"  , "license_name": "COPYRIGHT"},
-            {"subdir": "luskan", "license_name": "COPYRIGHT"},
             {"subdir": "newuoa", "license_name": "COPYRIGHT"},
             {"subdir": "slsqp" , "license_name": "COPYRIGHT"},
             {"subdir": "stogo" , "license_name": "COPYRIGHT"},
         ]
+        if self.options.get_safe("enable_luksan", True):
+            algs_licenses.append({"subdir": "luksan", "license_name": "COPYRIGHT"})
         for alg_license in algs_licenses:
             copy(self, alg_license["license_name"],
                       src=os.path.join(self.source_folder, "src", "algs", alg_license["subdir"]),

--- a/recipes/nlopt/all/conanfile.py
+++ b/recipes/nlopt/all/conanfile.py
@@ -1,11 +1,10 @@
 from conan import ConanFile
 from conan.tools.build import stdcpp_library
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, get, replace_in_file, rm, rmdir
-from conan.tools.scm import Version
+from conan.tools.files import copy, get, rm, rmdir
 import os
 
-required_conan_version = ">=1.54.0"
+required_conan_version = ">=2"
 
 
 class NloptConan(ConanFile):
@@ -36,8 +35,6 @@ class NloptConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
-        if Version(self.version) < "2.9.0":
-            del self.options.enable_luksan
 
     def configure(self):
         if self.options.shared:
@@ -45,15 +42,14 @@ class NloptConan(ConanFile):
         if not self.options.enable_cxx_routines:
             self.settings.rm_safe("compiler.cppstd")
             self.settings.rm_safe("compiler.libcxx")
-        if not self.options.get_safe("enable_luksan", True):
+        if not self.options.enable_luksan:
             self.license = "MIT"
 
     def layout(self):
         cmake_layout(self, src_folder="src")
 
     def build_requirements(self):
-        if Version(self.version) >= "2.10.1":
-            self.tool_requires("cmake/[>=3.18]")
+        self.tool_requires("cmake/[>=3.18]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -66,24 +62,14 @@ class NloptConan(ConanFile):
         tc.variables["NLOPT_OCTAVE"] = False
         tc.variables["NLOPT_MATLAB"] = False
         tc.variables["NLOPT_GUILE"] = False
-        if Version(self.version) >= "2.10.0":
-            tc.variables["NLOPT_JAVA"] = False
+        tc.variables["NLOPT_JAVA"] = False
         tc.variables["NLOPT_SWIG"] = False
-        if Version(self.version) >= "2.9.0":
-            tc.variables["NLOPT_LUKSAN"] = self.options.enable_luksan
+        tc.variables["NLOPT_LUKSAN"] = self.options.enable_luksan
         tc.variables["NLOPT_TESTS"] = False
         tc.variables["WITH_THREADLOCAL"] = True
         tc.generate()
 
-    def _patch_sources(self):
-        # don't force PIC
-        if Version(self.version) < Version("2.8.0"):
-            cmakelists = os.path.join(self.source_folder, "CMakeLists.txt")
-            replace_in_file(self, cmakelists, "set (CMAKE_C_FLAGS \"-fPIC ${CMAKE_C_FLAGS}\")", "")
-            replace_in_file(self, cmakelists, "set (CMAKE_CXX_FLAGS \"-fPIC ${CMAKE_CXX_FLAGS}\")", "")
-
     def build(self):
-        self._patch_sources()
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
@@ -100,7 +86,7 @@ class NloptConan(ConanFile):
             {"subdir": "slsqp" , "license_name": "COPYRIGHT"},
             {"subdir": "stogo" , "license_name": "COPYRIGHT"},
         ]
-        if self.options.get_safe("enable_luksan", True):
+        if self.options.enable_luksan:
             algs_licenses.append({"subdir": "luksan", "license_name": "COPYRIGHT"})
         for alg_license in algs_licenses:
             copy(self, alg_license["license_name"],
@@ -118,10 +104,6 @@ class NloptConan(ConanFile):
         self.cpp_info.set_property("cmake_target_name", "NLopt::nlopt")
         self.cpp_info.set_property("pkg_config_name", "nlopt")
 
-        self.cpp_info.names["cmake_find_package"] = "NLopt"
-        self.cpp_info.names["cmake_find_package_multi"] = "NLopt"
-        self.cpp_info.components["nloptlib"].names["cmake_find_package"] = "nlopt"
-        self.cpp_info.components["nloptlib"].names["cmake_find_package_multi"] = "nlopt"
         self.cpp_info.components["nloptlib"].set_property("cmake_target_name", "NLopt::nlopt")
         self.cpp_info.components["nloptlib"].set_property("pkg_config_name", "nlopt")
 

--- a/recipes/nlopt/all/test_package/CMakeLists.txt
+++ b/recipes/nlopt/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES C)
 
 find_package(NLopt REQUIRED CONFIG)

--- a/recipes/nlopt/config.yml
+++ b/recipes/nlopt/config.yml
@@ -11,5 +11,3 @@ versions:
     folder: all
   "2.6.2":
     folder: all
-  "2.6.1":
-    folder: all

--- a/recipes/nlopt/config.yml
+++ b/recipes/nlopt/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.10.1":
+    folder: all
   "2.10.0":
     folder: all
   "2.9.1":

--- a/recipes/nlopt/config.yml
+++ b/recipes/nlopt/config.yml
@@ -1,13 +1,3 @@
 versions:
   "2.10.1":
     folder: all
-  "2.10.0":
-    folder: all
-  "2.9.1":
-    folder: all
-  "2.7.1":
-    folder: all
-  "2.7.0":
-    folder: all
-  "2.6.2":
-    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **nlopt/***

#### Motivation
I would like to use nlopt without LGPL.

#### Details
- add new option "enable_luksan" that allows disabling LGPL part of library ("luksan" directory) so that resulting library is licensed under MIT
- fix folder name for license copying ("luksan" instead of "luskan")
- set NLOPT_JAVA to False
https://github.com/stevengj/nlopt/releases/tag/v2.10.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
