### PR TITLE
[vvl] Removing CMAKE fpic replacement

### DIFF
--- a/recipes/vulkan-validationlayers/all/conanfile.py
+++ b/recipes/vulkan-validationlayers/all/conanfile.py
@@ -75,8 +75,7 @@ class VulkanValidationLayersConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
-        for text in ["set(CMAKE_CXX_STANDARD 17)", "set(CMAKE_CXX_STANDARD_REQUIRED ON)",
-                     "set(CMAKE_POSITION_INDEPENDENT_CODE ON)"]:
+        for text in ["set(CMAKE_CXX_STANDARD 17)", "set(CMAKE_CXX_STANDARD_REQUIRED ON)"]:
             replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
                             text, "")
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **vulkan-validationlayers/1.4.350.0**

#### Motivation
Build on Linux is failing with:

```bash
[ 99%] Building CXX object layers/CMakeFiles/vvl.dir/utils/spirv_tools_utils.cpp.o
[ 99%] Building CXX object layers/CMakeFiles/vvl.dir/layer_options.cpp.o
[100%] Linking CXX shared module libVkLayer_khronos_validation.so
/opt/cci/gcc13-rev0/x86_64-linux-gnu/lib/gcc/x86_64-linux-gnu/13.4.0/../../../../x86_64-linux-gnu/bin/ld: libVkLayer_utils.a(image_utils.cpp.o): warning: relocation against `_ZTVNSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEEE@@GLIBCXX_3.4.21' in read-only section `.text.unlikely'
/opt/cci/gcc13-rev0/x86_64-linux-gnu/lib/gcc/x86_64-linux-gnu/13.4.0/../../../../x86_64-linux-gnu/bin/ld: gpuav/spirv/libgpu_av_spirv.a(descriptor_indexing_oob_pass.cpp.o): relocation R_X86_64_PC32 against symbol `_ZSt4cout@@GLIBCXX_3.4' can not be used when making a shared object; recompile with -fPIC
/opt/cci/gcc13-rev0/x86_64-linux-gnu/lib/gcc/x86_64-linux-gnu/13.4.0/../../../../x86_64-linux-gnu/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status
gmake[2]: *** [layers/CMakeFiles/vvl.dir/build.make:3146: layers/libVkLayer_khronos_validation.so] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:213: layers/CMakeFiles/vvl.dir/all] Error 2
gmake: *** [Makefile:136: all] Error 2

vulkan-validationlayers/1.4.350.0: ERROR: 
Package '180ed4b9a4e507790634d2ce7826d64aa335a66b' build failed
vulkan-validationlayers/1.4.350.0: WARN: Build folder /tmp/workspace/cci/tph-prod/conan-home/p/b/vulka7ab9e63970b72/b/build/Release
ERROR: vulkan-validationlayers/1.4.350.0: Error in build() method, line 106
	cmake.build()
	ConanException: Error 2 while executing
```

#### Details
I just checked the original commit: https://github.com/KhronosGroup/Vulkan-ValidationLayers/commit/a8ee379cae0d5c506aa26e8b2af1d4f27af18cee
So, I think it makes sense to keep this as Conan does not manage it because of its `package_type="shared-library"`

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
