### PR TITLE
rocksdb: Fix is_msvc typo and avx2 arg

### DIFF
--- a/recipes/rocksdb/all/conanfile.py
+++ b/recipes/rocksdb/all/conanfile.py
@@ -130,7 +130,7 @@ class RocksDBConan(ConanFile):
         if not bool(self.options.enable_sse):
             tc.variables["PORTABLE"] = True
         else:
-            tc.cache_variables["PORTABLE"] = "avx2" if is_mvc(self) else "haswell"
+            tc.cache_variables["PORTABLE"] = "AVX2" if is_msvc(self) else "haswell"
         # not available yet in CCI
         tc.variables["WITH_NUMA"] = False
         tc.generate()


### PR DESCRIPTION
### Summary
Changes to recipe:  **rocksdb/11.1.1**

#### Motivation
~The recipe is currently broken.~
The option `enable_sse` is broken when the value is different than `False`.

#### Details
Fix the is_msvc typo so the recipe actually works. Also changes "avx2" to "AVX2" because the arguments to /arch on MSVC are, in fact, case-sensitive


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
