### PR TITLE
mimalloc: add 3.3.2

### DIFF
--- a/recipes/mimalloc/all/conandata.yml
+++ b/recipes/mimalloc/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.3.2":
+    url: "https://github.com/microsoft/mimalloc/archive/v3.3.2.tar.gz"
+    sha256: "ca02384e007f46950598500dfaebde5ff9948c1d231f5a81b058799afa64bbbb"
   "3.2.8":
     url: "https://github.com/microsoft/mimalloc/archive/v3.2.8.tar.gz"
     sha256: "68163666575518c213a6593850099adce3863b340ca2751103dbd1f253664e05"

--- a/recipes/mimalloc/config.yml
+++ b/recipes/mimalloc/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.3.2":
+    folder: all
   "3.2.8":
     folder: all
   "2.2.4":


### PR DESCRIPTION
Specify library name and version: **mimalloc/3.3.2**

Adds the latest stable mimalloc release ([v3.3.2](https://github.com/microsoft/mimalloc/releases/tag/v3.3.2), 2026-04-29).

### Headline change vs 3.2.8 (Windows static override)

Upstream enabled **static override of `malloc`/`free` on Windows with the static CRT (`/MT`)** without requiring `mimalloc-redirect.dll`, addressing [microsoft/mimalloc#1074](https://github.com/microsoft/mimalloc/issues/1074). Two cooperating source changes:

`CMakeLists.txt` — removed the `if(NOT WIN32)` guard around `MI_MALLOC_OVERRIDE` for `mimalloc-static` / `mimalloc-obj`:

```diff
 if(MI_OVERRIDE)
-  if(NOT WIN32)
-    if(MI_BUILD_STATIC)
-      target_compile_definitions(mimalloc-static PRIVATE MI_MALLOC_OVERRIDE)
-    endif()
-    if(MI_BUILD_OBJECT)
-      target_compile_definitions(mimalloc-obj PRIVATE MI_MALLOC_OVERRIDE)
-    endif()
+  if(MI_BUILD_STATIC)
+    target_compile_definitions(mimalloc-static PRIVATE MI_MALLOC_OVERRIDE)
+  endif()
+  if(MI_BUILD_OBJECT)
+    target_compile_definitions(mimalloc-obj PRIVATE MI_MALLOC_OVERRIDE)
   endif()
 endif()
```

`src/alloc-override.c` — removed `!(defined(_WIN32))` from the top-level guard so the strong defs of `malloc`/`free`/`calloc`/`realloc`/`operator new`/`operator delete` now compile on Windows:

```diff
-#if defined(MI_MALLOC_OVERRIDE) && !(defined(_WIN32))
+#if defined(MI_MALLOC_OVERRIDE)
```

### Recipe changes

Forward-compatible — only the `config.yml` + `conandata.yml` entries. No `conanfile.py` change, no patches:

```yaml
# recipes/mimalloc/config.yml
versions:
  "3.3.2":     # ← new
    folder: all
  "3.2.8":
    folder: all
  ...
```

```yaml
# recipes/mimalloc/all/conandata.yml
sources:
  "3.3.2":     # ← new
    url: "https://github.com/microsoft/mimalloc/archive/v3.3.2.tar.gz"
    sha256: "ca02384e007f46950598500dfaebde5ff9948c1d231f5a81b058799afa64bbbb"
  "3.2.8":
    ...
```

### Validation

- **Upstream mimalloc CI on `v3.3.2`** ([run 25137277252](https://github.com/microsoft/mimalloc/actions/runs/25137277252)) — every Windows job passed including the static-CRT static-override path:
  - `Test (basic, windows-latest)`: success
  - `Test (extra, windows-latest)`: success
  - `Test (basic, windows-11-arm)`: success
  - `Test (extra, windows-11-arm)`: success
  - `Test (basic, macos-latest / macos-14 / macos-15-intel)`: success
  - `Test (basic, ubuntu-latest / ubuntu-22.04-arm)`: success
- **Local `conan create` on macOS arm64** with `override=True single_object=True shared=False`: `test_package` reports `mimalloc version 30302`.
- **Local Windows binary forensics via clang-cl + xwin** was attempted but my xwin-pinned SDK is older than what 3.3.2 expects (`_CRT_HYBRIDPATCHABLE` / `_CRT_NOEXCEPT` are Win11 22H2 SDK macros). The CCI Windows runners have current SDKs, so I'm relying on the conan-center CI to exercise that path empirically on top of the upstream CI evidence above.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] Checked that this PR is not a duplicate.
- [x] Tested locally (macOS) and verified upstream Windows CI on the target tag.