### PR TITLE
cyrus-sasl: enable enable gssapi, fix windows arm64 build

### DIFF
--- a/recipes/cyrus-sasl/all/conanfile.py
+++ b/recipes/cyrus-sasl/all/conanfile.py
@@ -53,7 +53,7 @@ class CyrusSaslConan(ConanFile):
         "with_scram": True,
         "with_otp": True,
         "with_krb4": True,
-        "with_gssapi": False, # FIXME: should be True
+        "with_gssapi": True,
         "with_plain": True,
         "with_anon": True,
         "with_postgresql": False,
@@ -78,6 +78,7 @@ class CyrusSaslConan(ConanFile):
             del self.options.with_postgresql
             del self.options.with_mysql
             del self.options.with_sqlite3
+            del self.options.with_gssapi
 
     def configure(self):
         if self.options.shared:
@@ -97,6 +98,8 @@ class CyrusSaslConan(ConanFile):
             self.requires("libmysqlclient/8.1.0")
         if self.options.get_safe("with_sqlite3"):
             self.requires("sqlite3/3.44.2")
+        if self.options.get_safe("with_gssapi"):
+            self.requires("krb5/1.21.2")
 
     def validate(self):
         if is_msvc(self) and not self.options.shared:
@@ -217,7 +220,7 @@ class CyrusSaslConan(ConanFile):
         msbuild.build(sln=os.path.join(self.source_folder, "win32", "cyrus-sasl-core.sln"))
         # TODO: add sasldb support
         # msbuild.build(sln=os.path.join(self.source_folder, "win32", "cyrus-sasl-sasldb.sln"))
-        if self.options.with_gssapi:
+        if self.options.get_safe("with_gssapi"):
             msbuild.build(sln=os.path.join(self.source_folder, "win32", "cyrus-sasl-gssapiv2.sln"))
 
     def generate(self):

--- a/recipes/cyrus-sasl/all/conanfile.py
+++ b/recipes/cyrus-sasl/all/conanfile.py
@@ -104,10 +104,6 @@ class CyrusSaslConan(ConanFile):
     def validate(self):
         if is_msvc(self) and not self.options.shared:
             raise ConanInvalidConfiguration("Static library output is not supported when building with MSVC")
-        if self.options.with_gssapi:
-            raise ConanInvalidConfiguration(
-                f"{self.name}:with_gssapi=True requires krb5 recipe, not yet available in conan-center",
-            )
 
     def build_requirements(self):
         if not is_msvc(self):

--- a/recipes/cyrus-sasl/all/conanfile.py
+++ b/recipes/cyrus-sasl/all/conanfile.py
@@ -8,8 +8,9 @@ from conan.tools.gnu import Autotools, AutotoolsDeps, AutotoolsToolchain
 from conan.tools.layout import basic_layout
 from conan.tools.microsoft import unix_path, is_msvc, MSBuildDeps, MSBuildToolchain, MSBuild
 import os
+from pathlib import Path
 
-required_conan_version = ">=1.54.0"
+required_conan_version = ">=2.1"
 
 
 class CyrusSaslConan(ConanFile):
@@ -63,10 +64,6 @@ class CyrusSaslConan(ConanFile):
 
     def export_sources(self):
         export_conandata_patches(self)
-
-    @property
-    def _settings_build(self):
-        return getattr(self, "settings_build", self.settings)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -146,7 +143,7 @@ class CyrusSaslConan(ConanFile):
             "--with-mysql={}".format(rootpath_no(self.options.with_mysql, "libmysqlclient")),
             "--without-sqlite",
             "--with-sqlite3={}".format(rootpath_no(self.options.with_sqlite3, "sqlite3")),
-            "--with-saslauthd={}".format(yes_no(self.options.with_saslauthd)),
+            "--with-saslauthd={}".format(yes_no(self.options.get_safe("with_saslauthd"))),
         ])
         if self.options.with_gssapi:
             tc.configure_args.append("--with-gss_impl=mit")
