### PR TITLE
catch2: publish version 3.15.0

### DIFF
--- a/recipes/catch2/3.x.x/conandata.yml
+++ b/recipes/catch2/3.x.x/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.15.0":
+    url: "https://github.com/catchorg/Catch2/archive/refs/tags/v3.15.0.tar.gz"
+    sha256: "9650c55e497759cc39b977e45524bc8acb15256061c112080916ab6cb0b1ea66"
   "3.14.0":
     url: "https://github.com/catchorg/Catch2/archive/refs/tags/v3.14.0.tar.gz"
     sha256: "ba2a939efead3c833c499cf487e185762f419a71d30158cd1b43c6079c586490"

--- a/recipes/catch2/config.yml
+++ b/recipes/catch2/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.15.0":
+    folder: 3.x.x
   "3.14.0":
     folder: 3.x.x
   "2.13.10":


### PR DESCRIPTION
### Summary

Changes to recipe: **catch2/[3.15.0]**

#### Motivation

Publishes catch2 3.15.0, which was released upstream.

#### Details

Only conandata.yml and config.yml were updated. The existing recipe is reused as-is.

---

- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan
