### PR TITLE
[cxxmcp] Add recipe

### DIFF
--- a/recipes/cxxmcp/all/conandata.yml
+++ b/recipes/cxxmcp/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2.0.2":
+    url: "https://github.com/caomengxuan666/cxxmcp/archive/refs/tags/v2.0.2.tar.gz"
+    sha256: "666083520e2e4b03a5e32938380b46870ac1540cb298e8b63cf3f7078e4cbf93"

--- a/recipes/cxxmcp/all/conandata.yml
+++ b/recipes/cxxmcp/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "2.0.2":
-    url: "https://github.com/caomengxuan666/cxxmcp/archive/refs/tags/v2.0.2.tar.gz"
-    sha256: "666083520e2e4b03a5e32938380b46870ac1540cb298e8b63cf3f7078e4cbf93"
+  "1.1.6":
+    url: "https://github.com/caomengxuan666/cxxmcp/releases/download/v1.1.6/cxxmcp-sdk-source-v1.1.6.tar.gz"
+    sha256: "7d321ee1e48f71666659949c98b5e3c81b273db98607b21d7b3d9301f5bf42e2"

--- a/recipes/cxxmcp/all/conanfile.py
+++ b/recipes/cxxmcp/all/conanfile.py
@@ -9,15 +9,25 @@ required_conan_version = ">=2.0"
 
 class CxxmcpConan(ConanFile):
     name = "cxxmcp"
-    description = "C++ MCP SDK for protocol, client, server, transport, peer, and handler APIs."
+    description = "C++17 SDK for the Model Context Protocol."
     license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/caomengxuan666/cxxmcp"
     topics = ("mcp", "model-context-protocol", "json-rpc", "sdk")
     package_type = "static-library"
     settings = "os", "arch", "compiler", "build_type"
-    options = {"fPIC": [True, False]}
-    default_options = {"fPIC": True}
+    options = {
+        "fPIC": [True, False],
+        "with_http": [True, False],
+        "with_websocket": [True, False],
+        "with_auth": [True, False],
+    }
+    default_options = {
+        "fPIC": True,
+        "with_http": False,
+        "with_websocket": False,
+        "with_auth": False,
+    }
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -27,9 +37,10 @@ class CxxmcpConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("cpp-httplib/0.45.0", transitive_headers=True, transitive_libs=True)
         self.requires("nlohmann_json/3.12.0", transitive_headers=True)
         self.requires("tl-expected/1.2.0", transitive_headers=True)
+        if self.options.with_http or self.options.with_websocket:
+            self.requires("cpp-httplib/0.45.0", transitive_headers=True)
 
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
@@ -42,17 +53,17 @@ class CxxmcpConan(ConanFile):
         deps = CMakeDeps(self)
         deps.generate()
 
+        http_enabled = bool(self.options.with_http) or bool(self.options.with_websocket)
+
         tc = CMakeToolchain(self)
         tc.variables["CXXMCP_BUILD_SDK"] = True
-        tc.variables["CXXMCP_BUILD_RUNTIME"] = False
-        tc.variables["CXXMCP_BUILD_APP"] = False
-        tc.variables["CXXMCP_BUILD_GATEWAY"] = False
-        tc.variables["CXXMCP_BUILD_CLI"] = False
         tc.variables["CXXMCP_BUILD_EXAMPLES"] = False
         tc.variables["CXXMCP_BUILD_TESTS"] = False
         tc.variables["CXXMCP_BUILD_DOCS"] = False
+        tc.variables["CXXMCP_ENABLE_HTTP"] = http_enabled
+        tc.variables["CXXMCP_ENABLE_WEBSOCKET"] = bool(self.options.with_websocket)
+        tc.variables["CXXMCP_ENABLE_AUTH"] = bool(self.options.with_auth)
         tc.variables["CXXMCP_USE_SYSTEM_DEPS"] = True
-        tc.variables["BUILD_SHARED_LIBS"] = False
         if self.settings.os != "Windows":
             tc.variables["CMAKE_POSITION_INDEPENDENT_CODE"] = bool(self.options.fPIC)
         tc.generate()
@@ -69,19 +80,27 @@ class CxxmcpConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
+        http_enabled = bool(self.options.with_http) or bool(self.options.with_websocket)
+        websocket_enabled = bool(self.options.with_websocket)
+        optional_defines = []
+        if http_enabled:
+            optional_defines.append("CXXMCP_ENABLE_HTTP=1")
+        if websocket_enabled:
+            optional_defines.append("CXXMCP_ENABLE_WEBSOCKET=1")
+
         self.cpp_info.set_property("cmake_file_name", "cxxmcp")
+        self.cpp_info.set_property("cmake_target_name", "cxxmcp::sdk")
+        self.cpp_info.libs = ["mcp_server", "mcp_client", "mcp_protocol"]
+        self.cpp_info.defines.extend(optional_defines)
+        self._add_common_system_libs(self.cpp_info, http_enabled)
 
         self.cpp_info.components["core"].set_property("cmake_target_name", "cxxmcp::core")
         self.cpp_info.components["core"].requires = ["tl-expected::expected"]
