### PR TITLE
Fix/ffmpeg meson libs detection

### DIFF
--- a/recipes/ffmpeg/all/conandata.yml
+++ b/recipes/ffmpeg/all/conandata.yml
@@ -9,6 +9,10 @@ sources:
     url: "https://ffmpeg.org/releases/ffmpeg-4.4.6.tar.bz2"
     sha256: "822c980717470a2a576e5adba4e8a40977d15c3312b89dcd121547262b730d11"
 patches:
+  "8.1":
+    - patch_file: "patches/8.1-0001-fix-msvc-lib-name-resolution.patch"
+      patch_description: "Fix MSVC -l flag translation: search -L dirs for actual lib file (foo.lib, libfoo.a, etc.) instead of blindly appending .lib. Fixes Meson-built deps like lcms that produce libfoo.a on Windows."
+      patch_type: "portability"
   "4.4.6":
     - patch_file: "patches/4.4-0001-fix-aom_codec_av1_dx_algo.patch"
       patch_description: "Compatibility with shared libaom"

--- a/recipes/ffmpeg/all/patches/8.1-0001-fix-msvc-lib-name-resolution.patch
+++ b/recipes/ffmpeg/all/patches/8.1-0001-fix-msvc-lib-name-resolution.patch
@@ -1,0 +1,40 @@
+diff --git a/configure b/configure
+index 1759694..8cc33a7 100644
+--- a/configure
++++ b/configure
+@@ -5110,6 +5110,26 @@ cparser_flags(){
+ }
+ 
+ msvc_common_flags(){
++    # Resolve a library name by searching linker paths for actual files.
++    # Meson-built packages on Windows produce libfoo.a instead of foo.lib
++    # (mesonbuild/meson#7378), so the naive "-lfoo -> foo.lib" fails.
++    # Parse $LDFLAGS for -LIBPATH: entries (set by Conan/env) since test_ld
++    # splits -L and -l flags into separate subshell invocations.
++    _msvc_resolve_lib(){
++        _name="$1"
++        for _flag in $LDFLAGS; do
++            case $_flag in
++                -LIBPATH:*) _dir="${_flag#-LIBPATH:}" ;;
++                -libpath:*) _dir="${_flag#-libpath:}" ;;
++                *) continue ;;
++            esac
++            for _cand in "${_name}.lib" "lib${_name}.a" "lib${_name}.lib" "${_name}.a"; do
++                [ -f "${_dir}/${_cand}" ] && echo "$_cand" && return
++            done
++        done
++        echo "${_name}.lib"
++    }
++
+     for flag; do
+         case $flag in
+             # In addition to specifying certain flags under the compiler
+@@ -5131,7 +5151,7 @@ msvc_common_flags(){
+             -lz)                  echo zlib.lib ;;
+             -lx264)               echo libx264.lib ;;
+             -lstdc++)             ;;
+-            -l*)                  echo ${flag#-l}.lib ;;
++            -l*)                  _msvc_resolve_lib "${flag#-l}" ;;
+             -LARGEADDRESSAWARE)   echo $flag ;;
+             -L*) [ "$_flags_type" = "link" ] && echo -libpath:${flag#-L} ;;
+             -Wl,*)                ;;


### PR DESCRIPTION
### Summary
Changes to recipe:  **ffmpeg/8.1**

#### Motivation
When building ffmpeg on Windows with an MSVC-compatible compiler (clang-cl, MSVC), ffmpeg's configure script translates -lfoo flags to foo.lib via a hardcoded pattern in msvc_common_flags().
This breaks for packages built with Meson, which produce libfoo.a instead of foo.lib on Windows — for example lcms2, which generates liblcms2.a.

The result is a link error: the linker receives lcms2.lib but the actual file on disk is liblcms2.a, so the library is not found.

#### Details
Adds a helper function _msvc_resolve_lib() inside msvc_common_flags() in ffmpeg's configure script.
Rather than blindly appending .lib, it searches the linker search paths (extracted from $LDFLAGS -LIBPATH: entries set by Conan's AutotoolsDeps/PkgConfigDeps) for the actual library file, probing candidates in order:
- foo.lib — standard MSVC name
- libfoo.a — Meson-built static library on Windows
- libfoo.lib — alternate Meson output
- foo.a — fallback static name
Falls back to foo.lib if no file is found on disk (preserving existing behavior for deps not yet in the search path at configure time).

Reported upstream [ffmpeg/#23048](https://code.ffmpeg.org/FFmpeg/FFmpeg/pulls/23048)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
