### PR TITLE
cmake: Fix undesired files go into the package

### DIFF
--- a/recipes/cmake/binary/conanfile.py
+++ b/recipes/cmake/binary/conanfile.py
@@ -18,11 +18,6 @@ class CMakeConan(ConanFile):
     license = "BSD-3-Clause"
     settings = "os", "arch"
 
-    # Disable generation of build and run environment.
-    # They are not needed, as nothing is being build/run.
-    virtualbuildenv = False
-    virtualrunenv = False
-
     def validate(self):
         if self.settings.arch not in ["x86_64", "armv8"]:
             raise ConanInvalidConfiguration("CMake binaries are only provided for x86_64 and armv8 architectures. " +
@@ -31,26 +26,26 @@ class CMakeConan(ConanFile):
         if self.settings.os == "Windows" and self.settings.arch == "armv8" and Version(self.version) < "3.24":
             raise ConanInvalidConfiguration("CMake only supports ARM64 binaries on Windows starting from 3.24")
 
-    def layout(self):
-        self.folders.build = "build"
-        self.cpp.build.bindirs = ["bin"]
-
+    @property
+    def _unzipped_folder(self):
+        return os.path.join(self.build_folder, "unzipped")
+        
     def build(self):
         arch = str(self.settings.arch) if self.settings.os != "Macos" else "universal"
         get(self, **self.conan_data["sources"][self.version][str(self.settings.os)][arch],
-            destination=self.build_folder, strip_root=True)
+            destination=self._unzipped_folder, strip_root=True)
 
     def package_id(self):
         if self.info.settings.os == "Macos":
             del self.info.settings.arch
 
     def package(self):
-        copy(self, "*", src=self.build_folder, dst=self.package_folder)
+        copy(self, "*", src=self._unzipped_folder, dst=self.package_folder)
 
         if self.settings.os == "Macos":
-            docs_folder = os.path.join(self.build_folder, "CMake.app", "Contents", "doc", "cmake")
+            docs_folder = os.path.join(self._unzipped_folder, "CMake.app", "Contents", "doc", "cmake")
         else:
-            docs_folder = os.path.join(self.build_folder, "doc", "cmake")
+            docs_folder = os.path.join(self._unzipped_folder, "doc", "cmake")
 
         licensefile = "LICENSE.rst" if Version(self.version) >= "4.0.0" else "Copyright.txt"
         copy(self, licensefile, src=docs_folder, dst=os.path.join(self.package_folder, "licenses"), keep_path=False)

--- a/recipes/cmake/binary/conanfile.py
+++ b/recipes/cmake/binary/conanfile.py
@@ -31,10 +31,14 @@ class CMakeConan(ConanFile):
         if self.settings.os == "Windows" and self.settings.arch == "armv8" and Version(self.version) < "3.24":
             raise ConanInvalidConfiguration("CMake only supports ARM64 binaries on Windows starting from 3.24")
 
+    def layout(self):
+        self.folders.build = "build"
+        self.cpp.build.bindirs = ["bin"]
+
     def build(self):
         arch = str(self.settings.arch) if self.settings.os != "Macos" else "universal"
         get(self, **self.conan_data["sources"][self.version][str(self.settings.os)][arch],
-            destination=self.source_folder, strip_root=True)
+            destination=self.build_folder, strip_root=True)
 
     def package_id(self):
         if self.info.settings.os == "Macos":

--- a/recipes/cmake/binary/conanfile.py
+++ b/recipes/cmake/binary/conanfile.py
@@ -18,6 +18,11 @@ class CMakeConan(ConanFile):
     license = "BSD-3-Clause"
     settings = "os", "arch"
 
+    # Disable generation of build and run environment.
+    # They are not needed, as nothing is being build/run.
+    virtualbuildenv = False
+    virtualrunenv = False
+
     def validate(self):
         if self.settings.arch not in ["x86_64", "armv8"]:
             raise ConanInvalidConfiguration("CMake binaries are only provided for x86_64 and armv8 architectures. " +


### PR DESCRIPTION
### Summary
Changes to recipe:  **cmake** (affects all future versions)

#### Extract in a seperate build folder
    
Previously, the CMake release archive was extracted directly
inside the source folder. From there, everything was copied
to the package folder.

This is not a problem when building in the Conan Cache,
as the source folder is empty at the beginning.

However, when exporting the package via `conan export-pkg`,
the following files go into the package unintendedly:

```
conanfile.py
conandata.yml
test_package/
```

Seperate build and source folder to avoid that problem.

#### Disable generation of build and run environment

The environments are not needed, as nothing is
being build/run.

This eliminates the generated `conanbuild*`, `conanrun*`
and possibly `deactivate_conan*` files from the package.

The CMake package at ConanCenter currently includes all these files,
e.g. `conanrun.sh` at package root:
`. "/tmp/workspace/cci_prod_PR-30046/conan-home/p/b/cmakee51bdf8697224/b/conanrunenv-x86_64.sh"`
These paths/files are build-system dependent and have no purpose.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
