### PR TITLE
[fmt] Backport patch for Clang + C++20 compatibility on fmt <11.1

### DIFF
--- a/recipes/fmt/all/conandata.yml
+++ b/recipes/fmt/all/conandata.yml
@@ -67,6 +67,12 @@ sources:
 patches:
   "5.3.0":
     - patch_file: "patches/fix-install-5.3.0.patch"
+  "11.0.2":
+    - patch_file: "patches/11.0.2-0001-backport-consteval.patch"
+  "11.0.1":
+    - patch_file: "patches/11.0.0-0001-backport-consteval.patch"
+  "11.0.0":
+    - patch_file: "patches/11.0.0-0001-backport-consteval.patch"
   "10.2.1":
     - patch_file: "patches/10.2-0001-backport-consteval.patch"
   "10.2.0":

--- a/recipes/fmt/all/conandata.yml
+++ b/recipes/fmt/all/conandata.yml
@@ -17,8 +17,6 @@ sources:
   "11.1.1":
     url: "https://github.com/fmtlib/fmt/releases/download/11.1.1/fmt-11.1.1.zip"
     sha256: "a25124e41c15c290b214c4dec588385153c91b47198dbacda6babce27edc4b45"
-  "11.1.0":
-    url: "https://github.com/fmtlib/fmt/releases/download/11.1.0/fmt-11.1.0.zip"
   "11.0.2":
     url: "https://github.com/fmtlib/fmt/releases/download/11.0.2/fmt-11.0.2.zip"
     sha256: "40fc58bebcf38c759e11a7bd8fdc163507d2423ef5058bba7f26280c5b9c5465"

--- a/recipes/fmt/all/conandata.yml
+++ b/recipes/fmt/all/conandata.yml
@@ -17,6 +17,8 @@ sources:
   "11.1.1":
     url: "https://github.com/fmtlib/fmt/releases/download/11.1.1/fmt-11.1.1.zip"
     sha256: "a25124e41c15c290b214c4dec588385153c91b47198dbacda6babce27edc4b45"
+  "11.1.0":
+    url: "https://github.com/fmtlib/fmt/releases/download/11.1.0/fmt-11.1.0.zip"
   "11.0.2":
     url: "https://github.com/fmtlib/fmt/releases/download/11.0.2/fmt-11.0.2.zip"
     sha256: "40fc58bebcf38c759e11a7bd8fdc163507d2423ef5058bba7f26280c5b9c5465"
@@ -65,3 +67,13 @@ sources:
 patches:
   "5.3.0":
     - patch_file: "patches/fix-install-5.3.0.patch"
+  "10.2.1":
+    - patch_file: "patches/10.2-0001-backport-consteval.patch"
+  "10.2.0":
+    - patch_file: "patches/10.2-0001-backport-consteval.patch"
+  "10.1.1":
+    - patch_file: "patches/10.1.1-0001-backport-consteval.patch"
+  "10.1.0":
+    - patch_file: "patches/10.1.0-0001-backport-consteval.patch"
+  "10.0.0":
+    - patch_file: "patches/10.0.0-0001-backport-consteval.patch"

--- a/recipes/fmt/all/patches/10.0.0-0001-backport-consteval.patch
+++ b/recipes/fmt/all/patches/10.0.0-0001-backport-consteval.patch
@@ -1,4 +1,10 @@
+Backport to fix Apple Clang + C++20 build errors:
+os.cc:215:29: error: call to consteval function 'fmt::basic_format_string<char, const char *>::basic_format_string<FMT_COMPILE_STRING, 0>' is not a constant expression
+
+Extracted from https://github.com/fmtlib/fmt/commit/6797f0c39a4ef13061cbc3bb850c35af7428fdc4
+Related to https://github.com/fmtlib/fmt/issues/4177 and https://github.com/fmtlib/fmt/issues/4740
 diff --git a/include/fmt/core.h b/include/fmt/core.h
+
 index 46723d5..236ad0b 100644
 --- a/include/fmt/core.h
 +++ b/include/fmt/core.h

--- a/recipes/fmt/all/patches/10.0.0-0001-backport-consteval.patch
+++ b/recipes/fmt/all/patches/10.0.0-0001-backport-consteval.patch
@@ -1,0 +1,13 @@
+diff --git a/include/fmt/core.h b/include/fmt/core.h
+index 46723d5..236ad0b 100644
+--- a/include/fmt/core.h
++++ b/include/fmt/core.h
+@@ -2766,7 +2766,7 @@ template <typename Char, typename... Args> class basic_format_string {
+                   detail::count_statically_named_args<Args...>()) {
+       using checker =
+           detail::format_string_checker<Char, remove_cvref_t<Args>...>;
+-      detail::parse_format_string<true>(str_, checker(s));
++      detail::parse_format_string<true>(str_, checker(str_));
+     }
+ #else
+     detail::check_format_string<Args...>(s);

