### PR TITLE
ninjahsm/1.3.0: add recipe

### DIFF
--- a/recipes/ninjahsm/all/conandata.yml
+++ b/recipes/ninjahsm/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.3.0":
+    url: "https://github.com/gbmhunter/NinjaHSM/archive/refs/tags/v1.3.0.tar.gz"
+    sha256: "e51306932113a32efeb76842baac732027cc2fd7772d9ef623f9b51c1bace430"

--- a/recipes/ninjahsm/all/conanfile.py
+++ b/recipes/ninjahsm/all/conanfile.py
@@ -1,0 +1,64 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+
+required_conan_version = ">=2.1"
+
+
+class NinjaHSMConan(ConanFile):
+    name = "ninjahsm"
+    description = (
+        "A small, simple hierarchical state machine (HSM) library for C++ embedded systems. "
+        "Header-only, no dynamic memory allocation."
+    )
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/gbmhunter/NinjaHSM"
+    topics = ("state-machine", "hsm", "statechart", "embedded", "fsm", "hierarchical", "header-only")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    @property
+    def _min_cppstd(self):
+        return 17
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def requirements(self):
+        # NinjaHSM's public headers include <etl/delegate.h>, so ETL must be visible to consumers.
+        self.requires("etl/20.39.4", transitive_headers=True)
+
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        check_min_cppstd(self, self._min_cppstd)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def build(self):
+        pass
+
+    def package(self):
+        copy(
+            self,
+            "LICENSE",
+            src=self.source_folder,
+            dst=os.path.join(self.package_folder, "licenses"),
+        )
+        copy(
+            self,
+            "*.hpp",
+            src=os.path.join(self.source_folder, "src"),
+            dst=os.path.join(self.package_folder, "include"),
+        )
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/ninjahsm/all/test_package/CMakeLists.txt
+++ b/recipes/ninjahsm/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package CXX)
+
+find_package(ninjahsm REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} src/test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE ninjahsm::ninjahsm)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/ninjahsm/all/test_package/conanfile.py
+++ b/recipes/ninjahsm/all/test_package/conanfile.py
@@ -1,0 +1,27 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(cmd, env="conanrun")

--- a/recipes/ninjahsm/all/test_package/src/test_package.cpp
+++ b/recipes/ninjahsm/all/test_package/src/test_package.cpp
@@ -1,0 +1,51 @@
+// Minimal consumer used by conan-center-index CI to verify the packaged headers can be found
+// and used, and that the transitive ETL dependency is visible.
+#include <NinjaHSM/NinjaHSM.hpp>
+
+using namespace NinjaHSM;
+
+namespace {
+
+struct Event {
+    int id;
+};
+
+class Machine {
+public:
+    Machine() :
+        m_idle(makeState<Event,
+            &Machine::idle_entry, &Machine::idle_event, &Machine::idle_exit>("Idle", *this)),
+        m_running(makeState<Event,
+            &Machine::running_entry, &Machine::running_event, &Machine::running_exit>("Running", *this, &m_idle)),
+        m_sm() {
+        m_sm.initialTransitionTo(m_idle);
+    }
+
+    void step(const Event& event) { m_sm.handleEvent(event); }
+
+private:
+    void idle_entry() {}
+    void idle_event(const Event& event) {
+        if (event.id == 1) {
+            m_sm.transitionTo(m_running);
+        }
+    }
+    void idle_exit() {}
+
+    void running_entry() {}
+    void running_event(const Event& event) {}
+    void running_exit() {}
+
+    State<Event> m_idle;
+    State<Event> m_running;
+    StateMachine<Event> m_sm;
+};
+
+} // namespace
+
+int main() {
+    Machine machine;
+    Event event{1};
+    machine.step(event);
+    return 0;
+}

--- a/recipes/ninjahsm/config.yml
+++ b/recipes/ninjahsm/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.3.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version: **ninjahsm/1.3.0**

[NinjaHSM](https://github.com/gbmhunter/NinjaHSM) is a small, header-only hierarchical state machine (HSM) library for embedded C++. It performs no dynamic memory allocation and depends on `etl` (already in CCI), whose headers are exposed transitively.

The recipe is header-only (`package_type = "header-library"`, `package_id().clear()`), requires C++17, and packages the headers from the upstream `src/` directory. It was validated locally with `conan create` (downloads the v1.3.0 tag, pulls `etl/20.39.4`, builds and runs the `test_package`).