### PR TITLE
publish onnxruntime v1.26.0 and onnx v1.21.0

### DIFF
--- a/recipes/onnxruntime/all/conandata.yml
+++ b/recipes/onnxruntime/all/conandata.yml
@@ -1,7 +1,12 @@
 sources:
+  "1.26.0":
+    url: "https://github.com/microsoft/onnxruntime/archive/refs/tags/v1.26.0.tar.gz"
+    sha256: "2a90eb9a306c1eeb29213f5b165a55008ac5cb7d27e0935c4458c51a49ef091d"
   "1.24.4":
     url: "https://github.com/microsoft/onnxruntime/archive/refs/tags/v1.24.4.tar.gz"
     sha256: "0cf4d2ee4392fbb8aedaabc6b2ba11b4a680d1071fa4f75546c2289ca5b404cf"
 patches:
+  "1.26.0":
+    - patch_file: "patches/1.26.0-fix-cutlass-cuda-provider.patch"
   "1.24.4":
     - patch_file: "patches/fix-cutlass-cuda-provider.patch"

--- a/recipes/onnxruntime/all/conanfile.py
+++ b/recipes/onnxruntime/all/conanfile.py
@@ -6,6 +6,7 @@ from conan.tools.apple import is_apple_os
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, replace_in_file
+from conan.tools.scm import Version
 
 required_conan_version = ">=2"
 
@@ -50,7 +51,7 @@ class OnnxRuntimeConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("onnx/[>=1.20.1 <1.21]")
+        self.requires("onnx/[>=1.20.1 <1.22]")
         self.requires("abseil/[>=20240116.1 <=20260107.1]")
         self.requires("protobuf/[>=3.21.12 <7]")
         self.requires("date/[>=3.0.1 <3.1]")
@@ -73,7 +74,8 @@ class OnnxRuntimeConan(ConanFile):
         self.requires("cpuinfo/[>=cci.20250110]")
 
     def validate(self):
-        check_min_cppstd(self, 17)
+        min_cppstd = 20 if Version(self.version) >= "1.25.0" else 17
+        check_min_cppstd(self, min_cppstd)
         onnx = self.dependencies["onnx"]
         if not onnx.options.disable_static_registration:
             raise ConanInvalidConfiguration(
@@ -111,15 +113,17 @@ class OnnxRuntimeConan(ConanFile):
         tc.variables["onnxruntime_DISABLE_RTTI"] = False
         tc.variables["onnxruntime_DISABLE_EXCEPTIONS"] = False
 
-        tc.variables["onnxruntime_ARMNN_RELU_USE_CPU"] = False
-        tc.variables["onnxruntime_ARMNN_BN_USE_CPU"] = False
         tc.variables["onnxruntime_ENABLE_CPU_FP16_OPS"] = False
-        tc.variables["onnxruntime_ENABLE_EAGER_MODE"] = False
         tc.variables["onnxruntime_ENABLE_LAZY_TENSOR"] = False
+        if Version(self.version) < "1.25.0":
+            tc.variables["onnxruntime_ARMNN_RELU_USE_CPU"] = False
+            tc.variables["onnxruntime_ARMNN_BN_USE_CPU"] = False
+            tc.variables["onnxruntime_ENABLE_EAGER_MODE"] = False
 
         tc.variables["onnxruntime_ENABLE_CUDA_EP_INTERNAL_TESTS"] = False
-        tc.variables["onnxruntime_USE_NEURAL_SPEED"] = False
         tc.variables["onnxruntime_USE_MEMORY_EFFICIENT_ATTENTION"] = False
+        if Version(self.version) < "1.25.0":
+            tc.variables["onnxruntime_USE_NEURAL_SPEED"] = False
 
         # Disable a warning that gets converted to an error
         tc.preprocessor_definitions["_SILENCE_ALL_CXX23_DEPRECATION_WARNINGS"] = "1"

--- a/recipes/onnxruntime/all/patches/1.26.0-fix-cutlass-cuda-provider.patch
+++ b/recipes/onnxruntime/all/patches/1.26.0-fix-cutlass-cuda-provider.patch
@@ -1,0 +1,14 @@
+diff --git a/cmake/onnxruntime_providers_cuda.cmake b/cmake/onnxruntime_providers_cuda.cmake
+--- a/cmake/onnxruntime_providers_cuda.cmake
++++ b/cmake/onnxruntime_providers_cuda.cmake
+@@ -314,8 +314,8 @@
+               ${ABSEIL_LIBS} ${ONNXRUNTIME_PROVIDERS_SHARED} Boost::mp11 safeint_interface)
+     endif()
+
+-    include(cutlass)
+-    target_include_directories(${target} PRIVATE ${cutlass_SOURCE_DIR}/include ${cutlass_SOURCE_DIR}/examples ${cutlass_SOURCE_DIR}/tools/util/include)
++    find_package(NvidiaCutlass)
++    target_link_libraries(${target} PRIVATE nvidia::cutlass::cutlass)
+     target_link_libraries(${target} PRIVATE Eigen3::Eigen)
+     target_include_directories(${target} PRIVATE ${ONNXRUNTIME_ROOT} ${CMAKE_CURRENT_BINARY_DIR} PUBLIC ${CUDAToolkit_INCLUDE_DIRS})
+

--- a/recipes/onnxruntime/config.yml
+++ b/recipes/onnxruntime/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.26.0":
+    folder: all
   "1.24.4":
     folder: all


### PR DESCRIPTION
### Summary

Changes to recipe:
- **onnx/[1.21.0]**
- **onnxruntime/[1.26.0]**

#### Motivation

Publishes onnxruntime 1.26.0, which was released upstream. Version 1.25.0 raised the minimum C++ standard to C++20 and removed several CMake options that existed in earlier releases, so the recipe needed minor adjustments to stay compatible across versions.

#### Details

- Added 1.26.0 source entry in conandata.yml with a version-prefixed patch file for the CUDA provider fix.
- Renamed the existing 1.24.4 patch file to include the version prefix for consistency.
- Updated conanfile.py to require C++20 for versions 1.25.0 and later (C++17 for older versions).
- Guarded removal of CMake variables that were dropped in 1.25.0: `onnxruntime_ARMNN_RELU_USE_CPU`, `onnxruntime_ARMNN_BN_USE_CPU`, `onnxruntime_ENABLE_EAGER_MODE`, and `onnxruntime_USE_NEURAL_SPEED`.
- The 1.26.0 CUDA provider patch switches from the bundled cutlass fetch (`include(cutlass)`) to `find_package(NvidiaCutlass)`, matching how the build system changed upstream.
- Also publishes onnx 1.21.0 and widens the `onnx` requirement to `>=1.20.1 <1.22` so onnxruntime 1.26.0 can resolve against it.

---

- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan