### PR TITLE
wiringpi: Add version 3.18

### DIFF
--- a/recipes/wiringpi/all/CMakeLists.txt
+++ b/recipes/wiringpi/all/CMakeLists.txt
@@ -7,6 +7,7 @@ message(STATUS "SRC_FILES: ${SRC_FILES}")
 if(NOT WIRINGPI_WITH_WPI_EXTENSIONS)
   list(FILTER SRC_FILES EXCLUDE REGEX ".*wpiExtensions.c")
   list(FILTER SRC_FILES EXCLUDE REGEX ".*drcNet.c")
+  list(FILTER SRC_FILES EXCLUDE REGEX "WiringpiV1.c")
 endif()
 
 add_library(${PROJECT_NAME} ${SRC_FILES})

--- a/recipes/wiringpi/all/CMakeLists.txt
+++ b/recipes/wiringpi/all/CMakeLists.txt
@@ -7,8 +7,10 @@ message(STATUS "SRC_FILES: ${SRC_FILES}")
 if(NOT WIRINGPI_WITH_WPI_EXTENSIONS)
   list(FILTER SRC_FILES EXCLUDE REGEX ".*wpiExtensions.c")
   list(FILTER SRC_FILES EXCLUDE REGEX ".*drcNet.c")
-  list(FILTER SRC_FILES EXCLUDE REGEX "WiringpiV1.c")
 endif()
+
+# WiringpiV1 is not part of any object in the upstream Makefile
+list(FILTER SRC_FILES EXCLUDE REGEX "WiringpiV1.c")
 
 add_library(${PROJECT_NAME} ${SRC_FILES})
 target_include_directories(${PROJECT_NAME} PUBLIC ${WIRINGPI_SRC_DIR}/wiringPi)

--- a/recipes/wiringpi/all/conandata.yml
+++ b/recipes/wiringpi/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "3.10":
-    url: "https://github.com/WiringPi/WiringPi/archive/refs/tags/3.10.tar.gz"
-    sha256: "d0a7b182154e763b4baff1a57a5e0fca093fcf081f663cb2fb17f5ada564e016"
+  "3.18":
+    url: "https://github.com/WiringPi/WiringPi/archive/refs/tags/3.18.tar.gz"
+    sha256: "c7a06c462372df1650219a10cdd4e8e1da763a41399539ecd1ee1dd4e14e09a8"

--- a/recipes/wiringpi/all/conanfile.py
+++ b/recipes/wiringpi/all/conanfile.py
@@ -7,6 +7,7 @@ from conan.tools.scm import Version
 
 required_conan_version = ">=2.4"
 
+
 class WiringpiConan(ConanFile):
     name = "wiringpi"
     description = "GPIO Interface library for the Raspberry Pi"
@@ -49,11 +50,6 @@ class WiringpiConan(ConanFile):
         if self.settings.compiler == "gcc" and \
             Version(self.settings.compiler.version) < 8:
             raise ConanInvalidConfiguration(f"{self.ref} requires gcc >= 8")
-        # wiringPi.c:1755:9: error: case label does not reduce to an integer constant
-        if self.settings.compiler == "gcc" and \
-            Version(self.settings.compiler.version).major == 11 and \
-            self.settings.build_type == "Debug":
-            raise ConanInvalidConfiguration(f"{self.ref} doesn't support gcc 11 in Debug build")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/wiringpi/config.yml
+++ b/recipes/wiringpi/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "3.10":
+  "3.18":
     folder: "all"


### PR DESCRIPTION
Add the latest available version

Closes https://github.com/conan-io/conan-center-index/pull/29967/, as debug builds with gcc 11 are now fixed [out.txt](https://github.com/user-attachments/files/28221005/out.txt)


---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
