### PR TITLE
[protobuf] Fix minimum abseil version

### DIFF
--- a/recipes/protobuf/all/conanfile.py
+++ b/recipes/protobuf/all/conanfile.py
@@ -81,7 +81,7 @@ class ProtobufConan(ConanFile):
             self.requires("zlib/[>=1.2.11 <2]")
 
         if self._protobuf_release >= "30.1":
-            self.requires("abseil/[>=20230802.1 <=20260107.1]", transitive_headers=True, transitive_libs=True)
+            self.requires("abseil/[>=20240722.0 <=20260107.1]", transitive_headers=True, transitive_libs=True)
         else:
             # 5.29.x cannot use newer abseil than this, because newer abseil requires c++17 as minmum
             # and it no longer has the `absl::if_constexpr` CMake target


### PR DESCRIPTION
### Summary
Changes to recipe:  **protobuf**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Bump the minimum required version of `abseil` to `20240722.0` for `protobuf>=30.1` since compiling with earlier versions of `abseil` would fail anyways.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
Starting with protobuf version `30.1`, a depedendency on `absl::container_internal::Layout::WithStaticSizes` was introduced via https://github.com/protocolbuffers/protobuf/commit/f971ed3f36099cb380420cb57f67940470394337 .
That symbol is available since abseil `20240722.0` via https://github.com/abseil/abseil-cpp/commit/5839a14828f31f1c2876003677e0ce8e28544b1f .

Compiling protobuf `6.30.1` with abseil `20240116.2` would result in the error:

``` txt
`...\src\src\google\protobuf\arena.cc(513,35): error C2039: 'WithStaticSizes': is not a member of 'absl::lts_20240116::container_internal::Layout<google::protobuf::internal::SerialArena
ChunkHeader,std::atomic<void *>,std::atomic<google::protobuf::internal::SerialArena *>>' [...\b\proto8a153eac50aa9\b\build\libprotobuf.vcxproj]
```

Tested version combinations:



Abseil | Protobuf | Compilation
-- | -- | --
20240116.2 | 6.30.1 | Fails
20240722.0 | 6.30.1 | Works
20240722.0 | 6.32.1 | Works
20240722.0 | 6.33.5 | Works


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
