### PR TITLE
ms-gsl: Replace version 4.2.1 with newer version 4.2.2

### DIFF
--- a/recipes/ms-gsl/all/conandata.yml
+++ b/recipes/ms-gsl/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "4.2.1":
-    url: "https://github.com/microsoft/GSL/archive/v4.2.1.tar.gz"
-    sha256: "d959f1cb8bbb9c94f033ae5db60eaf5f416be1baa744493c32585adca066fe1f"
+  "4.2.2":
+    url: "https://github.com/microsoft/GSL/archive/v4.2.2.tar.gz"
+    sha256: "59e2a0a0ea22e8bcf9db2dc4d4bd21212ac6595748295fc27a7e02cf75eac4b5"
   "4.2.0":
     url: "https://github.com/microsoft/GSL/archive/v4.2.0.tar.gz"
     sha256: "2c717545a073649126cb99ebd493fa2ae23120077968795d2c69cbab821e4ac6"

--- a/recipes/ms-gsl/config.yml
+++ b/recipes/ms-gsl/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "4.2.1":
+  "4.2.2":
     folder: all
   "4.2.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **ms-gsl/4.2.2**

#### Motivation
Bugfixes in the GSL library since 4.2.1

Fix MSVC's C4875 when compiling GSL 4.2.1 with latest MSVC toolset. https://github.com/microsoft/GSL/pull/1243

#### Details
new version 4.2.2 replace version 4.2.1
Built packages on MacOS w/ XCode 16.4 & Conan version 2.28.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
