### PR TITLE
Pybind usage for embed executables should directly link the embed target

### DIFF
--- a/recipes/pybind11_json/all/test_package/CMakeLists.txt
+++ b/recipes/pybind11_json/all/test_package/CMakeLists.txt
@@ -6,5 +6,4 @@ set(CMAKE_CXX_STANDARD 11)
 find_package(pybind11_json REQUIRED CONFIG)
 
 add_executable(test_package test_package.cpp)
- # FIXME: target should be pybind11_json, replace once Conan v1 has been dropped
-target_link_libraries(test_package PUBLIC pybind11_json::pybind11_json)
+target_link_libraries(test_package PUBLIC pybind11_json::pybind11_json pybind11::embed)


### PR DESCRIPTION
Closes https://github.com/conan-io/conan/issues/19974, which after discussing with the team, it's not a CMakeConfigDeps (Where CMakeDeps was indeed overlinking), but a misunderstanding of the pybind11 recipe usage.

While the issue of recipes that link against a system lib via a build-module still might pop up, it's not a concern right now

cc @memsharded @jcar87 after discussing with them

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
