### PR TITLE
libzip: use recent versions

### DIFF
--- a/recipes/libzippp/all/conandata.yml
+++ b/recipes/libzippp/all/conandata.yml
@@ -2,18 +2,3 @@ sources:
   "7.1-1.10.1":
     url: "https://github.com/ctabin/libzippp/archive/libzippp-v7.1-1.10.1.tar.gz"
     sha256: "9ded3c4b5641e65d2b3a3dd0cbc4106209ee17c17df70e5187e7171420752546"
-  "7.0-1.10.1":
-    url: "https://github.com/ctabin/libzippp/archive/libzippp-v7.0-1.10.1.tar.gz"
-    sha256: "67d6808406b4fc255016ede52c7b5105e2d0e43899a3331de9ed86da5dea07a1"
-  "6.1-1.9.2":
-    url: "https://github.com/ctabin/libzippp/archive/libzippp-v6.1-1.9.2.tar.gz"
-    sha256: "3796f174780f23938749da493cf4cbc4c55f84a568ec395f2c256dfe10129305"
-  "6.0-1.9.2":
-    url: "https://github.com/ctabin/libzippp/archive/libzippp-v6.0-1.9.2.tar.gz"
-    sha256: "f9aef9811802a18e69cd50527381d70c2e0f0d8a839f1d41914f6234f5964fc3"
-  "5.0-1.8.0":
-    url: "https://github.com/ctabin/libzippp/archive/libzippp-v5.0-1.8.0.tar.gz"
-    sha256: "b70f2d0f64eb68b00a16290bac40ac1a3fd3d2896cfddc93e370a7fa28c591c5"
-  "4.0":
-    url: "https://github.com/ctabin/libzippp/archive/libzippp-v4.0-1.7.3.tar.gz"
-    sha256: "7560c2d8bbace39245ba6e89c5454b8bc5eb753bb13451bca2c7b5810c0a2f2d"

--- a/recipes/libzippp/all/conanfile.py
+++ b/recipes/libzippp/all/conanfile.py
@@ -1,12 +1,11 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.files import get, copy, rmdir, replace_in_file
+from conan.tools.files import get, copy, rmdir
 from conan.tools.build import check_min_cppstd
-from conan.tools.scm import Version
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.0"
 
 
 class LibZipppConan(ConanFile):
@@ -46,12 +45,9 @@ class LibZipppConan(ConanFile):
 
     def requirements(self):
         self.requires("zlib/[>=1.2.11 <2]")
-        if Version(self.version) == "4.0":
-            self.requires("libzip/1.7.3")
-        else:
-            versions = str(self.version).split("-")
-            if len(versions) == 2:
-                self.requires(f"libzip/{versions[1]}")
+        versions = str(self.version).split("-")
+        if len(versions) == 2:
+            self.requires(f"libzip/{versions[1]}")
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
@@ -83,14 +79,7 @@ class LibZipppConan(ConanFile):
         deps = CMakeDeps(self)
         deps.generate()
 
-    def _patch_source(self):
-        if Version(self.version) <= "6.0":
-            replace_in_file(self, os.path.join(self.source_folder, 'CMakeLists.txt'),
-                            'find_package(LIBZIP MODULE REQUIRED)',
-                            'find_package(libzip REQUIRED CONFIG)')
-
     def build(self):
-        self._patch_source()
         cmake = CMake(self)
         cmake.configure()
         cmake.build()

--- a/recipes/libzippp/config.yml
+++ b/recipes/libzippp/config.yml
@@ -1,13 +1,3 @@
 versions:
   "7.1-1.10.1":
     folder: all
-  "7.0-1.10.1":
-    folder: all
-  "6.1-1.9.2":
-    folder: all
-  "6.0-1.9.2":
-    folder: all
-  "5.0-1.8.0":
-    folder: all
-  "4.0":
-    folder: all

--- a/recipes/xlsxio/all/conanfile.py
+++ b/recipes/xlsxio/all/conanfile.py
@@ -55,7 +55,7 @@ class XlsxioConan(ConanFile):
 
     def requirements(self):
         if self.options.with_libzip:
-            self.requires("libzip/1.10.1")
+            self.requires("libzip/[>=1.10.1 <2]")
         elif Version(self.version) >= "0.2.34" and self.options.with_minizip_ng :
             self.requires("minizip-ng/[>=4.0.1 <5]")
         else:


### PR DESCRIPTION
### Summary
* libzippp: keep most recent version (depends on libzip 1.10.1)
* xlsxio: use version range for libzip


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
