### PR TITLE
protobuf: Add version 6.34.2

### DIFF
--- a/recipes/protobuf/all/conandata.yml
+++ b/recipes/protobuf/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "6.34.2":
+    url: "https://github.com/protocolbuffers/protobuf/releases/download/v34.2/protobuf-34.2.tar.gz"
+    sha256: "d1e04237fa1a9f141f943ff0302b4fe241cd88ecd1a2e76b4bc9bb77c7fc2345"
   "6.33.5":
     url: "https://github.com/protocolbuffers/protobuf/releases/download/v33.5/protobuf-33.5.tar.gz"
     sha256: "c6c7c27fadc19d40ab2eaa23ff35debfe01f6494a8345559b9bb285ce4144dd1"
@@ -7,6 +10,42 @@ sources:
     sha256: "877bf9f880631aa31daf2c09896276985696728137fcd43cc534a28c5566d9ba"
 absl_deps:
   # reference: https://github.com/protocolbuffers/protobuf/blob/main/cmake/abseil-cpp.cmake
+  "6.34.2":
+    - absl_absl_check
+    - absl_absl_log
+    - absl_algorithm
+    - absl_base
+    - absl_bind_front
+    - absl_bits
+    - absl_btree
+    - absl_cleanup
+    - absl_cord
+    - absl_core_headers
+    - absl_debugging
+    - absl_die_if_null
+    - absl_dynamic_annotations
+    - absl_flags
+    - absl_flat_hash_map
+    - absl_flat_hash_set
+    - absl_function_ref
+    - absl_hash
+    - absl_layout
+    - absl_log_initialize
+    - absl_log_globals
+    - absl_log_severity
+    - absl_memory
+    - absl_node_hash_map
+    - absl_node_hash_set
+    - absl_optional
+    - absl_random_distributions
+    - absl_random_random
+    - absl_span
+    - absl_status
+    - absl_statusor
+    - absl_strings
+    - absl_synchronization
+    - absl_time
+    - absl_utility
   "6.33.5":
     - absl_absl_check
     - absl_absl_log

--- a/recipes/protobuf/config.yml
+++ b/recipes/protobuf/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "6.34.2":
+    folder: all
   "6.33.5":
     folder: all
   "5.29.6":


### PR DESCRIPTION
### Summary
Changes to recipe:  **protobuf/6.34.2**

#### Motivation
Add new version 6.34.2

#### Details

- add Conan version `6.34.2` for upstream protobuf release `v34.2`
- add source entry `https://github.com/protocolbuffers/protobuf/releases/download/v34.2/protobuf-34.2.tar.gz`
- add SHA-256 `d1e04237fa1a9f141f943ff0302b4fe241cd88ecd1a2e76b4bc9bb77c7fc2345`
- add the `absl_deps` list for `6.34.2` from the upstream `cmake/abseil-cpp.cmake`

Add support for latest version in 6.34 series of google protobuf

Add new version to yaml - test build on MacOS w/ XCode 16.4 with C++17


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
