### PR TITLE
Fix jemalloc test package when prefix is set

### DIFF
--- a/recipes/jemalloc/all/conanfile.py
+++ b/recipes/jemalloc/all/conanfile.py
@@ -194,3 +194,5 @@ class JemallocConan(ConanFile):
             self.cpp_info.defines = ["JEMALLOC_EXPORT="]
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.extend(["dl", "pthread", "rt"])
+        if self.options.prefix:
+            self.cpp_info.defines.append("JEMALLOC_MANGLE")

--- a/recipes/jemalloc/all/conanfile.py
+++ b/recipes/jemalloc/all/conanfile.py
@@ -194,5 +194,3 @@ class JemallocConan(ConanFile):
             self.cpp_info.defines = ["JEMALLOC_EXPORT="]
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.extend(["dl", "pthread", "rt"])
-        if self.options.prefix:
-            self.cpp_info.defines.append("JEMALLOC_MANGLE")

--- a/recipes/jemalloc/all/test_package/CMakeLists.txt
+++ b/recipes/jemalloc/all/test_package/CMakeLists.txt
@@ -4,4 +4,5 @@ project(test_package LANGUAGES C)
 find_package(jemalloc REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
+target_compile_definitions(${PROJECT_NAME} PRIVATE JEMALLOC_MANGLE)
 target_link_libraries(${PROJECT_NAME} PRIVATE jemalloc::jemalloc)

--- a/recipes/jemalloc/all/test_package/CMakeLists.txt
+++ b/recipes/jemalloc/all/test_package/CMakeLists.txt
@@ -4,5 +4,4 @@ project(test_package LANGUAGES C)
 find_package(jemalloc REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
-target_compile_definitions(${PROJECT_NAME} PRIVATE JEMALLOC_MANGLE)
 target_link_libraries(${PROJECT_NAME} PRIVATE jemalloc::jemalloc)


### PR DESCRIPTION
Add JEMALLOC_MANGLE to test package defines so that it still builds when `jemalloc/*:prefix=<whatever>` is set.


### Summary
Changes to recipe:  **jemalloc/5.3.1**

#### Motivation
See #30177 - without this change, the following command will fail in the test package:
Fix #30177

```
conan create . --user amerry --channel test --version 5.3.1 -o:a 'jemalloc/*:prefix=je_'
```

#### Details

The test package was failing with `-o:a 'jemalloc/*:prefix=je_'` because the test package was trying to call `malloc` and `malloc_stats_print`, rather than `je_malloc` and `je_malloc_stats_print`. The jemalloc headers will not define the unprefixed names by default (to avoid clashes with the default malloc), but they _will_ define the unprefixed names if `JEMALLOC_MANGLE` is defined. So the solution is simply to add that definition.

Tested locally with:

```
conan create . --user amerry --channel test --version 5.3.1 -o:a 'jemalloc/*:prefix=je_'
```

and also with

```
conan create . --user amerry --channel test --version 5.3.1
```

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