@@ -187,24 +184,26 @@ class CyrusSaslConan(ConanFile):
         deps.generate()
 
     def _patch_sources_msvc(self):
-        # TODO: to remove once https://github.com/conan-io/conan/pull/12817 available in conan client
-        platform_toolset = MSBuildToolchain(self).toolset
-        import_conan_generators = ""
-        for props_file in ["conantoolchain.props", "conandeps.props"]:
-            props_path = os.path.join(self.generators_folder, props_file)
-            if os.path.exists(props_path):
-                import_conan_generators += f"<Import Project=\"{props_path}\" />"
-        for vcxproj_file in self.source_path.joinpath("win32").glob("*.vcxproj"):
+        conantoolchain_props = os.path.join(self.generators_folder, MSBuildToolchain.filename)
+        conandeps_props = os.path.join(self.generators_folder, "conandeps.props")
+        for vcxproj_file in Path(self.source_folder).joinpath("win32").glob("*.vcxproj"):
+            replace_in_file(
+                self, vcxproj_file,
+                """<Import Project="$(VCTargetsPath)\\Microsoft.Cpp.props" />""",
+                f"""<Import Project="{conantoolchain_props}" /><Import Project="$(VCTargetsPath)\\Microsoft.Cpp.props" />""",
+            )
             replace_in_file(self, vcxproj_file,
-                            "<PlatformToolset>v140</PlatformToolset>",
-                            f"<PlatformToolset>{platform_toolset}</PlatformToolset>")
+                '<Import Project="$(VCTargetsPath)\\Microsoft.Cpp.targets" />',
+                f'<Import Project="{conandeps_props}" /><Import Project="$(VCTargetsPath)\\Microsoft.Cpp.targets" />')
             replace_in_file(self, vcxproj_file, "<WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>", "")
-            if props_path:
-                replace_in_file(self, vcxproj_file,
-                                '<Import Project="$(VCTargetsPath)\\Microsoft.Cpp.targets" />',
-                                f'{import_conan_generators}<Import Project="$(VCTargetsPath)\\Microsoft.Cpp.targets" />')
+            if self.settings.arch == "armv8":
+                replace_in_file(self, vcxproj_file, "x64", "ARM64")
+
+        for solution_file in Path(self.source_folder).joinpath("win32").glob("*.sln"):
+            if self.settings.arch == "armv8":
+                replace_in_file(self, solution_file, "x64", "ARM64")
         replace_in_file(self, os.path.join(self.source_folder, "win32", "openssl.props"),
-                        "libeay32.lib;", "")
+                    "libeay32.lib;", "")
         # https://github.com/cyrusimap/cyrus-sasl/issues/730
         copy(self, "md5global.h",
              src=os.path.join(self.source_folder, "win32", "include"),
@@ -253,7 +252,7 @@ class CyrusSaslConan(ConanFile):
 
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs = ["resolv"]
-            if self.options.with_saslauthd:
+            if self.options.get_safe("with_saslauthd"):
                 self.cpp_info.system_libs.append("crypt")
         elif is_msvc(self):
             self.cpp_info.system_libs = ["ws2_32"]

--- a/recipes/cyrus-sasl/all/conanfile.py
+++ b/recipes/cyrus-sasl/all/conanfile.py
@@ -53,7 +53,7 @@ class CyrusSaslConan(ConanFile):
         "with_scram": True,
         "with_otp": True,
         "with_krb4": True,
-        "with_gssapi": True,
+        "with_gssapi": False,
         "with_plain": True,
         "with_anon": True,
         "with_postgresql": False,


### PR DESCRIPTION
### Summary
- enable gssapi (from https://github.com/conan-io/conan-center-index/pull/28741)
- fix windows arm64 build
- stop using deprecated `self.source_path`

Close https://github.com/conan-io/conan-center-index/pull/28741


---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
