### PR TITLE
sdl: publish version 3.4.8

### DIFF
--- a/recipes/sdl/3.x/conandata.yml
+++ b/recipes/sdl/3.x/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.4.8":
+    url: "https://github.com/libsdl-org/SDL/releases/download/release-3.4.8/SDL3-3.4.8.tar.gz"
+    sha256: "e9fff7467fb60f037e6708da18b25560649e4c63edc2a69bb871b960d9cbfbba"
   "3.4.0":
     url: "https://github.com/libsdl-org/SDL/releases/download/release-3.4.0/SDL3-3.4.0.tar.gz"
     sha256: "082cbf5f429e0d80820f68dc2b507a94d4cc1b4e70817b119bbb8ec6a69584b8"

--- a/recipes/sdl/config.yml
+++ b/recipes/sdl/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.4.8":
+    folder: 3.x
   "3.4.0":
     folder: 3.x
   "2.32.10":


### PR DESCRIPTION
### Summary

Changes to recipe: **sdl/[3.4.8]**

#### Motivation

Updates the SDL 3.x recipe from 3.4.0 to 3.4.8, a patch release that fixes several bugs upstream.

#### Details

Only conandata.yml and config.yml were updated. The 3.4.0 entry was replaced with 3.4.8, following the existing convention for this recipe slot. The existing recipe is reused as-is.

---

- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan
