### PR TITLE
simdjson: replace version 4.6.3 by 4.6.4

### DIFF
--- a/recipes/simdjson/all/conandata.yml
+++ b/recipes/simdjson/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "4.6.3":
-    url: "https://github.com/simdjson/simdjson/archive/v4.6.3.tar.gz"
-    sha256: "bde0c42f43899c4c5c48be826c09abd22500ed537b89f16b3cced5eec477c263"
+  "4.6.4":
+    url: "https://github.com/simdjson/simdjson/archive/v4.6.4.tar.gz"
+    sha256: "b091107844fe928158c5c2265c20360fff312889ddf7ebc4528a0f0f8f2ff9cd"
   "3.13.0":
     url: "https://github.com/simdjson/simdjson/archive/v3.13.0.tar.gz"
     sha256: "07a1bb3587aac18fd6a10a83fe4ab09f1100ab39f0cb73baea1317826b9f9e0d"

--- a/recipes/simdjson/config.yml
+++ b/recipes/simdjson/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "4.6.3":
+  "4.6.4":
     folder: all
   "3.13.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **simdjson/4.6.4**, related to #30274.

#### Motivation
See #30274

#### Details
I replaced version 4.6.3 by 4.6.4 in `conandata.yml` and also updated `config.yml`. The actual python recipe did not require any change.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
