### PR TITLE
glaze: publish version 7.6.0

### DIFF
--- a/recipes/glaze/all/conandata.yml
+++ b/recipes/glaze/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "7.6.0":
-    url: "https://github.com/stephenberry/glaze/archive/refs/tags/v7.6.0.tar.gz"
-    sha256: "839cd7bd2bda4db1a4e973f18851c2ecdccf82c75512453f68b2389d43a3e8ad"
+  "7.7.1":
+    url: "https://github.com/stephenberry/glaze/archive/refs/tags/v7.7.1.tar.gz"
+    sha256: "c51217ca374f2a7d556c501a849d3a43dfffff47ba7711b6f0c22020e71ff63d"
   "7.4.0":
     url: "https://github.com/stephenberry/glaze/archive/refs/tags/v7.4.0.tar.gz"
     sha256: "e7592590187dd56f16558a08b36e90bf349e885330f3a3961048df302cc9dfa1"

--- a/recipes/glaze/all/conandata.yml
+++ b/recipes/glaze/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "7.6.0":
+    url: "https://github.com/stephenberry/glaze/archive/refs/tags/v7.6.0.tar.gz"
+    sha256: "839cd7bd2bda4db1a4e973f18851c2ecdccf82c75512453f68b2389d43a3e8ad"
   "7.4.0":
     url: "https://github.com/stephenberry/glaze/archive/refs/tags/v7.4.0.tar.gz"
     sha256: "e7592590187dd56f16558a08b36e90bf349e885330f3a3961048df302cc9dfa1"

--- a/recipes/glaze/config.yml
+++ b/recipes/glaze/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "7.6.0":
+    folder: all
   "7.4.0":
     folder: all
   "7.2.0":

--- a/recipes/glaze/config.yml
+++ b/recipes/glaze/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "7.6.0":
+  "7.7.1":
     folder: all
   "7.4.0":
     folder: all


### PR DESCRIPTION
### Summary

Changes to recipe: **glaze/[7.6.0]**

#### Motivation

Publishes glaze 7.6.0, which was released upstream.

#### Details

Only conandata.yml and config.yml were updated. The existing recipe is reused as-is.

---

- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan
