### PR TITLE
aws-sdk-cpp: drop unconditional `stdc++` from system_libs

### DIFF
--- a/recipes/aws-sdk-cpp/all/conanfile.py
+++ b/recipes/aws-sdk-cpp/all/conanfile.py
@@ -2,7 +2,7 @@ import os
 
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.build import cross_building, stdcpp_library
+from conan.tools.build import cross_building
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rename, replace_in_file, rm, rmdir
 from conan.tools.microsoft import is_msvc
@@ -718,10 +718,6 @@ class AwsSdkCppConan(ConanFile):
         if self.settings.os == "Macos":
             if self.options.get_safe("text-to-speech"):
                 self.cpp_info.components["text-to-speech"].frameworks.extend(["CoreAudio", "AudioToolbox"])
-
-        libcxx = stdcpp_library(self)
-        if libcxx:
-            self.cpp_info.components["core"].system_libs.append(libcxx)
 
         self.cpp_info.components["plugin_scripts"].requires = ["core"]
         self.cpp_info.components["plugin_scripts"].builddirs.extend([


### PR DESCRIPTION
### Summary
Changes to recipe:  **aws-sdk-cpp/all**

#### Motivation

Fixes #30205.

The recipe unconditionally appends `stdcpp_library(self)` (e.g. `stdc++` on GCC + libstdc++) to the `core` component's `system_libs`. This puts a trailing `-lstdc++` on the consumer's link line, which silently overrides `-static-libstdc++` when downstream tries to link the C++ runtime statically — the resulting executable ends up linked to libstdc++ both statically and dynamically.

Minimal reproduction (no aws-sdk-cpp involved — just the link-line semantics):

```bash
$ cat > t.cpp <<'EOF'
#include <iostream>
int main() { std::cout << "hi\n"; return 0; }
EOF

$ g++ t.cpp -o t -static-libstdc++
$ ldd t | grep stdc++          # (no output — libstdc++ statically linked)

$ g++ t.cpp -o t -static-libstdc++ -lstdc++
$ ldd t | grep stdc++
libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (...)
```

Confirmed identical behavior under GCC 11.4 and GCC 14.3 — the conflict is in how gcc's driver interprets a trailing `-lstdc++`, not a quirk of any specific compiler release. Issue #30205 has the full repro and discussion.

#### Details

The auto-injection of `stdc++` into `system_libs` is only useful for downstream consumers that link with a C driver (`gcc`/`clang`), where libstdc++ is not auto-supplied. With a C++ driver (`g++`/`clang++`) — overwhelmingly the standard case for C++ projects — libstdc++ is already pulled in by the driver, so the explicit `-lstdc++` from `system_libs` is redundant at best and breaks `-static-libstdc++` at worst.

Drop the unconditional append plus the now-unused `stdcpp_library` import. Consumers that genuinely need libstdc++ from a C-driver link can list it themselves.

This pattern dates back to the `aws-sdk-cpp/1.8.130` recipe (`fe384eea1`) and was carried forward mechanically during the Conan v2 migration (`39bad7231`), with no rationale captured in either commit.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan
