### PR TITLE
[perf] Support crosscompilation

### DIFF
--- a/recipes/perf/all/conanfile.py
+++ b/recipes/perf/all/conanfile.py
@@ -6,7 +6,7 @@ from conan.tools.files import apply_conandata_patches, chdir, copy, export_conan
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.layout import basic_layout
 
-required_conan_version = ">=1.47.0"
+required_conan_version = ">=2.0"
 
 
 class Perf(ConanFile):
@@ -101,8 +101,3 @@ class Perf(ConanFile):
         self.cpp_info.libdirs = []
         self.cpp_info.resdirs = []
         self.cpp_info.includedirs = []
-
-        # TODO: remove in conan v2
-        bin_path = os.path.join(self.package_folder, "bin")
-        self.output.info(f"Appending PATH environment variable: {bin_path}")
-        self.env_info.PATH.append(bin_path)

--- a/recipes/perf/all/conanfile.py
+++ b/recipes/perf/all/conanfile.py
@@ -5,7 +5,6 @@ from conan.errors import ConanInvalidConfiguration
 from conan.tools.files import apply_conandata_patches, chdir, copy, export_conandata_patches, get
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.layout import basic_layout
-from conan.errors import ConanException
 
 required_conan_version = ">=1.47.0"
 

--- a/recipes/perf/all/conanfile.py
+++ b/recipes/perf/all/conanfile.py
@@ -21,22 +21,35 @@ class Perf(ConanFile):
     package_type = "application"
     settings = "os", "arch", "compiler", "build_type"
 
-    def _get_perf_arch(self):
-        # perf has a strict set of values it can take for the ARCH env variable
-        # it must match the name of one of the subfolders from the arch folder
-        conan_arch_prefix_to_perf_arch_map = {
-            "armv7": "arm",
-            "armv8": "arm64",
-            "x86": "x86",
-            "mips": "mips",
-            "riscv": "riscv",
-        }
-
-        for conan_arch_prefix, perf_arch in conan_arch_prefix_to_perf_arch_map.items():
-            if str(self.settings.arch).startswith(conan_arch_prefix):
-                return perf_arch
-
-        raise ConanException(f'{self.settings.arch} not yet supported by this recipe')
+    def _get_linux_arch(self):
+        # INFO: Map based on https://github.com/torvalds/linux/tree/master/arch
+        arch = str(self.settings.arch)
+        if arch.startswith("armv8"):
+            return "arm64"
+        if arch.startswith("armv"):
+            return "arm"
+        if arch.startswith("ppc"):
+            return "powerpc"
+        if arch.startswith("e2k-"):
+            return "e2k"
+        if arch.startswith("xtensa"):
+            return "xtensa"
+        if arch.startswith("tc"):
+            return "arc"
+        if arch.startswith("riscv"):
+            return "riscv"
+        if arch.startswith("sparc"):
+            return "sparc"
+        if arch.startswith("mips"):
+            return "mips"
+        if arch.startswith("s390"):
+            return "s390"
+        if arch.startswith("x86"):
+            return "x86"
+        if arch.startswith("avr"):
+            return "avr"
+        if arch.startswith("sh4le"):
+            return "sh"
 
     def export_sources(self):
         export_conandata_patches(self)
@@ -50,6 +63,8 @@ class Perf(ConanFile):
     def validate(self):
         if self.settings.os not in ["Linux", "FreeBSD"]:
             raise ConanInvalidConfiguration("perf is supported only on Linux")
+        if not self._get_linux_arch():
+            raise ConanInvalidConfiguration(f"Unsupported architecture: {self.settings.arch}")
 
     def build_requirements(self):
         self.tool_requires("flex/2.6.4")
@@ -62,7 +77,7 @@ class Perf(ConanFile):
         tc = AutotoolsToolchain(self)
         tc.make_args += ["NO_LIBPYTHON=1"]
         tc.make_args += ["WERROR=0"]
-        tc.make_args += [f"ARCH={self._get_perf_arch()}"]
+        tc.make_args += [f"ARCH={self._get_linux_arch()}"]
         tc.generate()
 
     def build(self):

--- a/recipes/perf/all/test_package/conanfile.py
+++ b/recipes/perf/all/test_package/conanfile.py
@@ -10,5 +10,3 @@ class TestPackageConan(ConanFile):
     def test(self):
         if can_run(self):
             self.run("perf --version", env="conanrun")
-
-

--- a/recipes/perf/all/test_package/conanfile.py
+++ b/recipes/perf/all/test_package/conanfile.py
@@ -1,13 +1,14 @@
 from conan import ConanFile
-
+from conan.tools.build import can_run
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "VirtualBuildEnv"
-    test_type = "explicit"
 
-    def build_requirements(self):
-        self.tool_requires(self.tested_reference_str)
+    def requirements(self):
+        self.requires(self.tested_reference_str)
 
     def test(self):
-        self.run("perf version")
+        if can_run(self):
+            self.run("perf --version", env="conanrun")
+
+

--- a/recipes/perf/all/test_package/conanfile.py
+++ b/recipes/perf/all/test_package/conanfile.py
@@ -1,8 +1,12 @@
 from conan import ConanFile
 from conan.tools.build import can_run
+from conan.tools.layout import basic_layout
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
+
+    def layout(self):
+        basic_layout(self)
 
     def requirements(self):
         self.requires(self.tested_reference_str)


### PR DESCRIPTION
### Summary
Changes to recipe:  **perf**

#### Motivation
I need to crosscompile perf.

#### Details
If you try to crosscompile this recipe (e.g. `linux@x86_64` -> `linux@arm`) you get all sorts of errors, like
```
arch/x86/util/header.c: In function 'get_cpuid':
arch/x86/util/header.c:17:2: error: impossible constraint in 'asm'
  __asm__ __volatile__ (".byte 0x53\n\tcpuid\n\t"
  ^~~~~~~
arch/x86/util/header.c:17:2: error: impossible constraint in 'asm'
  __asm__ __volatile__ (".byte 0x53\n\tcpuid\n\t"
  ^~~~~~~
```
This is because the `ARCH` env variable is not being properly set so the build system does not understand that it is crosscompiling.

After this patch crosscompilation works fine.
```
  CC      util/expr.o
  LD      util/intel-pt-decoder/perf-in.o
  LD      util/perf-in.o
  LD      perf-in.o
  LINK    perf

perf/5.13: Package '85c999356992c5713d308db1a4d7bab6bf572f27' built
```

Since I was working on this recipe, I've also updated the test package.

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