--- a/recipes/fmt/all/patches/10.1.0-0001-backport-consteval.patch
+++ b/recipes/fmt/all/patches/10.1.0-0001-backport-consteval.patch
@@ -1,0 +1,13 @@
+diff --git a/include/fmt/core.h b/include/fmt/core.h
+index bfdca5f..c0b4ee7 100644
+--- a/include/fmt/core.h
++++ b/include/fmt/core.h
+@@ -2739,7 +2739,7 @@ template <typename Char, typename... Args> class basic_format_string {
+                   detail::count_statically_named_args<Args...>()) {
+       using checker =
+           detail::format_string_checker<Char, remove_cvref_t<Args>...>;
+-      detail::parse_format_string<true>(str_, checker(s));
++      detail::parse_format_string<true>(str_, checker(str_));
+     }
+ #else
+     detail::check_format_string<Args...>(s);

--- a/recipes/fmt/all/patches/10.1.0-0001-backport-consteval.patch
+++ b/recipes/fmt/all/patches/10.1.0-0001-backport-consteval.patch
@@ -1,3 +1,9 @@
+Backport to fix Apple Clang + C++20 build errors:
+os.cc:215:29: error: call to consteval function 'fmt::basic_format_string<char, const char *>::basic_format_string<FMT_COMPILE_STRING, 0>' is not a constant expression
+
+Extracted from https://github.com/fmtlib/fmt/commit/6797f0c39a4ef13061cbc3bb850c35af7428fdc4
+Related to https://github.com/fmtlib/fmt/issues/4177 and https://github.com/fmtlib/fmt/issues/4740
+
 diff --git a/include/fmt/core.h b/include/fmt/core.h
 index bfdca5f..c0b4ee7 100644
 --- a/include/fmt/core.h

--- a/recipes/fmt/all/patches/10.1.1-0001-backport-consteval.patch
+++ b/recipes/fmt/all/patches/10.1.1-0001-backport-consteval.patch
@@ -1,0 +1,13 @@
+diff --git a/include/fmt/core.h b/include/fmt/core.h
+index f9e3b7d..62ccf42 100644
+--- a/include/fmt/core.h
++++ b/include/fmt/core.h
+@@ -2737,7 +2737,7 @@ template <typename Char, typename... Args> class basic_format_string {
+                   detail::count_statically_named_args<Args...>()) {
+       using checker =
+           detail::format_string_checker<Char, remove_cvref_t<Args>...>;
+-      detail::parse_format_string<true>(str_, checker(s));
++      detail::parse_format_string<true>(str_, checker(str_));
+     }
+ #else
+     detail::check_format_string<Args...>(s);

--- a/recipes/fmt/all/patches/10.1.1-0001-backport-consteval.patch
+++ b/recipes/fmt/all/patches/10.1.1-0001-backport-consteval.patch
@@ -1,3 +1,9 @@
+Backport to fix Apple Clang + C++20 build errors:
+os.cc:215:29: error: call to consteval function 'fmt::basic_format_string<char, const char *>::basic_format_string<FMT_COMPILE_STRING, 0>' is not a constant expression
+
+Extracted from https://github.com/fmtlib/fmt/commit/6797f0c39a4ef13061cbc3bb850c35af7428fdc4
+Related to https://github.com/fmtlib/fmt/issues/4177 and https://github.com/fmtlib/fmt/issues/4740
+
 diff --git a/include/fmt/core.h b/include/fmt/core.h
 index f9e3b7d..62ccf42 100644
 --- a/include/fmt/core.h

