### PR TITLE
fltk, os x: add UniformTypeIdentifiers framework

### DIFF
--- a/recipes/fltk/all/conanfile.py
+++ b/recipes/fltk/all/conanfile.py
@@ -132,10 +132,11 @@ class FltkConan(ConanFile):
         elif is_apple_os(self):
             self.cpp_info.frameworks = [
                 "AppKit", "ApplicationServices", "Carbon", "Cocoa", "CoreFoundation", "CoreGraphics",
-                "CoreText", "CoreVideo", "Foundation", "IOKit", "UniformTypeIdentifiers"
+                "CoreText", "CoreVideo", "Foundation", "IOKit"
             ]
-            self.cpp_info.sharedlinkflags.append("-Wl,-weak_framework,ScreenCaptureKit")
-            self.cpp_info.exelinkflags.append("-Wl,-weak_framework,ScreenCaptureKit")
+            for weak_framework in ["ScreenCaptureKit", "UniformTypeIdentifiers"]:
+                self.cpp_info.sharedlinkflags.append(f"-Wl,-weak_framework,{weak_framework}")
+                self.cpp_info.exelinkflags.append(f"-Wl,-weak_framework,{weak_framework}")
             if self.options.with_gl:
                 self.cpp_info.frameworks.append("OpenGL")
         elif self.settings.os == "Windows":

--- a/recipes/fltk/all/conanfile.py
+++ b/recipes/fltk/all/conanfile.py
@@ -132,7 +132,7 @@ class FltkConan(ConanFile):
         elif is_apple_os(self):
             self.cpp_info.frameworks = [
                 "AppKit", "ApplicationServices", "Carbon", "Cocoa", "CoreFoundation", "CoreGraphics",
-                "CoreText", "CoreVideo", "Foundation", "IOKit",
+                "CoreText", "CoreVideo", "Foundation", "IOKit", "UniformTypeIdentifiers"
             ]
             self.cpp_info.sharedlinkflags.append("-Wl,-weak_framework,ScreenCaptureKit")
             self.cpp_info.exelinkflags.append("-Wl,-weak_framework,ScreenCaptureKit")
@@ -146,5 +146,5 @@ class FltkConan(ConanFile):
                 self.cpp_info.system_libs.append("gdiplus")
             if self.options.with_gl:
                 self.cpp_info.system_libs.append("opengl32")
-            
+
             self.cpp_info.system_libs.append("ws2_32")


### PR DESCRIPTION
### Summary
Changes to recipe:  **fltk/1.4.x**

#### Motivation
I met a bug and found a fix

#### Details

When linking with recent fltk library

```
[ 88%] Linking CXX executable syncspirit-fltk.app/Contents/MacOS/syncspirit-fltk
```

I got the error:

```
ld: warning: -s is obsolete
Undefined symbols for architecture arm64:
  "_OBJC_CLASS_$_UTType", referenced from:
       in libfltk.a[176](Fl_Native_File_Chooser_MAC.mm.o)
ld: symbol(s) not found for architecture arm64
```

The issue is originally mentioned in upstream https://github.com/fltk/fltk/issues/1047

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
