### PR TITLE
cloudini/1.2.1: new recipe

### DIFF
--- a/recipes/cloudini/all/conandata.yml
+++ b/recipes/cloudini/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.2.1":
+    url: "https://github.com/facontidavide/cloudini/archive/refs/tags/1.2.1.tar.gz"
+    sha256: "02be413fefdcf2630b759811b796097f9bd887b03b5ca66c72d1e251a5138e8b"

--- a/recipes/cloudini/all/conanfile.py
+++ b/recipes/cloudini/all/conanfile.py
@@ -6,7 +6,6 @@ from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get
 from conan.tools.microsoft import is_msvc
-from conan.tools.scm import Version
 
 required_conan_version = ">=2.0.9"
 
@@ -34,24 +33,11 @@ class CloudiniConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        # LZ4 and ZSTD are PRIVATE-linked in upstream and not exposed in
-        # public headers, so consumers do not need their includes.
-        self.requires("lz4/1.10.0", transitive_headers=False)
-        self.requires("zstd/1.5.7", transitive_headers=False)
+        self.requires("lz4/[>=1.9.4 <2]")
+        self.requires("zstd/[>=1.5 <1.6]")
 
     def validate(self):
         check_min_cppstd(self, 20)
-        min_versions = {
-            "gcc": "10",
-            "clang": "12",
-            "apple-clang": "13",
-        }
-        compiler = str(self.settings.compiler)
-        minv = min_versions.get(compiler)
-        if minv and Version(self.settings.compiler.version) < minv:
-            raise ConanInvalidConfiguration(
-                f"{self.ref} requires {compiler} >= {minv} for C++20 support"
-            )
         if is_msvc(self):
             raise ConanInvalidConfiguration(
                 f"{self.ref} has not been tested with MSVC. "
@@ -59,7 +45,7 @@ class CloudiniConan(ConanFile):
             )
 
     def build_requirements(self):
-        self.tool_requires("cmake/[>=3.16 <4]")
+        self.tool_requires("cmake/[>=3.16]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/cloudini/all/conanfile.py
+++ b/recipes/cloudini/all/conanfile.py
@@ -1,0 +1,103 @@
+import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get
+from conan.tools.microsoft import is_msvc
+from conan.tools.scm import Version
+
+required_conan_version = ">=2.0.9"
+
+
+class CloudiniConan(ConanFile):
+    name = "cloudini"
+    description = "Point cloud compression library for ROS, MCAP and Foxglove"
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/facontidavide/cloudini"
+    topics = ("point-cloud", "compression", "ros", "ros2", "mcap", "lidar")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+    implements = ["auto_shared_fpic"]
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        # LZ4 and ZSTD are PRIVATE-linked in upstream and not exposed in
+        # public headers, so consumers do not need their includes.
+        self.requires("lz4/1.10.0", transitive_headers=False)
+        self.requires("zstd/1.5.7", transitive_headers=False)
+
+    def validate(self):
+        check_min_cppstd(self, 20)
+        min_versions = {
+            "gcc": "10",
+            "clang": "12",
+            "apple-clang": "13",
+        }
+        compiler = str(self.settings.compiler)
+        minv = min_versions.get(compiler)
+        if minv and Version(self.settings.compiler.version) < minv:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires {compiler} >= {minv} for C++20 support"
+            )
+        if is_msvc(self):
+            raise ConanInvalidConfiguration(
+                f"{self.ref} has not been tested with MSVC. "
+                "Please open an issue at https://github.com/facontidavide/cloudini if you need MSVC support."
+            )
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.16 <4]")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.cache_variables["CLOUDINI_FORCE_VENDORED_DEPS"] = False
+        tc.cache_variables["CLOUDINI_BUILD_TOOLS"] = False
+        tc.cache_variables["CLOUDINI_BUILD_BENCHMARKS"] = False
+        tc.cache_variables["BUILD_TESTING"] = False
+        tc.generate()
+        deps = CMakeDeps(self)
+        # Upstream's CMakeLists references LZ4::lz4_static and zstd::libzstd_static
+        # explicitly. CCI's lz4/zstd recipes export these names when their `shared`
+        # option is False (matching our default). The set_property overrides keep
+        # this working even if a consumer forces lz4/zstd to shared via `-o *:shared=True`.
+        deps.set_property("lz4", "cmake_target_name", "LZ4::lz4_static")
+        deps.set_property("zstd", "cmake_target_name", "zstd::libzstd_static")
+        deps.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure(build_script_folder=os.path.join(self.source_folder, "cloudini_lib"))
+        cmake.build()
+
+    def package(self):
+        copy(
+            self,
+            "LICENSE",
+            src=self.source_folder,
+            dst=os.path.join(self.package_folder, "licenses"),
+        )
+        CMake(self).install()
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "cloudini")
+        self.cpp_info.set_property("cmake_target_name", "cloudini::cloudini")
+        self.cpp_info.libs = ["cloudini_lib"]
+        self.cpp_info.includedirs = ["include"]
+        if self.settings.os in ("Linux", "FreeBSD"):
+            self.cpp_info.system_libs.extend(["m", "pthread"])

