### PR TITLE
geo-utils-cpp: new recipe

### DIFF
--- a/recipes/geo-utils-cpp/all/conandata.yml
+++ b/recipes/geo-utils-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.2":
+    url: "https://github.com/gistrec/geo-utils-cpp/archive/v1.0.2.tar.gz"
+    sha256: "be01e145e38341544ba283ebd7ca9896e9b488659167b72ce662960fe4d58bb4"
   "1.0.1":
     url: "https://github.com/gistrec/geo-utils-cpp/archive/v1.0.1.tar.gz"
     sha256: "2594b5dd736dab3ee99dc586dd326f699b90243b6074df582a32547f90b82a08"

--- a/recipes/geo-utils-cpp/all/conandata.yml
+++ b/recipes/geo-utils-cpp/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.0.1":
+    url: "https://github.com/gistrec/geo-utils-cpp/archive/v1.0.1.tar.gz"
+    sha256: "2594b5dd736dab3ee99dc586dd326f699b90243b6074df582a32547f90b82a08"

--- a/recipes/geo-utils-cpp/all/conandata.yml
+++ b/recipes/geo-utils-cpp/all/conandata.yml
@@ -1,7 +1,4 @@
 sources:
-  "1.0.2":
-    url: "https://github.com/gistrec/geo-utils-cpp/archive/v1.0.2.tar.gz"
-    sha256: "be01e145e38341544ba283ebd7ca9896e9b488659167b72ce662960fe4d58bb4"
-  "1.0.1":
-    url: "https://github.com/gistrec/geo-utils-cpp/archive/v1.0.1.tar.gz"
-    sha256: "2594b5dd736dab3ee99dc586dd326f699b90243b6074df582a32547f90b82a08"
+  "1.1.0":
+    url: "https://github.com/gistrec/geo-utils-cpp/archive/v1.1.0.tar.gz"
+    sha256: "fcf31dba71e9c9db265bb44b91d54f0f101feda54660b843e1a1a4c74e5d565c"

--- a/recipes/geo-utils-cpp/all/conandata.yml
+++ b/recipes/geo-utils-cpp/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "1.1.0":
-    url: "https://github.com/gistrec/geo-utils-cpp/archive/v1.1.0.tar.gz"
-    sha256: "fcf31dba71e9c9db265bb44b91d54f0f101feda54660b843e1a1a4c74e5d565c"
+  "1.2.0":
+    url: "https://github.com/gistrec/geo-utils-cpp/archive/v1.2.0.tar.gz"
+    sha256: "129b2a966891a5a911884d4b7e8e46f0e8b41d1a79f166ed4e527592cdd84935"

--- a/recipes/geo-utils-cpp/all/conanfile.py
+++ b/recipes/geo-utils-cpp/all/conanfile.py
@@ -1,0 +1,52 @@
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+import os
+
+required_conan_version = ">=1.52.0"
+
+
+class GeoUtilsCppConan(ConanFile):
+    name = "geo-utils-cpp"
+    description = "Header-only C++17 library for geographic (lat/lng) geometry: distance, bearing, area, point-in-polygon."
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/gistrec/geo-utils-cpp"
+    topics = ("geometry", "geographic", "lat-lng", "spherical", "gps", "header-only")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    @property
+    def _min_cppstd(self):
+        return 17
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def build(self):
+        pass
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        copy(self, "*.hpp",
+             os.path.join(self.source_folder, "include"),
+             os.path.join(self.package_folder, "include"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "GeoUtilsCpp")
+        self.cpp_info.set_property("cmake_target_name", "geo::utils")
+        self.cpp_info.set_property("pkg_config_name", "geo-utils-cpp")
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/geo-utils-cpp/all/conanfile.py
+++ b/recipes/geo-utils-cpp/all/conanfile.py
@@ -1,7 +1,9 @@
 from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.files import copy, get
 from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.52.0"
@@ -22,6 +24,16 @@ class GeoUtilsCppConan(ConanFile):
     def _min_cppstd(self):
         return 17
 
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "gcc": "7",
+            "clang": "5",
+            "apple-clang": "10",
+            "Visual Studio": "15",
+            "msvc": "191",
+        }
+
     def layout(self):
         basic_layout(self, src_folder="src")
 
@@ -31,6 +43,11 @@ class GeoUtilsCppConan(ConanFile):
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support.",
+            )
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/geo-utils-cpp/all/test_package/CMakeLists.txt
+++ b/recipes/geo-utils-cpp/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(GeoUtilsCpp REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE geo::utils)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/geo-utils-cpp/all/test_package/conanfile.py
+++ b/recipes/geo-utils-cpp/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            self.run(os.path.join(self.cpp.build.bindirs[0], "test_package"), env="conanrun")

--- a/recipes/geo-utils-cpp/all/test_package/test_package.cpp
+++ b/recipes/geo-utils-cpp/all/test_package/test_package.cpp
@@ -1,0 +1,14 @@
+#include <cassert>
+#include <cstdlib>
+
+#include <geo/spherical.hpp>
+
+int main() {
+    const geo::LatLng nyc{40.7128, -74.0060};
+    const geo::LatLng london{51.5074, -0.1278};
+
+    const double d = geo::distance_between(nyc, london);
+    assert(d > 5'000'000.0 && d < 6'000'000.0);
+
+    return EXIT_SUCCESS;
+}

--- a/recipes/geo-utils-cpp/config.yml
+++ b/recipes/geo-utils-cpp/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.0.1":
+    folder: all

--- a/recipes/geo-utils-cpp/config.yml
+++ b/recipes/geo-utils-cpp/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.0.2":
+    folder: all
   "1.0.1":
     folder: all

--- a/recipes/geo-utils-cpp/config.yml
+++ b/recipes/geo-utils-cpp/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.1.0":
+  "1.2.0":
     folder: all

--- a/recipes/geo-utils-cpp/config.yml
+++ b/recipes/geo-utils-cpp/config.yml
@@ -1,5 +1,3 @@
 versions:
-  "1.0.2":
-    folder: all
-  "1.0.1":
+  "1.1.0":
     folder: all


### PR DESCRIPTION
### Summary

Changes to recipe: **geo-utils-cpp/1.0.1**, **geo-utils-cpp/1.0.2**

#### Motivation

Adding [geo-utils-cpp](https://github.com/gistrec/geo-utils-cpp) to Conan Center. It is a header-only C++17 library for geographic (lat/lng) geometry: distance, bearing, polygon area, point-in-polygon, and path proximity.

The library is Apache-2.0 licensed, has no dependencies, and is already published in vcpkg ([microsoft/vcpkg#51592](https://github.com/microsoft/vcpkg/pull/51592)). This PR makes it consumable through Conan as well.

#### Details

- Adds a new recipe at `recipes/geo-utils-cpp/all/` for versions `1.0.1` and `1.0.2`, pulled from the GitHub release tarballs.
- Uses `package_type = "header-library"`, `no_copy_source = True`, and `package_id = info.clear()` so the package is identical across settings.
- Enforces the C++17 minimum via `check_min_cppstd` (when `cppstd` is set) and rejects compilers below the C++17 floor (gcc 7, clang 5, apple-clang 10, msvc 191) via `ConanInvalidConfiguration`.
- Sets package properties to match the upstream CMake/pkg-config exports:
  - `cmake_file_name = "GeoUtilsCpp"` for `find_package(GeoUtilsCpp)`
  - `cmake_target_name = "geo::utils"` to match the upstream alias
  - `pkg_config_name = "geo-utils-cpp"` to match the installed `.pc` file
- Adds a `test_package` that exercises `geo::distance_between` on two well-known points.

---

- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link the related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan