### PR TITLE
asio: Add version 1.38.0

### DIFF
--- a/recipes/asio/all/conandata.yml
+++ b/recipes/asio/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.38.0":
+    url: "https://github.com/chriskohlhoff/asio/archive/asio-1-38-0.tar.gz"
+    sha256: "5cf78ede456fd13b95fe692711f4f689be26c826f1f5541c7a1df3aa32bd9dbd"
   "1.36.0":
     url: "https://github.com/chriskohlhoff/asio/archive/asio-1-36-0.tar.gz"
     sha256: "0310a76b27e1854f09f696b30de57dc490b5e1b17faed1eb8c9a2891f956e52b"

--- a/recipes/asio/all/conanfile.py
+++ b/recipes/asio/all/conanfile.py
@@ -1,6 +1,7 @@
 from conan import ConanFile
 from conan.tools.files import copy, get
 from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.50.0"
@@ -31,7 +32,10 @@ class Asio(ConanFile):
         pass
 
     def package(self):
-        root_dir = os.path.join(self.source_folder, "asio")
+        root_dir = self.source_folder
+        if Version(self.version) < "1.38.0":
+            root_dir = os.path.join(self.source_folder, "asio")
+
         include_dir = os.path.join(root_dir, "include")
         copy(self, "LICENSE_1_0.txt", src=root_dir, dst=os.path.join(self.package_folder, "licenses"))
         copy(self, "*.hpp", src=include_dir, dst=os.path.join(self.package_folder, "include"))

--- a/recipes/asio/config.yml
+++ b/recipes/asio/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.38.0":
+    folder: all
   "1.36.0":
     folder: all
   "1.34.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  **asio/1.38.0**

#### Motivation
Update asio to the latest release.

#### Details
I had to modify the recipe because the root directory had been moved. Although the library’s author added symbolic links for backward compatibility, Conan doesn’t create them - at least on Windows. (This is likely because administrator privileges are required to create them.)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] ~~If this is a bug fix, please link related issue or provide bug details~~
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
