### PR TITLE
inih: use version range for meson tool_requires

### DIFF
--- a/recipes/inih/all/conandata.yml
+++ b/recipes/inih/all/conandata.yml
@@ -2,24 +2,6 @@ sources:
   "62":
     url: "https://github.com/benhoyt/inih/archive/refs/tags/r62.tar.gz"
     sha256: "9c15fa751bb8093d042dae1b9f125eb45198c32c6704cd5481ccde460d4f8151"
-  "60":
-    url: "https://github.com/benhoyt/inih/archive/r60.tar.gz"
-    sha256: "706aa05c888b53bd170e5d8aa8f8a9d9ccf5449dfed262d5103d1f292af26774"
   "58":
     url: "https://github.com/benhoyt/inih/archive/r58.tar.gz"
     sha256: "e79216260d5dffe809bda840be48ab0eec7737b2bb9f02d2275c1b46344ea7b7"
-  "57":
-    url: "https://github.com/benhoyt/inih/archive/r57.tar.gz"
-    sha256: "f03f98ca35c3adb56b2358573c8d3eda319ccd5287243d691e724b7eafa970b3"
-  "56":
-    url: "https://github.com/benhoyt/inih/archive/r56.tar.gz"
-    sha256: "4f2ba6bd122d30281a8c7a4d5723b7af90b56aa828c0e88256d7fceda03a491a"
-  "55":
-    url: "https://github.com/benhoyt/inih/archive/r55.tar.gz"
-    sha256: "ba55f8ae2a8caf0653f30f48567241e14ea916acfc13481f502d8a9c8f507f68"
-  "52":
-    url: "https://github.com/benhoyt/inih/archive/r52.tar.gz"
-    sha256: "439cff9ce9a8afc52d08772ac3e93b3cecd79c7707f871fb4534fb3a48201880"
-  "51":
-    url: "https://github.com/benhoyt/inih/archive/r51.tar.gz"
-    sha256: "132361da6d3172760a40319722b50244aee1b7ce7077a0dd8805881e6a8ea4aa"

--- a/recipes/inih/all/conanfile.py
+++ b/recipes/inih/all/conanfile.py
@@ -62,7 +62,7 @@ class InihConan(ConanFile):
             raise ConanInvalidConfiguration("Shared inih is not supported with msvc")
 
     def build_requirements(self):
-        self.tool_requires("meson/1.2.1")
+        self.tool_requires("meson/[>=1.2.1 <2]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/inih/all/conanfile.py
+++ b/recipes/inih/all/conanfile.py
@@ -1,7 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import fix_apple_shared_install_name
-from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import copy, get, rmdir
 from conan.tools.build import check_min_cppstd
 from conan.tools.layout import basic_layout
@@ -10,7 +9,7 @@ from conan.tools.microsoft import is_msvc
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.1"
 
 
 class InihConan(ConanFile):
@@ -34,10 +33,6 @@ class InihConan(ConanFile):
         "with_inireader": True,
     }
 
-    @property
-    def _min_cppstd(self):
-        return 11
-
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -55,9 +50,8 @@ class InihConan(ConanFile):
 
     def validate(self):
         # since 57, INIReader requires C++11
-        if Version(self.version) >= "57" and self.options.with_inireader and \
-            self.settings.compiler.get_safe("cppstd"):
-            check_min_cppstd(self, self._min_cppstd)
+        if self.options.with_inireader:
+            check_min_cppstd(self, 11)
         if self.options.shared and is_msvc(self):
             raise ConanInvalidConfiguration("Shared inih is not supported with msvc")
 
@@ -68,14 +62,11 @@ class InihConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
-        env = VirtualBuildEnv(self)
-        env.generate()
         tc = MesonToolchain(self)
         tc.project_options["distro_install"] = True
         tc.project_options["with_INIReader"] = self.options.with_inireader
-        # since 57, INIReader requires C++11
-        if Version(self.version) >= "57" and not is_msvc(self):
-            tc.cpp_args.append("-std=c++11")
+        if Version(self.version) >= "62":
+            tc.project_options["tests"] = False
         tc.generate()
 
     def build(self):

--- a/recipes/inih/config.yml
+++ b/recipes/inih/config.yml
@@ -1,17 +1,5 @@
 versions:
   "62":
     folder: "all"
-  "60":
-    folder: "all"
   "58":
-    folder: "all"
-  "57":
-    folder: "all"
-  "56":
-    folder: "all"
-  "55":
-    folder: "all"
-  "52":
-    folder: "all"
-  "51":
     folder: "all"


### PR DESCRIPTION
### Summary
Changes to recipe:  **inih/51** and up.

#### Motivation
inih requires a specific version of meson, failing to use compatible version available on the system.
Fixes #30260.

#### Details
Replaces `self.tool_requires("meson/1.2.1")` with `self.tool_requires("meson/[>=1.2.1 <2]")` in `recipes/inih/all/conanfile.py`, matching the convention used by other meson-consuming recipes (pkgconf, glib, libwebp).

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
