### PR TITLE
Add expat version 2.8.1

### DIFF
--- a/recipes/expat/all/conandata.yml
+++ b/recipes/expat/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.8.1":
+    url: "https://github.com/libexpat/libexpat/releases/download/R_2_8_1/expat-2.8.1.tar.xz"
+    sha256: "10b195ee78160a908388180a8fe3603d4e9a12f4755fbf5f3816b23a9d750da0"
   "2.8.0":
     url: "https://github.com/libexpat/libexpat/releases/download/R_2_8_0/expat-2.8.0.tar.xz"
     sha256: "a37bfae0aa9775bd8521ebd85dc456d486f0ff31138f6c91fd902ea732624542"

--- a/recipes/expat/config.yml
+++ b/recipes/expat/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.8.1":
+    folder: all
   "2.8.0":
     folder: all
   "2.7.5":


### PR DESCRIPTION
### Summary
Changes to recipe:  **expat/2.8.1**

#### Motivation
- Expat 2.8.1 was released to address CVE-2026-45186, let's bump the version.

#### Details
- Modify expat's conandata.yml and config.yml to add version 2.8.1.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
