### PR TITLE
sqlite3: add version version-3.53.1

### DIFF
--- a/recipes/sqlite3/all/conandata.yml
+++ b/recipes/sqlite3/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.53.1":
+    url: "https://sqlite.org/2026/sqlite-amalgamation-3530100.zip"
+    sha256: "36ad6e7f38540a3b21a2ac36340833f0a9e426bc1c752751c3ba669466827eae"
   "3.53.0":
     url: "https://sqlite.org/2026/sqlite-amalgamation-3530000.zip"
     sha256: "bf3733d7c71b3ab0f6fd8a9ea0052ad87fa037d94333e14ce09878ba3492c3b0"

--- a/recipes/sqlite3/all/conandata.yml
+++ b/recipes/sqlite3/all/conandata.yml
@@ -2,9 +2,6 @@ sources:
   "3.53.1":
     url: "https://sqlite.org/2026/sqlite-amalgamation-3530100.zip"
     sha256: "36ad6e7f38540a3b21a2ac36340833f0a9e426bc1c752751c3ba669466827eae"
-  "3.53.0":
-    url: "https://sqlite.org/2026/sqlite-amalgamation-3530000.zip"
-    sha256: "bf3733d7c71b3ab0f6fd8a9ea0052ad87fa037d94333e14ce09878ba3492c3b0"
   "3.51.3":
     url: "https://sqlite.org/2026/sqlite-amalgamation-3510300.zip"
     sha256: "acb1e6f5d832484bf6d32b681e858c38add8b2acdfd42ac5df24b8afb46552b4"

--- a/recipes/sqlite3/config.yml
+++ b/recipes/sqlite3/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.53.1":
+    folder: all
   "3.53.0":
     folder: all
   "3.51.3":

--- a/recipes/sqlite3/config.yml
+++ b/recipes/sqlite3/config.yml
@@ -1,8 +1,6 @@
 versions:
   "3.53.1":
     folder: all
-  "3.53.0":
-    folder: all
   "3.51.3":
     folder: all
   "3.44.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  **sqlite3/3.53.1**

#### Motivation
Update to new version of sqlite3 - security vulnerabilities fixed

- CVE-2025-70873 (Information Disclosure): A vulnerability in the SQLite zipfile extension that could disclose uninitialized heap memory during inflation.
- CVE-2025-7709 (Integer Overflow): An integer overflow issue specifically within the FTS5  ---- (Full-Text Search) extension.WAL-Reset Database Corruption Bug: A significant reliability issue where the Write-Ahead Log  - (WAL) could cause database corruption under specific reset conditions.
- CVE-2025-6965 (Buffer Overflow): A critical memory corruption flaw (CVSS 9.8) where aggregate terms could exceed available columns; while fixed in 3.50.2+, version 3.53.[1](https://blog.jetbrains.com/teamcity/2024/05/teamcity-major-bug-fix-release-for-all-versions/) is the current recommended stable path for mitigation.

#### Details

https://sqlite.org/releaselog/3_53_1.html

Built on MacOS ARM w/ XCode 16.4

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
