### PR TITLE
wiringpi/3.18: define _GNU_SOURCE for ppoll() on GCC 14

### DIFF
--- a/recipes/wiringpi/all/CMakeLists.txt
+++ b/recipes/wiringpi/all/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.15)
 project(wiringPi LANGUAGES C)
 
+add_compile_definitions(_GNU_SOURCE)
+
 file(GLOB SRC_FILES ${WIRINGPI_SRC_DIR}/wiringPi/*.c)
 
 message(STATUS "SRC_FILES: ${SRC_FILES}")

--- a/recipes/wiringpi/all/CMakeLists.txt
+++ b/recipes/wiringpi/all/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 project(wiringPi LANGUAGES C)
 
-add_compile_definitions(_GNU_SOURCE)
-
 file(GLOB SRC_FILES ${WIRINGPI_SRC_DIR}/wiringPi/*.c)
 
 message(STATUS "SRC_FILES: ${SRC_FILES}")
@@ -16,6 +14,7 @@ list(FILTER SRC_FILES EXCLUDE REGEX "WiringpiV1.c")
 
 add_library(${PROJECT_NAME} ${SRC_FILES})
 target_include_directories(${PROJECT_NAME} PUBLIC ${WIRINGPI_SRC_DIR}/wiringPi)
+target_compile_definitions(${PROJECT_NAME} PRIVATE _GNU_SOURCE)
 
 if(WIRINGPI_WITH_DEV_LIB)
     file(GLOB SRC_FILES ${WIRINGPI_SRC_DIR}/devLib/*.c)


### PR DESCRIPTION
### Summary
Changes to recipe: **wiringpi/3.18**

#### Motivation
GCC 14 promotes implicit function declarations from warning to error by default
([release notes](https://gcc.gnu.org/gcc-14/porting_to.html#c)). `wiringPi.c`
calls `ppoll(2)` (a Linux/GNU extension declared in `<poll.h>` only when
`_GNU_SOURCE` is defined), but the recipe-provided `CMakeLists.txt` does not
define it. As a result, building `wiringpi/3.18` with GCC 14 fails:

```
wiringPi.c: In function 'interruptHandlerV2':
wiringPi.c:2987:11: error: implicit declaration of function 'ppoll'; did you mean 'poll'?
 2987 |     ret = ppoll(&polls, 1, &tspec, NULL);
      |           ^~~~~
      |           poll
```

The upstream WiringPi Makefiles (both `wiringPi/Makefile` and `devLib/Makefile`)
already use `DEFS = -D_GNU_SOURCE`, so the recipe's CMake wrapper was simply
losing a flag the upstream build assumes.

#### Details
Added `add_compile_definitions(_GNU_SOURCE)` to the recipe's
`CMakeLists.txt`, applied before any `add_library` so it covers both
`wiringPi` and `wiringPiDevLib` — mirroring upstream's per-Makefile `DEFS`.

This is intentionally fixed in the recipe-owned `CMakeLists.txt` (which is
copied via `export_sources()`), rather than as a `patches/` entry against
upstream sources, because:

- The recipe's CMake wrapper is what omits the flag — the upstream sources
  themselves don't need patching.
- A single line in the wrapper continues to work for any future 3.x tarball
  without re-rolling a per-version patch.

Tested locally with:
- Conan 2.x
- GCC 14.2.0 / Linux
- profile targeting `armv7hf` (cross-compile), `shared=False`, `with_devlib=True`

Before: build fails at `wiringPi.c:2987` (`ppoll` implicit declaration).
After: both `libwiringPi.a` and `libwiringPiDevLib.a` build and link cleanly.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: searched issues and PRs for "wiringpi ppoll", "wiringpi _GNU_SOURCE", "wiringpi gcc 14" — none found.
- [x] If this is a bug fix, please link related issue or provide bug details — bug details inlined above; no existing issue found.
- [x] Tested locally with at least one configuration using a recent version of Conan