-
-        self.cpp_info.components["jsonrpcpp"].set_property("cmake_target_name", "cxxmcp::jsonrpcpp")
-        self.cpp_info.components["jsonrpcpp"].requires = ["nlohmann_json::nlohmann_json"]
 
         self.cpp_info.components["protocol"].set_property("cmake_target_name", "cxxmcp::protocol")
         self.cpp_info.components["protocol"].libs = ["mcp_protocol"]
         self.cpp_info.components["protocol"].requires = [
             "core",
-            "jsonrpcpp",
             "nlohmann_json::nlohmann_json",
         ]
 
@@ -90,26 +109,27 @@ class CxxmcpConan(ConanFile):
 
         self.cpp_info.components["client"].set_property("cmake_target_name", "cxxmcp::client")
         self.cpp_info.components["client"].libs = ["mcp_client"]
-        self.cpp_info.components["client"].requires = [
-            "transport",
-            "cpp-httplib::cpp-httplib",
-        ]
+        self.cpp_info.components["client"].requires = ["transport"]
+        self.cpp_info.components["client"].defines.extend(optional_defines)
+        self._add_common_system_libs(self.cpp_info.components["client"], http_enabled)
 
         self.cpp_info.components["server"].set_property("cmake_target_name", "cxxmcp::server")
         self.cpp_info.components["server"].libs = ["mcp_server"]
-        self.cpp_info.components["server"].requires = [
-            "transport",
-            "cpp-httplib::cpp-httplib",
-        ]
+        self.cpp_info.components["server"].requires = ["transport"]
+        self.cpp_info.components["server"].defines.extend(optional_defines)
+        self._add_common_system_libs(self.cpp_info.components["server"], http_enabled)
 
         self.cpp_info.components["peer"].set_property("cmake_target_name", "cxxmcp::peer")
         self.cpp_info.components["peer"].requires = ["client", "server"]
+        self.cpp_info.components["peer"].defines.extend(optional_defines)
 
         self.cpp_info.components["handler"].set_property("cmake_target_name", "cxxmcp::handler")
         self.cpp_info.components["handler"].requires = ["client", "server"]
+        self.cpp_info.components["handler"].defines.extend(optional_defines)
 
         self.cpp_info.components["service"].set_property("cmake_target_name", "cxxmcp::service")
         self.cpp_info.components["service"].requires = ["peer"]
+        self.cpp_info.components["service"].defines.extend(optional_defines)
 
         self.cpp_info.components["sdk"].set_property("cmake_target_name", "cxxmcp::sdk")
         self.cpp_info.components["sdk"].requires = [
@@ -121,9 +141,21 @@ class CxxmcpConan(ConanFile):
             "handler",
             "service",
         ]
+        self.cpp_info.components["sdk"].defines.extend(optional_defines)
 
-        self.cpp_info.components["plugin_sdk"].set_property("cmake_target_name", "cxxmcp::plugin_sdk")
-        self.cpp_info.components["plugin_sdk"].requires = ["protocol"]
+        if self.options.with_auth:
+            self.cpp_info.components["auth"].set_property("cmake_target_name", "cxxmcp::auth")
+            self.cpp_info.components["auth"].requires = [
+                "core",
+                "nlohmann_json::nlohmann_json",
+            ]
+            self.cpp_info.components["auth"].defines.append("CXXMCP_ENABLE_AUTH=1")
+            self.cpp_info.components["client"].requires.append("auth")
+            self.cpp_info.components["server"].requires.append("auth")
+            self.cpp_info.components["sdk"].requires.append("auth")
 
-        self.cpp_info.components["adapters"].set_property("cmake_target_name", "cxxmcp::adapters")
-        self.cpp_info.components["adapters"].requires = ["server", "plugin_sdk"]
+    def _add_common_system_libs(self, cpp_info, http_enabled):
+        if self.settings.os == "Windows" and http_enabled:
+            cpp_info.system_libs.extend(["ws2_32", "crypt32"])
+        elif self.settings.os in ("Linux", "FreeBSD"):
+            cpp_info.system_libs.append("pthread")

