### PR TITLE
imgui: Add version 1.92.8

### DIFF
--- a/recipes/imgui/all/conandata.yml
+++ b/recipes/imgui/all/conandata.yml
@@ -1,20 +1,20 @@
 # this package's recipe relies on version suffixes to handle imgui's docking branch.
 # Suffix: -docking for docking branch sources
 sources:
-  "1.92.7":
+  "1.92.8":
     core:
-      url: "https://github.com/ocornut/imgui/archive/v1.92.7.tar.gz"
-      sha256: "b21b14ce1ef6dd4d85fa54f68f8449a9be94f3b453aba7fe4ea2a9764e43a5ef"
+      url: "https://github.com/ocornut/imgui/archive/v1.92.8.tar.gz"
+      sha256: "fecb33d33930e12ff53a34064e9d3a06c8f7c3e04408f14cd36c80e3faac863b"
     testengine:
-      url: "https://github.com/ocornut/imgui_test_engine/archive/v1.92.7.tar.gz"
-      sha256: "3bb2320044854abb479facdde01c38c8af2e0257a630eb4b582b100a4fa60043"
-  "1.92.7-docking":
+      url: "https://github.com/ocornut/imgui_test_engine/archive/v1.92.8.tar.gz"
+      sha256: "66411ef3a0b7d42183a96cba079bceef8fa2c79f5d3507f8a183cbcc1d33ecc2"
+  "1.92.8-docking":
     core:
-      url: "https://github.com/ocornut/imgui/archive/v1.92.7-docking.tar.gz"
-      sha256: "2c58e28c957497eba0ed01c48a0bc5f118ec5f10a1c3721ba9436253a623bd72"
+      url: "https://github.com/ocornut/imgui/archive/v1.92.8-docking.tar.gz"
+      sha256: "ca0653454ed371b7a87e9b0bc29a5d15c9be7f7c0fbe778042fc48c71df1d3d8"
     testengine:
-      url: "https://github.com/ocornut/imgui_test_engine/archive/v1.92.7.tar.gz"
-      sha256: "3bb2320044854abb479facdde01c38c8af2e0257a630eb4b582b100a4fa60043"
+      url: "https://github.com/ocornut/imgui_test_engine/archive/v1.92.8.tar.gz"
+      sha256: "66411ef3a0b7d42183a96cba079bceef8fa2c79f5d3507f8a183cbcc1d33ecc2"
   "1.91.8":
     core:
       url: "https://github.com/ocornut/imgui/archive/v1.91.8.tar.gz"

--- a/recipes/imgui/config.yml
+++ b/recipes/imgui/config.yml
@@ -1,7 +1,7 @@
 versions:
-  "1.92.7":
+  "1.92.8":
     folder: all
-  "1.92.7-docking":
+  "1.92.8-docking":
     folder: all
   "1.91.8":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **imgui/1.92.8**

#### Motivation
Regular update with number of changes.

#### Details
* https://github.com/ocornut/imgui/releases/tag/v1.92.8
* https://github.com/ocornut/imgui/compare/v1.92.7...v1.92.8

Only build related changes I see are in the example vcxproj files:
```
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
```

I'd assume this is nothing that we need to care about? But Win is not my platform, so no clue what exactly the difference means.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
