### PR TITLE
kcp: publish version 2.0

### DIFF
--- a/recipes/kcp/all/conandata.yml
+++ b/recipes/kcp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.0.0":
+    url: "https://github.com/skywind3000/kcp/archive/refs/tags/2.0.0.tar.gz"
+    sha256: "ee35cee819dae26a7625e489c00b430846176f8457d5fc6e6258b41c32e4bd2f"
   "1.7.1":
     url: "https://github.com/skywind3000/kcp/archive/refs/tags/1.7.1.tar.gz"
     sha256: "41cb85b2b4c2ea5f534b785c88fe24d86c6aaca62c3ef181d18bf1db3da6758d"

--- a/recipes/kcp/all/conandata.yml
+++ b/recipes/kcp/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "2.0.0":
-    url: "https://github.com/skywind3000/kcp/archive/refs/tags/2.0.0.tar.gz"
-    sha256: "ee35cee819dae26a7625e489c00b430846176f8457d5fc6e6258b41c32e4bd2f"
+  "2.1.1":
+    url: "https://github.com/skywind3000/kcp/archive/refs/tags/2.1.1.tar.gz"
+    sha256: "54d3c80928d206529f67cba6f96f2c98007182b46e3112819b200d914f96e425"
   "1.7.1":
     url: "https://github.com/skywind3000/kcp/archive/refs/tags/1.7.1.tar.gz"
     sha256: "41cb85b2b4c2ea5f534b785c88fe24d86c6aaca62c3ef181d18bf1db3da6758d"

--- a/recipes/kcp/config.yml
+++ b/recipes/kcp/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "2.0.0":
+    folder: all
   "1.7.1":
     folder: all

--- a/recipes/kcp/config.yml
+++ b/recipes/kcp/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "2.0.0":
+  "2.1.1":
     folder: all
   "1.7.1":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **kcp/v2**

#### Motivation
Upstream released version 2.0.0, which introduces pluggable congestion control and a new V2 architecture.

#### Details
- Updated `config.yml` to include version 2.0.0.
- Added version 2.0.0 to `conandata.yml` with verified SHA256.
- Verified build and test package locally using Conan 2.x.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
