### PR TITLE
xorg: fix FreeBSD

### DIFF
--- a/recipes/xorg/all/conanfile.py
+++ b/recipes/xorg/all/conanfile.py
@@ -106,9 +106,10 @@ class XorgConan(ConanFile):
                 "pkg_config_name", name)
             self.cpp_info.components[name].set_property(
                 "component_version", pkg_config.version)
-            self.cpp_info.components[name].bindirs = []
-            self.cpp_info.components[name].includedirs = []
-            self.cpp_info.components[name].libdirs = []
+            if self.settings.os == "Linux":
+                self.cpp_info.components[name].bindirs = []
+                self.cpp_info.components[name].includedirs = []
+                self.cpp_info.components[name].libdirs = []
             self.cpp_info.components[name].set_property("pkg_config_custom_content",
                                                         "\n".join(f"{key}={value}" for key, value in pkg_config.variables.items() if key not in ["pcfiledir","prefix", "includedir"]))
 

--- a/recipes/xorg/all/conanfile.py
+++ b/recipes/xorg/all/conanfile.py
@@ -106,8 +106,8 @@ class XorgConan(ConanFile):
                 "pkg_config_name", name)
             self.cpp_info.components[name].set_property(
                 "component_version", pkg_config.version)
+            self.cpp_info.components[name].bindirs = []
             if self.settings.os == "Linux":
-                self.cpp_info.components[name].bindirs = []
                 self.cpp_info.components[name].includedirs = []
                 self.cpp_info.components[name].libdirs = []
             self.cpp_info.components[name].set_property("pkg_config_custom_content",

--- a/recipes/xorg/all/conanfile.py
+++ b/recipes/xorg/all/conanfile.py
@@ -9,6 +9,7 @@ required_conan_version = ">=1.50.0"
 
 class XorgConan(ConanFile):
     name = "xorg"
+    version = "system"
     package_type = "shared-library"
     url = "https://github.com/conan-io/conan-center-index"
     license = "MIT"
@@ -99,8 +100,7 @@ class XorgConan(ConanFile):
                      "xcb-dri3", "xcb-cursor", "xcb-dri2", "xcb-dri3", "xcb-glx", "xcb-present",
                      "xcb-composite", "xcb-ewmh", "xcb-res"] + ([] if self.settings.os == "FreeBSD" else ["uuid"]):
             pkg_config = PkgConfig(self, name)
-            pkg_config.fill_cpp_info(
-                self.cpp_info.components[name], is_system=self.settings.os != "FreeBSD")
+            pkg_config.fill_cpp_info(self.cpp_info.components[name])
             self.cpp_info.components[name].version = pkg_config.version
             self.cpp_info.components[name].set_property(
                 "pkg_config_name", name)

--- a/recipes/xorg/all/conanfile.py
+++ b/recipes/xorg/all/conanfile.py
@@ -69,10 +69,10 @@ class XorgConan(ConanFile):
                               "libxss", "xcb-util-wm", "xcb-util-image", "xcb-util-keysyms", "xcb-util-renderutil",
                               "libxxf86vm", "libxv", "xcb-util", "util-linux-libs", "xcb-util-cursor"], update=True, check=True)
 
-        package_manager.Pkg(self).install(["libX11", "libfontenc", "libice", "libsm", "libxaw", "libxcomposite", "libxcursor",
-                           "libxdamage", "libxdmcp", "libxtst", "libxinerama", "libxkbfile", "libxrandr", "libxres",
+        package_manager.Pkg(self).install(["libX11", "libfontenc", "libICE", "libSM", "libXaw", "libXcomposite", "libXcursor",
+                           "libXdamage", "libXdmcp", "libXtst", "libXinerama", "libxkbfile", "libXrandr", "libXres",
                            "libXScrnSaver", "xcb-util-wm", "xcb-util-image", "xcb-util-keysyms", "xcb-util-renderutil",
-                           "libxxf86vm", "libxv", "xkeyboard-config", "xcb-util", "xcb-util-cursor"], update=True, check=True)
+                           "libXxf86vm", "libXv", "xkeyboard-config", "xcb-util", "xcb-util-cursor"], update=True, check=True)
 
         if Version(conan_version) >= "2.0.10":
             alpine = package_manager.Apk(self)

--- a/recipes/xorg/all/conanfile.py
+++ b/recipes/xorg/all/conanfile.py
@@ -30,7 +30,7 @@ class XorgConan(ConanFile):
         apt.install(["libx11-dev", "libx11-xcb-dev", "libfontenc-dev", "libice-dev", "libsm-dev", "libxau-dev", "libxaw7-dev",
                      "libxcomposite-dev", "libxcursor-dev", "libxdamage-dev", "libxdmcp-dev", "libxext-dev", "libxfixes-dev",
                      "libxi-dev", "libxinerama-dev", "libxkbfile-dev", "libxmu-dev", "libxmuu-dev",
-                     "libxpm-dev", "libxrandr-dev", "libxrender-dev", "libxres-dev", "libxt-dev", "libxtst-dev",
+                     "libxpm-dev", "libxrandr-dev", "libxrender-dev", "libxres-dev", "libxss-dev", "libxt-dev", "libxtst-dev",
                      "libxv-dev", "libxxf86vm-dev", "libxcb-glx0-dev", "libxcb-render0-dev",
                      "libxcb-render-util0-dev", "libxcb-xkb-dev", "libxcb-icccm4-dev", "libxcb-image0-dev",
                      "libxcb-keysyms1-dev", "libxcb-randr0-dev", "libxcb-shape0-dev", "libxcb-sync-dev", "libxcb-xfixes0-dev",
@@ -43,7 +43,7 @@ class XorgConan(ConanFile):
         yum = package_manager.Yum(self)
         yum.install(["libxcb-devel", "libfontenc-devel", "libXaw-devel", "libXcomposite-devel",
                            "libXcursor-devel", "libXdmcp-devel", "libXtst-devel", "libXinerama-devel",
-                           "libxkbfile-devel", "libXrandr-devel", "libXres-devel",
+                           "libxkbfile-devel", "libXrandr-devel", "libXres-devel", "libXScrnSaver-devel",
                            "xcb-util-wm-devel", "xcb-util-image-devel", "xcb-util-keysyms-devel",
                            "xcb-util-renderutil-devel", "libXdamage-devel", "libXxf86vm-devel", "libXv-devel",
                            "xcb-util-devel", "libuuid-devel", "xcb-util-cursor-devel"], update=True, check=True)
@@ -51,7 +51,7 @@ class XorgConan(ConanFile):
         dnf = package_manager.Dnf(self)
         dnf.install(["libxcb-devel", "libfontenc-devel", "libXaw-devel", "libXcomposite-devel",
                            "libXcursor-devel", "libXdmcp-devel", "libXtst-devel", "libXinerama-devel",
-                           "libxkbfile-devel", "libXrandr-devel", "libXres-devel",
+                           "libxkbfile-devel", "libXrandr-devel", "libXres-devel", "libXScrnSaver-devel",
                            "xcb-util-wm-devel", "xcb-util-image-devel", "xcb-util-keysyms-devel",
                            "xcb-util-renderutil-devel", "libXdamage-devel", "libXxf86vm-devel", "libXv-devel",
                            "xcb-util-devel", "libuuid-devel", "xcb-util-cursor-devel"], update=True, check=True)
@@ -59,7 +59,7 @@ class XorgConan(ConanFile):
         zypper = package_manager.Zypper(self)
         zypper.install(["libxcb-devel", "libfontenc-devel", "libXaw-devel", "libXcomposite-devel",
                               "libXcursor-devel", "libXdmcp-devel", "libXtst-devel", "libXinerama-devel",
-                              "libxkbfile-devel", "libXrandr-devel", "libXres-devel",
+                              "libxkbfile-devel", "libXrandr-devel", "libXres-devel", "libXss-devel",
                               "xcb-util-wm-devel", "xcb-util-image-devel", "xcb-util-keysyms-devel",
                               "xcb-util-renderutil-devel", "libXdamage-devel", "libXxf86vm-devel", "libXv-devel",
                               "xcb-util-devel", "libuuid-devel", "xcb-util-cursor-devel"], update=True, check=True)
@@ -67,12 +67,12 @@ class XorgConan(ConanFile):
         pacman = package_manager.PacMan(self)
         pacman.install(["libxcb", "libfontenc", "libice", "libsm", "libxaw", "libxcomposite", "libxcursor",
                               "libxdamage", "libxdmcp", "libxtst", "libxinerama", "libxkbfile", "libxrandr", "libxres",
-                              "xcb-util-wm", "xcb-util-image", "xcb-util-keysyms", "xcb-util-renderutil",
+                              "libxss", "xcb-util-wm", "xcb-util-image", "xcb-util-keysyms", "xcb-util-renderutil",
                               "libxxf86vm", "libxv", "xcb-util", "util-linux-libs", "xcb-util-cursor"], update=True, check=True)
 
         package_manager.Pkg(self).install(["libX11", "libfontenc", "libICE", "libSM", "libXaw", "libXcomposite", "libXcursor",
                            "libXdamage", "libXdmcp", "libXtst", "libXinerama", "libxkbfile", "libXrandr", "libXres",
-                           "xcb-util-wm", "xcb-util-image", "xcb-util-keysyms", "xcb-util-renderutil",
+                           "libXScrnSaver", "xcb-util-wm", "xcb-util-image", "xcb-util-keysyms", "xcb-util-renderutil",
                            "libXxf86vm", "libXv", "xkeyboard-config", "xcb-util", "xcb-util-cursor"], update=True, check=True)
 
         if Version(conan_version) >= "2.0.10":
@@ -80,7 +80,7 @@ class XorgConan(ConanFile):
             alpine.install(["libx11-dev", "	libxcb-dev", "libfontenc-dev", "libice-dev", "libsm-dev", "	libxau-dev", "libxaw-dev",
                             "libxcomposite-dev", "libxcursor-dev", "libxdamage-dev", "libxdmcp-dev", "	libxext-dev", "libxfixes-dev", "libxi-dev",
                             "libxinerama-dev", "libxkbfile-dev", "	libxmu-dev", "libxpm-dev", "libxrandr-dev", "libxrender-dev", "libxres-dev",
-                            "libxt-dev", "libxtst-dev", "libxv-dev", "libxxf86vm-dev",
+                            "libxscrnsaver-dev", "libxt-dev", "libxtst-dev", "libxv-dev", "libxxf86vm-dev",
                             "xcb-util-wm-dev", "xcb-util-image-dev", "xcb-util-keysyms-dev", "xcb-util-renderutil-dev",
                             "libxinerama-dev", "libxcb-dev", "xcb-util-dev", "xcb-util-cursor-dev"], update=True, check=True)
 
@@ -93,7 +93,7 @@ class XorgConan(ConanFile):
         for name in ["x11", "x11-xcb", "fontenc", "ice", "sm", "xau", "xaw7",
                      "xcomposite", "xcursor", "xdamage", "xdmcp", "xext", "xfixes", "xi",
                      "xinerama", "xkbfile", "xmu", "xmuu", "xpm", "xrandr", "xrender", "xres",
-                     "xt", "xtst", "xv", "xxf86vm",
+                     "xscrnsaver", "xt", "xtst", "xv", "xxf86vm",
                      "xcb-xkb", "xcb-icccm", "xcb-image", "xcb-keysyms", "xcb-randr", "xcb-render",
                      "xcb-renderutil", "xcb-shape", "xcb-shm", "xcb-sync", "xcb-xfixes",
                      "xcb-xinerama", "xcb", "xcb-atom", "xcb-aux", "xcb-event", "xcb-util",

--- a/recipes/xorg/all/conanfile.py
+++ b/recipes/xorg/all/conanfile.py
@@ -29,7 +29,7 @@ class XorgConan(ConanFile):
         apt.install(["libx11-dev", "libx11-xcb-dev", "libfontenc-dev", "libice-dev", "libsm-dev", "libxau-dev", "libxaw7-dev",
                      "libxcomposite-dev", "libxcursor-dev", "libxdamage-dev", "libxdmcp-dev", "libxext-dev", "libxfixes-dev",
                      "libxi-dev", "libxinerama-dev", "libxkbfile-dev", "libxmu-dev", "libxmuu-dev",
-                     "libxpm-dev", "libxrandr-dev", "libxrender-dev", "libxres-dev", "libxss-dev", "libxt-dev", "libxtst-dev",
+                     "libxpm-dev", "libxrandr-dev", "libxrender-dev", "libxres-dev", "libxt-dev", "libxtst-dev",
                      "libxv-dev", "libxxf86vm-dev", "libxcb-glx0-dev", "libxcb-render0-dev",
                      "libxcb-render-util0-dev", "libxcb-xkb-dev", "libxcb-icccm4-dev", "libxcb-image0-dev",
                      "libxcb-keysyms1-dev", "libxcb-randr0-dev", "libxcb-shape0-dev", "libxcb-sync-dev", "libxcb-xfixes0-dev",
@@ -42,7 +42,7 @@ class XorgConan(ConanFile):
         yum = package_manager.Yum(self)
         yum.install(["libxcb-devel", "libfontenc-devel", "libXaw-devel", "libXcomposite-devel",
                            "libXcursor-devel", "libXdmcp-devel", "libXtst-devel", "libXinerama-devel",
-                           "libxkbfile-devel", "libXrandr-devel", "libXres-devel", "libXScrnSaver-devel",
+                           "libxkbfile-devel", "libXrandr-devel", "libXres-devel",
                            "xcb-util-wm-devel", "xcb-util-image-devel", "xcb-util-keysyms-devel",
                            "xcb-util-renderutil-devel", "libXdamage-devel", "libXxf86vm-devel", "libXv-devel",
                            "xcb-util-devel", "libuuid-devel", "xcb-util-cursor-devel"], update=True, check=True)
@@ -50,7 +50,7 @@ class XorgConan(ConanFile):
         dnf = package_manager.Dnf(self)
         dnf.install(["libxcb-devel", "libfontenc-devel", "libXaw-devel", "libXcomposite-devel",
                            "libXcursor-devel", "libXdmcp-devel", "libXtst-devel", "libXinerama-devel",
-                           "libxkbfile-devel", "libXrandr-devel", "libXres-devel", "libXScrnSaver-devel",
+                           "libxkbfile-devel", "libXrandr-devel", "libXres-devel",
                            "xcb-util-wm-devel", "xcb-util-image-devel", "xcb-util-keysyms-devel",
                            "xcb-util-renderutil-devel", "libXdamage-devel", "libXxf86vm-devel", "libXv-devel",
                            "xcb-util-devel", "libuuid-devel", "xcb-util-cursor-devel"], update=True, check=True)
@@ -58,7 +58,7 @@ class XorgConan(ConanFile):
         zypper = package_manager.Zypper(self)
         zypper.install(["libxcb-devel", "libfontenc-devel", "libXaw-devel", "libXcomposite-devel",
                               "libXcursor-devel", "libXdmcp-devel", "libXtst-devel", "libXinerama-devel",
-                              "libxkbfile-devel", "libXrandr-devel", "libXres-devel", "libXss-devel",
+                              "libxkbfile-devel", "libXrandr-devel", "libXres-devel",
                               "xcb-util-wm-devel", "xcb-util-image-devel", "xcb-util-keysyms-devel",
                               "xcb-util-renderutil-devel", "libXdamage-devel", "libXxf86vm-devel", "libXv-devel",
                               "xcb-util-devel", "libuuid-devel", "xcb-util-cursor-devel"], update=True, check=True)
@@ -66,12 +66,12 @@ class XorgConan(ConanFile):
         pacman = package_manager.PacMan(self)
         pacman.install(["libxcb", "libfontenc", "libice", "libsm", "libxaw", "libxcomposite", "libxcursor",
                               "libxdamage", "libxdmcp", "libxtst", "libxinerama", "libxkbfile", "libxrandr", "libxres",
-                              "libxss", "xcb-util-wm", "xcb-util-image", "xcb-util-keysyms", "xcb-util-renderutil",
+                              "xcb-util-wm", "xcb-util-image", "xcb-util-keysyms", "xcb-util-renderutil",
                               "libxxf86vm", "libxv", "xcb-util", "util-linux-libs", "xcb-util-cursor"], update=True, check=True)
 
         package_manager.Pkg(self).install(["libX11", "libfontenc", "libICE", "libSM", "libXaw", "libXcomposite", "libXcursor",
                            "libXdamage", "libXdmcp", "libXtst", "libXinerama", "libxkbfile", "libXrandr", "libXres",
-                           "libXScrnSaver", "xcb-util-wm", "xcb-util-image", "xcb-util-keysyms", "xcb-util-renderutil",
+                           "xcb-util-wm", "xcb-util-image", "xcb-util-keysyms", "xcb-util-renderutil",
                            "libXxf86vm", "libXv", "xkeyboard-config", "xcb-util", "xcb-util-cursor"], update=True, check=True)
 
         if Version(conan_version) >= "2.0.10":
@@ -79,7 +79,7 @@ class XorgConan(ConanFile):
             alpine.install(["libx11-dev", "	libxcb-dev", "libfontenc-dev", "libice-dev", "libsm-dev", "	libxau-dev", "libxaw-dev",
                             "libxcomposite-dev", "libxcursor-dev", "libxdamage-dev", "libxdmcp-dev", "	libxext-dev", "libxfixes-dev", "libxi-dev",
                             "libxinerama-dev", "libxkbfile-dev", "	libxmu-dev", "libxpm-dev", "libxrandr-dev", "libxrender-dev", "libxres-dev",
-                            "libxscrnsaver-dev", "libxt-dev", "libxtst-dev", "libxv-dev", "libxxf86vm-dev",
+                            "libxt-dev", "libxtst-dev", "libxv-dev", "libxxf86vm-dev",
                             "xcb-util-wm-dev", "xcb-util-image-dev", "xcb-util-keysyms-dev", "xcb-util-renderutil-dev",
                             "libxinerama-dev", "libxcb-dev", "xcb-util-dev", "xcb-util-cursor-dev"], update=True, check=True)
 
@@ -92,7 +92,7 @@ class XorgConan(ConanFile):
         for name in ["x11", "x11-xcb", "fontenc", "ice", "sm", "xau", "xaw7",
                      "xcomposite", "xcursor", "xdamage", "xdmcp", "xext", "xfixes", "xi",
                      "xinerama", "xkbfile", "xmu", "xmuu", "xpm", "xrandr", "xrender", "xres",
-                     "xscrnsaver", "xt", "xtst", "xv", "xxf86vm",
+                     "xt", "xtst", "xv", "xxf86vm",
                      "xcb-xkb", "xcb-icccm", "xcb-image", "xcb-keysyms", "xcb-randr", "xcb-render",
                      "xcb-renderutil", "xcb-shape", "xcb-shm", "xcb-sync", "xcb-xfixes",
                      "xcb-xinerama", "xcb", "xcb-atom", "xcb-aux", "xcb-event", "xcb-util",

--- a/recipes/xorg/all/test_package/conanfile.py
+++ b/recipes/xorg/all/test_package/conanfile.py
@@ -19,9 +19,10 @@ class TestPackageConan(ConanFile):
     def generate(self):
         pkg_config_deps = PkgConfigDeps(self)
         pkg_config_deps.generate()
-        pkg_config = self.conf_info.get("tools.gnu:pkg_config", default="pkg-config")
-        uuid_pkg_config_file = os.path.join(self.generators_folder, "uuid.pc")
-        self.run(f"{pkg_config} --validate {uuid_pkg_config_file}")
+        if self.settings.os == "Linux":
+            pkg_config = self.conf_info.get("tools.gnu:pkg_config", default="pkg-config")
+            uuid_pkg_config_file = os.path.join(self.generators_folder, "uuid.pc")
+            self.run(f"{pkg_config} --validate {uuid_pkg_config_file}")
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION

### Summary
Changes to recipe:  **xorg/system**
1. Fix FreeBSD package name casing
2. fix FreeBSD test recipe by not probing uuid.pc (it is not installed by the recipe on FreeBSD)
4. set include and lib dirs on freebsd 
libX11 is installed in /usr/local/ cf https://freebsd.pkgs.org/15/freebsd-aarch64/libX11-1.8.13_1,1~277371ac3e.pkg.html which is not taken into account by the compiler and linker by default cf https://wiki.freebsd.org/WarnerLosh/UsrLocal.

#### Motivation
```
  xorg/system: RUN: pkg install -y libX11 libfontenc libice libsm libxaw libxcomposite libxcursor libxdamage libxdmcp libxtst libxinerama libxkbfile libxrandr libxres libXScrnSaver xcb-util-wm xcb-util-image xcb-util-keysyms xcb-util-renderutil libxxf86vm libxv xkeyboard-config xcb-util xcb-util-cursor
  Updating FreeBSD-ports repository catalogue...
  FreeBSD-ports repository is up to date.
  Updating FreeBSD-ports-kmods repository catalogue...
  FreeBSD-ports-kmods repository is up to date.
  Updating FreeBSD-base repository catalogue...
  FreeBSD-base repository is up to date.
  All repositories are up to date.
  pkg: No packages available to install matching 'libice' have been found in the repositories
  pkg: No packages available to install matching 'libsm' have been found in the repositories
  pkg: No packages available to install matching 'libxaw' have been found in the repositories
  pkg: No packages available to install matching 'libxcomposite' have been found in the repositories
  pkg: No packages available to install matching 'libxcursor' have been found in the repositories
  pkg: No packages available to install matching 'libxdamage' have been found in the repositories
  pkg: No packages available to install matching 'libxdmcp' have been found in the repositories
  pkg: No packages available to install matching 'libxtst' have been found in the repositories
  pkg: No packages available to install matching 'libxinerama' have been found in the repositories
  pkg: No packages available to install matching 'libxrandr' have been found in the repositories
  pkg: No packages available to install matching 'libxres' have been found in the repositories
  pkg: No packages available to install matching 'libxxf86vm' have been found in the repositories
  pkg: No packages available to install matching 'libxv' have been found in the repositories
  
  ERROR: xorg/system: Error in system_requirements() method, line 72
  	package_manager.Pkg(self).install(["libX11", "libfontenc", "libice", "libsm", "libxaw", "libxcomposite", "libxcursor",
  	ConanException: Command 'pkg install -y libX11 libfontenc libice libsm libxaw libxcomposite libxcursor libxdamage libxdmcp libxtst libxinerama libxkbfile libxrandr libxres libXScrnSaver xcb-util-wm xcb-util-image xcb-util-keysyms xcb-util-renderutil libxxf86vm libxv xkeyboard-config xcb-util xcb-util-cursor' failed with exit code 1
```
#### Details
https://pkgs.org/download/libICE
https://pkgs.org/download/libSM
https://pkgs.org/download/libXaw
https://pkgs.org/download/libXcomposite
https://pkgs.org/download/libXcursor
https://pkgs.org/download/libXdamage
https://pkgs.org/download/libXdmcp
https://pkgs.org/download/libXtst
https://pkgs.org/download/libXinerama
https://pkgs.org/download/libXrandr
https://pkgs.org/download/libXres
https://pkgs.org/download/libXxf86vm
https://pkgs.org/download/libXv


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
