### PR TITLE
[p7zip] Honor tools.build:compiler_executables

### DIFF
--- a/recipes/p7zip/all/conanfile.py
+++ b/recipes/p7zip/all/conanfile.py
@@ -43,37 +43,14 @@ class PSevenZipConan(ConanFile):
         tc.generate()
 
     def _patch_compiler(self):
-        compilers_from_conf = self.conf.get("tools.build:compiler_executables", default={}, check_type=dict)
-        cc_from_conf = compilers_from_conf.get("c", "")
-        if cc_from_conf:
-            cc = cc_from_conf
-        else:
-            cc = "clang" if "clang" in str(self.settings.compiler) else str(self.settings.compiler)
-
-        cxx_from_conf = compilers_from_conf.get("cpp", "")
-        if cxx_from_conf:
-            cxx = cxx_from_conf
-        else:
-            cxx = "clang++" if "clang" in str(self.settings.compiler) else str(self.settings.compiler)
-            if self.settings.compiler == "gcc":
-                cxx = "g++"
-
-        # Replace the hard-coded compilers instead of using the 40 different Makefile permutations
+        # let the script fall back to the default compiler (environment, or from AutotoolsToolchain)
         replace_in_file(self, os.path.join(self.source_folder, "makefile.machine"),
-                              "CC=gcc", f"CC={cc}")
+                              "CC=gcc", "CC ?= cc")
         replace_in_file(self, os.path.join(self.source_folder, "makefile.machine"),
-                              "CXX=g++", f"CXX={cxx}")
-
-        optflags = ''
-        if is_apple_os(self):
-            optflags = '-arch ' + to_apple_arch(self)
-        # Manually modify the -O flag here based on the build type
-        optflags += " -O2" if self.settings.build_type == "Release" else " -O0"
-        # Silence the warning about `-s` not being valid on clang
-        if cc != "clang":
-            optflags += ' -s'
+                              "CXX=g++", "CXX ?= c++")
+        # respect the CFLAGS set by AutotoolsToolchain
         replace_in_file(self, os.path.join(self.source_folder, "makefile.machine"),
-                            "OPTFLAGS=-O -s", "OPTFLAGS=" + optflags)
+                                "OPTFLAGS=", "OPTFLAGS := $(CFLAGS) ")
 
     def _patch_sources(self):
         apply_conandata_patches(self)

--- a/recipes/p7zip/all/conanfile.py
+++ b/recipes/p7zip/all/conanfile.py
@@ -43,18 +43,30 @@ class PSevenZipConan(ConanFile):
         tc.generate()
 
     def _patch_compiler(self):
-        optflags = ''
-        if is_apple_os(self):
-            optflags = '-arch ' + to_apple_arch(self)
-        cc = "clang" if "clang" in str(self.settings.compiler) else str(self.settings.compiler)
-        cxx = "clang++" if "clang" in str(self.settings.compiler) else str(self.settings.compiler)
-        if self.settings.compiler == "gcc":
-            cxx = "g++"
+        compilers_from_conf = self.conf.get("tools.build:compiler_executables", default={}, check_type=dict)
+        cc_from_conf = compilers_from_conf.get("c", "")
+        if cc_from_conf:
+            cc = cc_from_conf
+        else:
+            cc = "clang" if "clang" in str(self.settings.compiler) else str(self.settings.compiler)
+
+        cxx_from_conf = compilers_from_conf.get("cpp", "")
+        if cxx_from_conf:
+            cxx = cxx_from_conf
+        else:
+            cxx = "clang++" if "clang" in str(self.settings.compiler) else str(self.settings.compiler)
+            if self.settings.compiler == "gcc":
+                cxx = "g++"
+
         # Replace the hard-coded compilers instead of using the 40 different Makefile permutations
         replace_in_file(self, os.path.join(self.source_folder, "makefile.machine"),
                               "CC=gcc", f"CC={cc}")
         replace_in_file(self, os.path.join(self.source_folder, "makefile.machine"),
                               "CXX=g++", f"CXX={cxx}")
+
+        optflags = ''
+        if is_apple_os(self):
+            optflags = '-arch ' + to_apple_arch(self)
         # Manually modify the -O flag here based on the build type
         optflags += " -O2" if self.settings.build_type == "Release" else " -O0"
         # Silence the warning about `-s` not being valid on clang
@@ -79,9 +91,5 @@ class PSevenZipConan(ConanFile):
         copy(self, "7za", src=os.path.join(self.source_folder, "bin"), dst=os.path.join(self.package_folder, "bin"))
 
     def package_info(self):
-        bin_path = os.path.join(self.package_folder, "bin")
-        self.output.info(f"Appending PATH environment variable: {bin_path}")
-        self.env_info.PATH.append(bin_path)
-
         self.cpp_info.includedirs = []
         self.cpp_info.libdirs = []


### PR DESCRIPTION
### Summary
Changes to recipe:  **p7zip**

#### Motivation
Currently the recipe doesn't honor the compiler configured on the profiles through `tools.build:compiler_executables` 

#### Details
I've noticed this recipe fails to build on my Ubuntu box where I don't have the default `gcc` installed, so there is no "plain" `gcc` executable. I only hace `gcc--11` installed and that's what I have set up on my profiles using `tools.build:compiler_executables`.
This recipe does not honor this config and instead has some logic to figure out which compiler to use.
This simple patch make `tools.build:compiler_executables` take precedence over said logic.


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
