### PR TITLE
Add `/hs` include dir to hyperscan

### DIFF
--- a/recipes/hyperscan/all/conanfile.py
+++ b/recipes/hyperscan/all/conanfile.py
@@ -111,16 +111,22 @@ class HyperscanConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "share"))
 
     def package_info(self):
+        # Canonical path is include/hs/ (#include <hs/hs.h>); include/ kept for backwards compatibility.
+        hs_include_dirs = ["include", os.path.join("include", "hs")]
+
         self.cpp_info.components["hs"].set_property("pkg_config_name", "libhs")
         self.cpp_info.components["hs"].libs = ["hs"]
         self.cpp_info.components["hs"].requires = ["boost::headers"]
+        self.cpp_info.components["hs"].includedirs = hs_include_dirs
 
         self.cpp_info.components["hs_runtime"].libs = ["hs_runtime"]
+        self.cpp_info.components["hs_runtime"].includedirs = hs_include_dirs
 
         if self.options.build_chimera:
             self.cpp_info.components["chimera"].set_property("pkg_config_name", "libch")
             self.cpp_info.components["chimera"].libs = ["chimera"]
             self.cpp_info.components["chimera"].requires = ["pcre::libpcre", "hs"]
+            self.cpp_info.components["chimera"].includedirs = hs_include_dirs
 
         if not self.options.shared:
             if self.settings.os in ["Linux", "FreeBSD"]:


### PR DESCRIPTION
### Summary
Changes to recipe:  **hyperscan/5.4.2, hyperscan/5.4.0**

#### Motivation

The recipe installs headers under `<prefix>/include/hs/` (`hs.h`, `ch.h`, etc.) but doesn't declare `includedirs` per component, so they default to `["include"]`. That mismatches what upstream considers the public include path: both [`libhs.pc.in`](https://github.com/intel/hyperscan/blob/v5.4.2/libhs.pc.in) and [`libch.pc.in`](https://github.com/intel/hyperscan/blob/v5.4.2/chimera/libch.pc.in) end with `Cflags: -I${includedir}/hs`, i.e. consumers are expected to write `#include <hs.h>`. With the current recipe that doesn't resolve, and consumers either switch to `#include <hs/hs.h>` or patch their own include paths.

The sibling [`vectorscan`](https://github.com/conan-io/conan-center-index/blob/master/recipes/vectorscan/all/conanfile.py) recipe already exposes `include/hs` for the same reason.

#### Details

Adds `include/hs` next to `include` in each component's `includedirs`, so both `#include <hs.h>` and `#include <hs/hs.h>` work. Nothing removed; existing `test_package` (`"hs/hs.h"`) still passes. Both versions in `config.yml` share `folder: all`, no `conandata.yml` changes.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
