### PR TITLE
zxc: add version 0.11.0

### DIFF
--- a/recipes/zxc/all/conandata.yml
+++ b/recipes/zxc/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "0.10.0":
-    url: "https://github.com/hellobertrand/zxc/archive/refs/tags/v0.10.0.tar.gz"
-    sha256: "35f648b282495c470c706375a5430c0d7261ae36e5ce03863d9e02f8907e49de"
+  "0.11.0":
+    url: "https://github.com/hellobertrand/zxc/archive/refs/tags/v0.11.0.tar.gz"
+    sha256: "a8e82e811aca54ca3c2f8b27e1184e795826ae87981e255d36630a6924ece202"

--- a/recipes/zxc/config.yml
+++ b/recipes/zxc/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.10.0":
+  "0.11.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **zxc/0.11.0**

#### Motivation
Version 0.11.0 is released.

#### Details
Release note: https://github.com/hellobertrand/zxc/releases/tag/v0.11.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!