### PR TITLE
drogon: bump version to 1.9.13

### DIFF
--- a/recipes/drogon/all/conandata.yml
+++ b/recipes/drogon/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "1.9.12":
-    url: "https://github.com/drogonframework/drogon/archive/v1.9.12.tar.gz"
-    sha256: "becc3c4f3b90f069f814baef164a7e3a2b31476dc6fe249b02ff07a13d032f48"
+  "1.9.13":
+    url: "https://github.com/drogonframework/drogon/archive/v1.9.13.tar.gz"
+    sha256: "c3bd0e276b82576151dc7376c8d4027dd1fcec282d784849e11f84a7e977b2f5"

--- a/recipes/drogon/config.yml
+++ b/recipes/drogon/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.9.12":
+  "1.9.13":
     folder: "all"


### PR DESCRIPTION
### Summary
Changes to recipe:  **drogon/1.9.13**

#### Motivation
Drogon 1.9.13 includes upstream API additions, build fixes, WebDAV-related fixes, HTTP client fixes, clang-cl fixes, and other maintenance improvements.

Notable upstream changes include:
- New `HttpRequest::clearHeaders()` method.
- New `setQueryParameter()` and `setBodyParameter()` methods.
- WebDAV HTTP method support.
- Per-request compression control for `HttpResponse`.
- Support for custom OPTIONS handling via middleware flagging.
- Fixes for `HttpClient`, connection limits, HTTP date formatting, invalid HTTP header number parsing, WebSocket route middleware initialization, and clang-cl compilation.

#### Details
Updated the version entry, source URL and checksum.
No recipe logic changes were required.

Tested building on Linux/clang and Windows/clang-cl.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