--- a/recipes/cloudini/all/test_package/CMakeLists.txt
+++ b/recipes/cloudini/all/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.16)
+project(test_package CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(cloudini REQUIRED CONFIG)
+
+add_executable(test_package test_package.cpp)
+target_link_libraries(test_package PRIVATE cloudini::cloudini)

--- a/recipes/cloudini/all/test_package/CMakeLists.txt
+++ b/recipes/cloudini/all/test_package/CMakeLists.txt
@@ -1,8 +1,5 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.15)
 project(test_package CXX)
-
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(cloudini REQUIRED CONFIG)
 

--- a/recipes/cloudini/all/test_package/conanfile.py
+++ b/recipes/cloudini/all/test_package/conanfile.py
@@ -1,0 +1,27 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(cmd, env="conanrun")

--- a/recipes/cloudini/all/test_package/test_package.cpp
+++ b/recipes/cloudini/all/test_package/test_package.cpp
@@ -1,0 +1,12 @@
+#include <cstdio>
+
+#include <cloudini_lib/cloudini.hpp>
+
+int main() {
+    // Force a link-time reference to a non-inline symbol defined in
+    // src/codec_common.cpp, proving the library is correctly linked.
+    std::printf(
+        "cloudini test_package: ToString(ZSTD) = %s\n",
+        Cloudini::ToString(Cloudini::CompressionOption::ZSTD));
+    return 0;
+}

--- a/recipes/cloudini/config.yml
+++ b/recipes/cloudini/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.2.1":
+    folder: all


### PR DESCRIPTION
## Specify library name and version

cloudini/1.2.1

## Description

Cloudini is a high-performance point cloud compression library implementing a two-stage approach: custom encoding for pointcloud fields followed by LZ4/ZSTD. It's used in ROS 2 (`point_cloud_transport` plugin), MCAP rosbag tooling, and Foxglove. This recipe packages the standalone C++20 library (`cloudini_lib`) — the ROS plugins and Foxglove extension are out of scope.

Homepage: https://github.com/facontidavide/cloudini
License: Apache-2.0

## Recipe notes

- C++20 required; gcc ≥ 10, clang ≥ 12, apple-clang ≥ 13.
- MSVC is not yet supported by upstream; the recipe raises `ConanInvalidConfiguration` for it. Will be revisited in a follow-up version.
- `lz4/1.10.0` and `zstd/1.5.7` are PRIVATE link dependencies (`transitive_headers=False`); their headers are not exposed in cloudini's public API.
- Upstream's CMakeLists references `LZ4::lz4_static` and `zstd::libzstd_static` explicitly; the recipe sets `cmake_target_name` on those deps defensively so the static target names are produced even when consumers force `*:shared=True`.
- Tools (`cloudini_rosbag_converter`, `mcap_cutter`, etc.), benchmarks, and tests are disabled via cache variables — only the library is packaged.
- `compiler.cppstd` and `compiler.libcxx` are intentionally NOT `rm_safe`d, because cloudini's public headers expose `std::vector`, `std::span`, etc. — types whose ABI varies across `-std` levels and across libstdc++/libc++.

## Local validation

Validated with Conan 2.27.1 on Linux x86_64 / gcc 15.2:

- `conan create recipes/cloudini/all --version=1.2.1` → static Release ✓
- `conan create recipes/cloudini/all --version=1.2.1 -o "&:shared=True"` → shared Release ✓
- `conan create recipes/cloudini/all --version=1.2.1 -s build_type=Debug` → static Debug ✓

`test_package` calls `Cloudini::ToString(Cloudini::CompressionOption::ZSTD)` (non-inline, defined in `src/codec_common.cpp`) to prove the library is actually linked, not just header-included.

---

- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've signed off every commit (`git commit -s`).