--- a/recipes/fmt/all/patches/10.2-0001-backport-consteval.patch
+++ b/recipes/fmt/all/patches/10.2-0001-backport-consteval.patch
@@ -1,3 +1,9 @@
+Backport to fix Apple Clang + C++20 build errors:
+os.cc:215:29: error: call to consteval function 'fmt::basic_format_string<char, const char *>::basic_format_string<FMT_COMPILE_STRING, 0>' is not a constant expression
+
+Extracted from https://github.com/fmtlib/fmt/commit/6797f0c39a4ef13061cbc3bb850c35af7428fdc4
+Related to https://github.com/fmtlib/fmt/issues/4177 and https://github.com/fmtlib/fmt/issues/4740
+
 --- a/include/fmt/core.h
 +++ b/include/fmt/core.h
 @@ -2783,7 +2783,7 @@ class basic_format_string {

--- a/recipes/fmt/all/patches/10.2-0001-backport-consteval.patch
+++ b/recipes/fmt/all/patches/10.2-0001-backport-consteval.patch
@@ -1,0 +1,12 @@
+--- a/include/fmt/core.h
++++ b/include/fmt/core.h
+@@ -2783,7 +2783,7 @@ class basic_format_string {
+     if constexpr (detail::count_named_args<Args...>() ==
+                   detail::count_statically_named_args<Args...>()) {
+       using checker =
+           detail::format_string_checker<Char, remove_cvref_t<Args>...>;
+-      detail::parse_format_string<true>(str_, checker(s));
++      detail::parse_format_string<true>(str_, checker(str_));
+     }
+ #else
+     detail::check_format_string<Args...>(s);

--- a/recipes/fmt/all/patches/11.0.0-0001-backport-consteval.patch
+++ b/recipes/fmt/all/patches/11.0.0-0001-backport-consteval.patch
@@ -1,0 +1,19 @@
+Backport to fix Apple Clang + C++20 build errors:
+os.cc:215:29: error: call to consteval function 'fmt::basic_format_string<char, const char *>::basic_format_string<FMT_COMPILE_STRING, 0>' is not a constant expression
+
+Extracted from https://github.com/fmtlib/fmt/commit/6797f0c39a4ef13061cbc3bb850c35af7428fdc4
+Related to https://github.com/fmtlib/fmt/issues/4177 and https://github.com/fmtlib/fmt/issues/4740
+
+diff --git a/include/fmt/base.h b/include/fmt/base.h
+index 976402a..e3d9139 100644
+--- a/include/fmt/base.h
++++ b/include/fmt/base.h
+@@ -2865,7 +2865,7 @@ template <typename Char, typename... Args> class basic_format_string {
+                   detail::count_statically_named_args<Args...>()) {
+       using checker =
+           detail::format_string_checker<Char, remove_cvref_t<Args>...>;
+-      detail::parse_format_string<true>(str_, checker(s));
++      detail::parse_format_string<true>(str_, checker(str_));
+     }
+ #else
+     detail::check_format_string<Args...>(s);

--- a/recipes/fmt/all/patches/11.0.2-0001-backport-consteval.patch
+++ b/recipes/fmt/all/patches/11.0.2-0001-backport-consteval.patch
@@ -1,0 +1,19 @@
+Backport to fix Apple Clang + C++20 build errors:
+os.cc:215:29: error: call to consteval function 'fmt::basic_format_string<char, const char *>::basic_format_string<FMT_COMPILE_STRING, 0>' is not a constant expression
+
+Extracted from https://github.com/fmtlib/fmt/commit/6797f0c39a4ef13061cbc3bb850c35af7428fdc4
+Related to https://github.com/fmtlib/fmt/issues/4177 and https://github.com/fmtlib/fmt/issues/4740
+
+diff --git a/include/fmt/base.h b/include/fmt/base.h
+index 6276494..682c8c6 100644
+--- a/include/fmt/base.h
++++ b/include/fmt/base.h
+@@ -2881,7 +2881,7 @@ template <typename Char, typename... Args> class basic_format_string {
+                   detail::count_statically_named_args<Args...>()) {
+       using checker =
+           detail::format_string_checker<Char, remove_cvref_t<Args>...>;
+-      detail::parse_format_string<true>(str_, checker(s));
++      detail::parse_format_string<true>(str_, checker(str_));
+     }
+ #else
+     detail::check_format_string<Args...>(s);


### PR DESCRIPTION
### Summary
Changes to recipe:  **fmt/[<11.1.0]**

#### Motivation

The fmt project has a report about not being able to build old versions using Clang + C++20:
* https://github.com/fmtlib/fmt/issues/4740
* https://github.com/fmtlib/fmt/issues/4177

This which was fixed on 11.1 by commit https://github.com/fmtlib/fmt/commit/6797f0c39a4ef13061cbc3bb850c35af7428fdc4. That commit contains several other changes, so this PR extracts only the related fix.

Related to https://github.com/conan-io/conan-center-index/pull/30125#issuecomment-4380518559

/cc @irieger

#### Details

Tested locally with Apple Clang 21 + C++20. It's possible to reproduce the error with versions <11.1. However, I only tested until 10.0.0 as this is the oldest version used in ConanCenteIndex.

#### Build Logs


#### NO patched

* 10.0.0 (error): [fmt-10.0.0-osx-armv8-clang21-cppstd20-release-static.log](https://github.com/user-attachments/files/27473433/fmt-10.0.0-osx-armv8-clang21-cppstd20-release-static.log)
* 10.1.0 (error): [fmt-10.1.0-osx-armv8-clang21-cppstd20-release-static.log](https://github.com/user-attachments/files/27473436/fmt-10.1.0-osx-armv8-clang21-cppstd20-release-static.log)
* 10.1.1 (error): [fmt-10.1.1-osx-armv8-clang21-cppstd20-release-static.log](https://github.com/user-attachments/files/27473440/fmt-10.1.1-osx-armv8-clang21-cppstd20-release-static.log)
* 10.2.0 (error): [fmt-10.2.0-osx-armv8-clang21-cppstd20-release-static.log](https://github.com/user-attachments/files/27473444/fmt-10.2.0-osx-armv8-clang21-cppstd20-release-static.log)
* 10.2.1 (error): [fmt-10.2.1-osx-armv8-clang21-cppstd20-release-static.log](https://github.com/user-attachments/files/27473448/fmt-10.2.1-osx-armv8-clang21-cppstd20-release-static.log)
* 11.0.0 (error): [fmt-11.0.0-osx-armv8-clang21-cppstd20-release-static.log](https://github.com/user-attachments/files/27473450/fmt-11.0.0-osx-armv8-clang21-cppstd20-release-static.log)
* 11.0.1 (error): [fmt-11.0.1-osx-armv8-clang21-cppstd20-release-static.log](https://github.com/user-attachments/files/27473452/fmt-11.0.1-osx-armv8-clang21-cppstd20-release-static.log)
* 11.0.2 (error): [fmt-11.0.2-osx-armv8-clang21-cppstd20-release-static.log](https://github.com/user-attachments/files/27473455/fmt-11.0.2-osx-armv8-clang21-cppstd20-release-static.log)


* 11.1.0 (success): [fmt-11.1.0-osx-armv8-clang21-cppstd20-release-static.log](https://github.com/user-attachments/files/27473456/fmt-11.1.0-osx-armv8-clang21-cppstd20-release-static.log)
* 11.1.1 (success): [fmt-11.1.1-osx-armv8-clang21-cppstd20-release-static.log](https://github.com/user-attachments/files/27473457/fmt-11.1.1-osx-armv8-clang21-cppstd20-release-static.log)
* 11.2.0 (success): [fmt-11.2.0-osx-armv8-clang21-cppstd20-release-static.log](https://github.com/user-attachments/files/27473458/fmt-11.2.0-osx-armv8-clang21-cppstd20-release-static.log)
* 12.0.0 (success): [fmt-12.0.0-osx-armv8-clang21-cppstd20-release-static.log](https://github.com/user-attachments/files/27473459/fmt-12.0.0-osx-armv8-clang21-cppstd20-release-static.log)
* 12.1.0 (success): [fmt-12.1.0-osx-armv8-clang21-cppstd20-release-static.log](https://github.com/user-attachments/files/27473461/fmt-12.1.0-osx-armv8-clang21-cppstd20-release-static.log)

#### Patched

* 10.0.0 (success): [fmt-10.0.0-osx-armv8-clang21-cppstd20-release-static-patched.log](https://github.com/user-attachments/files/27473432/fmt-10.0.0-osx-armv8-clang21-cppstd20-release-static-patched.log)
* 10.1.0 (sucess): [fmt-10.1.0-osx-armv8-clang21-cppstd20-release-static-patched.log](https://github.com/user-attachments/files/27473434/fmt-10.1.0-osx-armv8-clang21-cppstd20-release-static-patched.log)
* 10.1.1 (success): [fmt-10.1.1-osx-armv8-clang21-cppstd20-release-static-patched.log](https://github.com/user-attachments/files/27473439/fmt-10.1.1-osx-armv8-clang21-cppstd20-release-static-patched.log)
* 10.2.0 (success): [fmt-10.2.0-osx-armv8-clang21-cppstd20-release-static-patched.log](https://github.com/user-attachments/files/27473443/fmt-10.2.0-osx-armv8-clang21-cppstd20-release-static-patched.log)
* 10.2.1 (success): [fmt-10.2.1-osx-armv8-clang21-cppstd20-release-static-patched.log](https://github.com/user-attachments/files/27473446/fmt-10.2.1-osx-armv8-clang21-cppstd20-release-static-patched.log)
* 11.0.0 (success): [fmt-11.0.0-osx-armv8-clang21-cppstd20-release-static-patched.log](https://github.com/user-attachments/files/27473449/fmt-11.0.0-osx-armv8-clang21-cppstd20-release-static-patched.log)
* 11.0.1 (success): [fmt-11.0.1-osx-armv8-clang21-cppstd20-release-static-patched.log](https://github.com/user-attachments/files/27473451/fmt-11.0.1-osx-armv8-clang21-cppstd20-release-static-patched.log)
* 11.0.2 (success): [fmt-11.0.2-osx-armv8-clang21-cppstd20-release-static-patched.log](https://github.com/user-attachments/files/27473453/fmt-11.0.2-osx-armv8-clang21-cppstd20-release-static-patched.log)




---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
