### PR TITLE
corrade: add 2020.06.0.cci.20260327

### DIFF
--- a/recipes/corrade/all/conandata.yml
+++ b/recipes/corrade/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2020.06.0.cci.20260327":
+    sha256: d8f30e9a857172003b6b02304783f40e8038c36e4127a0cfec7fe14f41c13fd4
+    url: https://github.com/mosra/corrade/archive/22e7ffc6fcdeaa0df96e0d8b3d482ad6abe7dc36.tar.gz
   "2020.06":
     sha256: 2a62492ccc717422b72f2596a3e1a6a105b9574aa9467917f12d19ef3aab1341
     url: https://github.com/mosra/corrade/archive/v2020.06.tar.gz

--- a/recipes/corrade/config.yml
+++ b/recipes/corrade/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2020.06.0.cci.20260327":
+    folder: all
   "2020.06":
     folder: all
   "2019.10":


### PR DESCRIPTION
Specify library name and version: **corrade/2020.06.0.cci.20260327**

The last tagged release of Corrade is `v2020.06` (June 2020). Six years on, the library has evolved significantly but mosra has not cut a new tag, leaving downstream Conan users on an outdated release. This PR follows the CCI convention for libraries with prior releases (`<MAJOR>.<MINOR>.<PATCH>.cci.<YEAR MONTH DAY>`) and commit-locks to `22e7ffc6` — the last commit on 2026-03-27 in `mosra/corrade`.

### Changes

- `recipes/corrade/config.yml`: register the new version
- `recipes/corrade/all/conandata.yml`: source URL/sha256 for the pinned commit tarball

No changes to `conanfile.py` and no new patches.

### Verification

`conan create recipes/corrade/all --version=2020.06.0.cci.20260327 --build=missing` succeeds locally on macOS arm64 (apple-clang 17, libc++) and the existing `test_package` runs cleanly:

```
Test package for Corrade
Corrade 2020.6
Success
```

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan-center-index/blob/master/docs/preparing_the_environment.md#install-conan) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/docs/v2_migration.md#conan-client-versions-currently-deployed-in-the-service).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.