### PR TITLE
Add qtlogger recipe version 0.11.1

### DIFF
--- a/recipes/qtlogger/all/conandata.yml
+++ b/recipes/qtlogger/all/conandata.yml
@@ -1,0 +1,5 @@
+sources:
+  "0.11.1":
+    url:
+    - "https://github.com/yamixst/qtlogger/archive/refs/tags/v0.11.1.tar.gz"
+    sha256: "96ca7a9f20b7960f00dfddeb057db21788b4ee3e612d32204ec884d8d8e99819"

--- a/recipes/qtlogger/all/conanfile.py
+++ b/recipes/qtlogger/all/conanfile.py
@@ -1,0 +1,133 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, load, apply_conandata_patches
+from conan.tools.scm import Version
+import os
+import re
+
+required_conan_version = ">=2.0.9"
+
+class QtLoggerConan(ConanFile):
+    name = "qtlogger"
+    description = "Advanced Qt logging library with configurable pipelines, formatters, and sinks"
+    license = "MIT"
+    url = "https://github.com/yamixst/qtlogger"
+    homepage = "https://github.com/yamixst/qtlogger"
+    topics = ("qt", "logging", "logger", "qt6")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "with_network": [True, False],
+        "with_thread": [True, False],
+        "with_journal": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "with_network": False,
+        "with_thread": True,
+        "with_journal": False,
+    }
+
+    @property
+    def _min_qt_version(self):
+        return "6.0"
+
+    def set_version(self):
+        version_h = load(self, os.path.join(self.recipe_folder, "src", "qtlogger", "version.h"))
+        match = re.search(r"#define\s+QTLOGGER_VERSION\s+([0-9]+\.[0-9]+\.[0-9]+)", version_h)
+        if not match:
+            raise ConanInvalidConfiguration("Unable to determine version from src/qtlogger/version.h")
+        self.version = match.group(1)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+        self.options["qt"].gui = False
+        self.options["qt"].widgets = False
+
+    def layout(self):
+        cmake_layout(self, src_folder=".")
+
+    def requirements(self):
+        qt_ref = f"qt/[>={self._min_qt_version} <7]"
+        self.requires(qt_ref, transitive_headers=True, transitive_libs=True)
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, 17)
+
+        qt = self.dependencies["qt"]
+        if Version(str(qt.ref.version)) < self._min_qt_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires qt version >= {self._min_qt_version}"
+            )
+
+        if self.options.with_journal:
+            raise ConanInvalidConfiguration(
+                "with_journal is not supported in this Conan recipe because it requires the system libsystemd"
+            )
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.16 <4]")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["QTLOGGER_NO_EXAMPLES"] = True
+        tc.variables["QTLOGGER_NO_TESTS"] = True
+        tc.variables["QTLOGGER_LIBRARY"] = self.options.shared
+        tc.variables["QTLOGGER_NETWORK"] = self.options.with_network
+        tc.variables["QTLOGGER_NO_THREAD"] = not self.options.with_thread
+        tc.variables["QTLOGGER_JOURNAL"] = self.options.with_journal
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        apply_conandata_patches(self)
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["qtlogger"]
+        self.cpp_info.requires = ["qt::qtCore"]
+        self.cpp_info.set_property("cmake_file_name", "qtlogger")
+        self.cpp_info.set_property("cmake_target_name", "qtlogger::qtlogger")
+
+        if self.options.with_network:
+            self.cpp_info.requires.append("qt::qtNetwork")
+
+        if not self.options.with_thread:
+            self.cpp_info.defines.append("QTLOGGER_NO_THREAD")
+
+        if self.options.with_network:
+            self.cpp_info.defines.append("QTLOGGER_NETWORK")
+
+        if not self.options.shared:
+            self.cpp_info.defines.append("QTLOGGER_STATIC")
+
+        if self.settings.os == "Macos":
+            self.cpp_info.defines.append("QTLOGGER_OSLOG")
+        elif self.settings.os == "Android":
+            self.cpp_info.defines.append("QTLOGGER_ANDROIDLOG")
+        elif self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.defines.append("QTLOGGER_SYSLOG")

--- a/recipes/qtlogger/all/test_package/CMakeLists.txt
+++ b/recipes/qtlogger/all/test_package/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.16)
+project(test_package LANGUAGES CXX)
+
+find_package(qtlogger REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE qtlogger::qtlogger)
+
+set_target_properties(test_package PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+)

--- a/recipes/qtlogger/all/test_package/conanfile.py
+++ b/recipes/qtlogger/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/qtlogger/all/test_package/test_package.cpp
+++ b/recipes/qtlogger/all/test_package/test_package.cpp
@@ -1,0 +1,14 @@
+#include <QCoreApplication>
+
+#include <qtlogger/qtlogger.h>
+
+int main(int argc, char *argv[])
+{
+    QCoreApplication app(argc, argv);
+
+    gQtLogger.configure();
+    
+    qInfo("qtlogger test package");
+
+    return 0;
+}

--- a/recipes/qtlogger/config.yml
+++ b/recipes/qtlogger/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.11.1":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe: **qtlogger/0.11.1**

#### Motivation
This PR adds a new recipe for **qtlogger** version 0.11.1 — an advanced Qt logging library with configurable pipelines, formatters, and sinks. The library provides a flexible logging framework for Qt6 applications with support for various backends (syslog, OSLog, Android log, network sinks) and optional thread-aware logging.

#### Details
The new recipe includes:

- **conanfile.py** — Full Conan recipe with support for:
  - Shared/static library builds
  - Optional features: `with_network`, `with_thread`, `with_journal`
  - C++17 minimum requirement
  - Qt6 dependency (`>=6.0 <7`) with transitive headers/libs
  - Proper CMake integration via `CMakeToolchain` and `CMakeDeps`
  - Automatic version detection from `src/qtlogger/version.h`
  - Platform-specific defines for OSLog (macOS), AndroidLog, and Syslog (Linux/FreeBSD)
  - Conan 2.x compatibility (`required_conan_version >= 2.0.9`)

- **conandata.yml** — Sources definition with SHA256 verification

- **config.yml** — Version-to-folder mapping

- **test_package/** — A minimal test that verifies the library can be consumed via CMake's `find_package` and the logger can be configured and used at runtime
