### PR TITLE
stdiobus: AI agent transport SDK version 1.0.0

### DIFF
--- a/recipes/stdiobus/all/conandata.yml
+++ b/recipes/stdiobus/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.0.0":
+    url: "https://github.com/stdiobus/stdiobus-cpp/archive/refs/tags/v1.0.0.tar.gz"
+    sha256: "8d20a8a8a170a2ae77f93af5d5b2c24601247f3ae3a3b5aa5045fb11cbc64511"

--- a/recipes/stdiobus/all/conanfile.py
+++ b/recipes/stdiobus/all/conanfile.py
@@ -1,0 +1,68 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
+from conan.tools.files import copy, get
+from conan.tools.build import check_min_cppstd
+import os
+
+
+class StdioBusCppConan(ConanFile):
+    name = "stdiobus"
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/stdiobus/stdiobus-cpp"
+    description = "C++17 SDK for stdio Bus - AI agent transport layer for MCP/ACP protocols"
+    topics = ("stdiobus", "mcp", "acp", "agent", "transport", "json-rpc", "ipc")
+    package_type = "library"
+    settings = "os", "compiler", "build_type", "arch"
+    options = {"fPIC": [True, False], "exceptions": [True, False]}
+    default_options = {"fPIC": True, "exceptions": False}
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def layout(self):
+        cmake_layout(self)
+
+    def validate(self):
+        if self.settings.os == "Windows":
+            raise ConanInvalidConfiguration("stdiobus does not support Windows")
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, "17")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["STDIOBUS_CPP_EXCEPTIONS"] = bool(self.options.exceptions)
+        tc.variables["STDIOBUS_BUILD_TESTS"] = False
+        tc.variables["STDIOBUS_BUILD_EXAMPLES"] = False
+        tc.variables["STDIOBUS_BUILD_BENCHMARKS"] = False
+        tc.variables["STDIOBUS_BUILD_FUZZ"] = False
+        tc.variables["STDIOBUS_INSTALL"] = True
+        tc.variables["STDIOBUS_WARNINGS_AS_ERRORS"] = False
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "stdiobus")
+        self.cpp_info.set_property("cmake_target_name", "stdiobus::stdiobus")
+        self.cpp_info.set_property("pkg_config_name", "stdiobus")
+        self.cpp_info.libs = ["stdiobus", "stdio_bus"]
+        if self.options.exceptions:
+            self.cpp_info.defines.append("STDIOBUS_CPP_EXCEPTIONS=1")
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("pthread")

--- a/recipes/stdiobus/all/test_package/CMakeLists.txt
+++ b/recipes/stdiobus/all/test_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.14)
+project(test_stdiobus LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+find_package(stdiobus CONFIG REQUIRED)
+
+add_executable(test_stdiobus src/example.cpp)
+target_link_libraries(test_stdiobus PRIVATE stdiobus::stdiobus)

--- a/recipes/stdiobus/all/test_package/conanfile.py
+++ b/recipes/stdiobus/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+import os
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import can_run
+
+
+class StdioBusTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindir, "test_stdiobus")
+            self.run(cmd, env="conanrun")

--- a/recipes/stdiobus/all/test_package/src/example.cpp
+++ b/recipes/stdiobus/all/test_package/src/example.cpp
@@ -1,0 +1,8 @@
+#include <stdiobus/version.hpp>
+#include <iostream>
+
+int main() {
+    std::cout << "stdiobus version: " << stdiobus::version() << std::endl;
+    std::cout << "kernel compatible: " << std::boolalpha << stdiobus::kernel_compatible() << std::endl;
+    return stdiobus::version_major() == 1 ? 0 : 1;
+}

--- a/recipes/stdiobus/config.yml
+++ b/recipes/stdiobus/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.0.0":
+    folder: "all"


### PR DESCRIPTION
### Summary

Changes to recipe: **stdiobus/1.0.0** (new recipe)

#### Motivation

Adding the initial version of **stdiobus** — a C++17 SDK for [stdio Bus](https://stdiobus.com), a process-embedded message bus for AI agent orchestration over MCP/ACP protocols.

This library enables C++ applications to spawn and manage worker processes communicating via stdin/stdout using JSON-RPC. It provides RAII lifecycle management, async request/response via `std::future`, and event-loop integration via poll fd.

- **Homepage**: https://stdiobus.com
- **Source**: https://github.com/stdiobus/stdiobus-cpp
- **Release**: https://github.com/stdiobus/stdiobus-cpp/releases/tag/v1.0.0
- **License**: Apache-2.0

#### Details

- C++17, CMake 3.14+
- Platforms: Linux (x86_64, aarch64), macOS (x86_64, arm64)
- Windows rejected in `validate()`
- No external dependencies — bundles a prebuilt C kernel static library per platform
- Exports CMake target `stdiobus::stdiobus` via `find_package(stdiobus CONFIG)`
- Two error handling modes: status-style (default) and exception (opt-in)
- `test_package` verifies linkage and runtime version check

---

- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan
