### PR TITLE
libcap: add version 2.78

### DIFF
--- a/recipes/libcap/all/conandata.yml
+++ b/recipes/libcap/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.78":
+    url: "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.78.tar.xz"
+    sha256: "0d621e562fd932ccf67b9660fb018e468a683d7b827541df27813228c996bb11"
   "2.77":
     url: "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.77.tar.xz"
     sha256: "897bc18b44afc26c70e78cead3dbb31e154acc24bee085a5a09079a88dbf6f52"
@@ -45,6 +48,9 @@ sources:
     url: "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.45.tar.xz"
     sha256: "d66639f765c0e10557666b00f519caf0bd07a95f867dddaee131cd284fac3286"
 patches:
+  "2.78":
+    - patch_file: "patches/2.73/0001-libcap-Remove-hardcoded-fPIC.patch"
+    - patch_file: "patches/2.77/0001-Make.Rules-Make-compile-tools-configurable.patch"
   "2.77":
     - patch_file: "patches/2.73/0001-libcap-Remove-hardcoded-fPIC.patch"
     - patch_file: "patches/2.77/0001-Make.Rules-Make-compile-tools-configurable.patch"

--- a/recipes/libcap/config.yml
+++ b/recipes/libcap/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.78":
+    folder: all
   "2.77":
     folder: all
   "2.75":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libcap/2.78**

#### Motivation
A new version of libcap is available. Full diff between 2.77 and 2.78: https://git.kernel.org/pub/scm/libs/libcap/libcap.git/diff/?id=libcap-2.77&id2=libcap-2.78

#### Details
This version contains a fix for [CVE-2026-4878](https://nvd.nist.gov/vuln/detail/CVE-2026-4878): [commit 286ace125999 ("Address a potential TOCTOU race condition in cap_set_file().")](https://git.kernel.org/pub/scm/libs/libcap/libcap.git/commit/?id=286ace1259992bd0c5d9016715833f2e148ac596).


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
