### PR TITLE
civetweb: fix linker tools on GCC and fseeko() on Android 32-bit (API < 24)

### DIFF
--- a/recipes/civetweb/all/conandata.yml
+++ b/recipes/civetweb/all/conandata.yml
@@ -12,6 +12,15 @@ sources:
     url: "https://github.com/civetweb/civetweb/archive/v1.13.tar.gz"
     sha256: "a7ccc76c2f1b5f4e8d855eb328ed542f8fe3b882a6da868781799a98f4acdedc"
 patches:
+  "1.16":
+    - patch_file: "patches/0003-1.16-fix-not-override-ar-ranlib.patch"
+      patch_type: "portability"
+      patch_description: "Do not override linker tools AR and RANLIB for GCC for 1.16"
+      patch_source: "https://github.com/civetweb/civetweb/commit/afea23abf322fb7eba0f1bb8675e09b1039fb47d"
+    - patch_file: "patches/0004-1.16-fix-android-fseeko.patch"
+      patch_type: "portability"
+      patch_description: "Fix fseeko on Android 32-bit API < 24 for 1.16"
+      patch_source: "https://github.com/civetweb/civetweb/commit/afea23abf322fb7eba0f1bb8675e09b1039fb47d"
   "1.15":
     - patch_file: "patches/0002-1.14-fix-option-handling.patch"
       patch_type: "backport"

--- a/recipes/civetweb/all/conandata.yml
+++ b/recipes/civetweb/all/conandata.yml
@@ -16,11 +16,9 @@ patches:
     - patch_file: "patches/0003-1.16-fix-not-override-ar-ranlib.patch"
       patch_type: "portability"
       patch_description: "Do not override linker tools AR and RANLIB for GCC for 1.16"
-      patch_source: "https://github.com/civetweb/civetweb/commit/afea23abf322fb7eba0f1bb8675e09b1039fb47d"
     - patch_file: "patches/0004-1.16-fix-android-fseeko.patch"
       patch_type: "portability"
       patch_description: "Fix fseeko on Android 32-bit API < 24 for 1.16"
-      patch_source: "https://github.com/civetweb/civetweb/commit/afea23abf322fb7eba0f1bb8675e09b1039fb47d"
   "1.15":
     - patch_file: "patches/0002-1.14-fix-option-handling.patch"
       patch_type: "backport"

--- a/recipes/civetweb/all/patches/0003-1.16-fix-not-override-ar-ranlib.patch
+++ b/recipes/civetweb/all/patches/0003-1.16-fix-not-override-ar-ranlib.patch
@@ -1,0 +1,23 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c5368c08..0b1d5f92 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -282,18 +282,6 @@ set(CIVETWEB_CXX_STANDARD auto CACHE STRING
+   "The C++ standard to use; auto determines the latest supported by the compiler")
+ set_property(CACHE CIVETWEB_CXX_STANDARD PROPERTY STRINGS auto c++14 c++11 c++98)
+
+-# Configure the linker
+-if ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
+-  find_program(GCC_AR gcc-ar)
+-  if (GCC_AR)
+-    set(CMAKE_AR ${GCC_AR})
+-  endif()
+-  find_program(GCC_RANLIB gcc-ranlib)
+-  if (GCC_RANLIB)
+-    set(CMAKE_RANLIB ${GCC_RANLIB})
+-  endif()
+-endif()
+-
+ # Configure the C compiler
+ message(STATUS "Configuring C Compiler")
+ if ("${CIVETWEB_C_STANDARD}" STREQUAL "auto")

--- a/recipes/civetweb/all/patches/0004-1.16-fix-android-fseeko.patch
+++ b/recipes/civetweb/all/patches/0004-1.16-fix-android-fseeko.patch
@@ -1,0 +1,16 @@
+diff --git a/src/civetweb.c b/src/civetweb.c
+index 9e321edf..accd3b6b 100644
+--- a/src/civetweb.c
++++ b/src/civetweb.c
+@@ -894,6 +894,11 @@ typedef unsigned short int in_port_t;
+ #endif
+ #endif
+
++#if defined(__ANDROID_API__) && __ANDROID_API__ < 24 && !defined(__LP64__)
++    // https://android.googlesource.com/platform/bionic/+/master/docs/32-bit-abi.md#32_bit-and
++    #define fseeko fseek
++#endif
++
+ #define vsnprintf_impl vsnprintf
+
+ #if !defined(NO_SSL_DL) && !defined(NO_SSL)


### PR DESCRIPTION
### Summary
Changes to recipe:  **civetweb/1.16**
* Do not override linker tools AR and RANLIB for GCC  for 1.16
* Fix fseeko on Android 32-bit API < 24 for 1.16

#### Motivation
Fixes #30277

#### Details
* CMakeLists.txt overrides CMAKE_AR and CMAKE_RANLIB, breaking cross-compilation with custom toolchains
* Fix build on 32-bit Android API < 24: fseeko() not available


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