--- a/recipes/cxxmcp/all/conanfile.py
+++ b/recipes/cxxmcp/all/conanfile.py
@@ -1,0 +1,129 @@
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, rmdir
+import os
+
+required_conan_version = ">=2.0"
+
+
+class CxxmcpConan(ConanFile):
+    name = "cxxmcp"
+    description = "C++ MCP SDK for protocol, client, server, transport, peer, and handler APIs."
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/caomengxuan666/cxxmcp"
+    topics = ("mcp", "model-context-protocol", "json-rpc", "sdk")
+    package_type = "static-library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {"fPIC": [True, False]}
+    default_options = {"fPIC": True}
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("cpp-httplib/0.45.0", transitive_headers=True, transitive_libs=True)
+        self.requires("nlohmann_json/3.12.0", transitive_headers=True)
+        self.requires("tl-expected/1.2.0", transitive_headers=True)
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, 17)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
+
+        tc = CMakeToolchain(self)
+        tc.variables["CXXMCP_BUILD_SDK"] = True
+        tc.variables["CXXMCP_BUILD_RUNTIME"] = False
+        tc.variables["CXXMCP_BUILD_APP"] = False
+        tc.variables["CXXMCP_BUILD_GATEWAY"] = False
+        tc.variables["CXXMCP_BUILD_CLI"] = False
+        tc.variables["CXXMCP_BUILD_EXAMPLES"] = False
+        tc.variables["CXXMCP_BUILD_TESTS"] = False
+        tc.variables["CXXMCP_BUILD_DOCS"] = False
+        tc.variables["CXXMCP_USE_SYSTEM_DEPS"] = True
+        tc.variables["BUILD_SHARED_LIBS"] = False
+        if self.settings.os != "Windows":
+            tc.variables["CMAKE_POSITION_INDEPENDENT_CODE"] = bool(self.options.fPIC)
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "cxxmcp")
+
+        self.cpp_info.components["core"].set_property("cmake_target_name", "cxxmcp::core")
+        self.cpp_info.components["core"].requires = ["tl-expected::expected"]
+
+        self.cpp_info.components["jsonrpcpp"].set_property("cmake_target_name", "cxxmcp::jsonrpcpp")
+        self.cpp_info.components["jsonrpcpp"].requires = ["nlohmann_json::nlohmann_json"]
+
+        self.cpp_info.components["protocol"].set_property("cmake_target_name", "cxxmcp::protocol")
+        self.cpp_info.components["protocol"].libs = ["mcp_protocol"]
+        self.cpp_info.components["protocol"].requires = [
+            "core",
+            "jsonrpcpp",
+            "nlohmann_json::nlohmann_json",
+        ]
+
+        self.cpp_info.components["transport"].set_property("cmake_target_name", "cxxmcp::transport")
+        self.cpp_info.components["transport"].requires = ["protocol"]
+
+        self.cpp_info.components["client"].set_property("cmake_target_name", "cxxmcp::client")
+        self.cpp_info.components["client"].libs = ["mcp_client"]
+        self.cpp_info.components["client"].requires = [
+            "transport",
+            "cpp-httplib::cpp-httplib",
+        ]
+
+        self.cpp_info.components["server"].set_property("cmake_target_name", "cxxmcp::server")
+        self.cpp_info.components["server"].libs = ["mcp_server"]
+        self.cpp_info.components["server"].requires = [
+            "transport",
+            "cpp-httplib::cpp-httplib",
+        ]
+
+        self.cpp_info.components["peer"].set_property("cmake_target_name", "cxxmcp::peer")
+        self.cpp_info.components["peer"].requires = ["client", "server"]
+
+        self.cpp_info.components["handler"].set_property("cmake_target_name", "cxxmcp::handler")
+        self.cpp_info.components["handler"].requires = ["client", "server"]
+
+        self.cpp_info.components["service"].set_property("cmake_target_name", "cxxmcp::service")
+        self.cpp_info.components["service"].requires = ["peer"]
+
+        self.cpp_info.components["sdk"].set_property("cmake_target_name", "cxxmcp::sdk")
+        self.cpp_info.components["sdk"].requires = [
+            "protocol",
+            "client",
+            "server",
+            "transport",
+            "peer",
+            "handler",
+            "service",
+        ]
+
+        self.cpp_info.components["plugin_sdk"].set_property("cmake_target_name", "cxxmcp::plugin_sdk")
+        self.cpp_info.components["plugin_sdk"].requires = ["protocol"]
+
+        self.cpp_info.components["adapters"].set_property("cmake_target_name", "cxxmcp::adapters")
+        self.cpp_info.components["adapters"].requires = ["server", "plugin_sdk"]

--- a/recipes/cxxmcp/all/test_package/CMakeLists.txt
+++ b/recipes/cxxmcp/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(cxxmcp REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE cxxmcp::sdk)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/cxxmcp/all/test_package/conanfile.py
+++ b/recipes/cxxmcp/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/cxxmcp/all/test_package/test_package.cpp
+++ b/recipes/cxxmcp/all/test_package/test_package.cpp
@@ -1,0 +1,6 @@
+#include <cxxmcp/sdk.hpp>
+
+int main() {
+    mcp::ServerPeer server;
+    return server.list_prompts().empty() ? 0 : 1;
+}

--- a/recipes/cxxmcp/config.yml
+++ b/recipes/cxxmcp/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.0.2":
+    folder: all

--- a/recipes/cxxmcp/config.yml
+++ b/recipes/cxxmcp/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "2.0.2":
+  "1.1.6":
     folder: all


### PR DESCRIPTION
Summary:
- Update the cxxmcp recipe draft to cxxmcp/1.1.6
- Consume the published SDK source release archive and checksum
- Keep the default package SDK-only; HTTP, WebSocket, and auth remain opt-in options
- Remove obsolete runtime/plugin/adapters components from the package surface

Validation performed locally:
- git diff --check -- recipes/cxxmcp

Notes:
- The cxxmcp v1.1.6 release includes SDK source, release-gate evidence, release notes, and SHA256SUMS assets.
- Full Conan create validation should run in CI or a local environment with Conan 2 installed.