### PR TITLE
discord_game_sdk: Add recipe 3.2.1

### DIFF
--- a/recipes/discord_game_sdk/all/CMakeLists.txt
+++ b/recipes/discord_game_sdk/all/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.15)
+project(discord_game_sdk_cpp CXX)
+
+find_library(SDK_LIB discord_game_sdk PATHS "${SDK_LIB_FOLDER}" NO_DEFAULT_PATH)
+
+file(GLOB SRC_FILES "${CMAKE_CURRENT_SOURCE_DIR}/cpp/*.cpp")
+
+add_library(discord_game_sdk_cpp STATIC ${SRC_FILES})
+target_link_libraries(discord_game_sdk_cpp PUBLIC ${SDK_LIB})
+set_property(TARGET discord_game_sdk_cpp PROPERTY CXX_STANDARD 11)
+
+install(TARGETS discord_game_sdk_cpp ARCHIVE DESTINATION lib)
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/cpp/" DESTINATION include FILES_MATCHING PATTERN "*.h")
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/c/discord_game_sdk.h" DESTINATION include)

--- a/recipes/discord_game_sdk/all/conandata.yml
+++ b/recipes/discord_game_sdk/all/conandata.yml
@@ -1,0 +1,8 @@
+sources:
+  "3.2.1":
+    url: "https://dl-game-sdk.discordapp.net/3.2.1/discord_game_sdk.zip"
+    sha256: "6757bb4a1f5b42aa7b6707cbf2158420278760ac5d80d40ca708bb01d20ae6b4"
+patches:
+  "3.2.1":
+    - patch_file: "patches/3.2.1-0001-include-cstdint.patch"
+      patch_description: "Include <cstdint> so the C++ wrapper compiles on newer GCC/Clang"

--- a/recipes/discord_game_sdk/all/conanfile.py
+++ b/recipes/discord_game_sdk/all/conanfile.py
@@ -1,0 +1,108 @@
+import os
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rename
+from conan.tools.build import check_min_cppstd
+from conan.errors import ConanInvalidConfiguration
+
+required_conan_version = ">=2.0"
+
+
+class DiscordGameSdkConan(ConanFile):
+    name = "discord_game_sdk"
+    description = "The Discord GameSDK is an easy drop-in SDK to help you manage all the hard things that come with making a game."
+    license = "LicenseRef-discord-game-sdk" # https://discord.com/developers/docs/legal
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://discord.com/developers/docs/game-sdk/sdk-starter-guide"
+    topics = ("discord", "game", "sdk", "gamedev")
+    package_type = "shared-library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {"fPIC": [True, False]}
+    default_options = {"fPIC": True}
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    @property
+    def _sdk_lib_arch(self):
+        arch = str(self.settings.arch)
+        if arch == "x86":
+            return "x86"
+        elif arch == "x86_64":
+            return "x86_64"
+        elif arch.startswith("armv8"):
+            return "aarch64"
+        return None
+
+    @property
+    def _sdk_lib_dir(self):
+        return os.path.join(self.source_folder, "lib", self._sdk_lib_arch)
+
+    def validate(self):
+        os_name = str(self.settings.os)
+        arch_name = str(self.settings.arch)
+        supported = (
+            (os_name == "Windows" and arch_name in ("x86", "x86_64")) or
+            (os_name == "Linux" and arch_name == "x86_64") or
+            (os_name == "Macos" and arch_name in ("x86_64", "armv8"))
+        )
+        if not supported:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} does not support {os_name}/{arch_name}"
+            )
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, 11)
+
+    def export_sources(self):
+        copy(self, "CMakeLists.txt", src=self.recipe_folder, dst=self.export_sources_folder)
+        export_conandata_patches(self)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version],
+            destination=self.source_folder, strip_root=False)
+        apply_conandata_patches(self)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.cache_variables["SDK_LIB_FOLDER"] = self._sdk_lib_dir.replace("\\", "/")
+        tc.generate()
+
+    def build(self):
+        if self.settings.os == "Windows":
+            rename(self, os.path.join(self._sdk_lib_dir, "discord_game_sdk.dll.lib"),
+                   os.path.join(self._sdk_lib_dir, "discord_game_sdk.lib"))
+        elif self.settings.os == "Macos":
+            rename(self, os.path.join(self._sdk_lib_dir, "discord_game_sdk.dylib"),
+                   os.path.join(self._sdk_lib_dir, "libdiscord_game_sdk.dylib"))
+        else:
+            rename(self, os.path.join(self._sdk_lib_dir, "discord_game_sdk.so"),
+                   os.path.join(self._sdk_lib_dir, "libdiscord_game_sdk.so"))
+
+        cmake = CMake(self)
+        cmake.configure(build_script_folder=self.source_folder)
+        cmake.build()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+
+        if self.settings.os == "Windows":
+            copy(self, "discord_game_sdk.dll", src=self._sdk_lib_dir,
+                 dst=os.path.join(self.package_folder, "bin"), keep_path=False)
+            copy(self, "discord_game_sdk.lib", src=self._sdk_lib_dir,
+                 dst=os.path.join(self.package_folder, "lib"), keep_path=False)
+        elif self.settings.os == "Macos":
+            copy(self, "libdiscord_game_sdk.dylib", src=self._sdk_lib_dir,
+                 dst=os.path.join(self.package_folder, "lib"), keep_path=False)
+        else:
+            copy(self, "libdiscord_game_sdk.so", src=self._sdk_lib_dir,
+                 dst=os.path.join(self.package_folder, "lib"), keep_path=False)
+
+    def package_info(self):
+        self.cpp_info.libs = ["discord_game_sdk_cpp", "discord_game_sdk"]
+        if self.settings.os == "Windows":
+            self.cpp_info.bindirs = ["bin"]

--- a/recipes/discord_game_sdk/all/patches/3.2.1-0001-include-cstdint.patch
+++ b/recipes/discord_game_sdk/all/patches/3.2.1-0001-include-cstdint.patch
@@ -1,0 +1,9 @@
+diff --git a/cpp/types.h b/cpp/types.h
+index 76c4311..05120eb 100644
+--- a/cpp/types.h
++++ b/cpp/types.h
+@@ -6,3 +6,4 @@
+ #include <Windows.h>
+ #include <dxgi.h>
+ #endif
++#include <cstdint>

--- a/recipes/discord_game_sdk/all/test_package/CMakeLists.txt
+++ b/recipes/discord_game_sdk/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package CXX)
+
+find_package(discord_game_sdk REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE discord_game_sdk::discord_game_sdk)

--- a/recipes/discord_game_sdk/all/test_package/conanfile.py
+++ b/recipes/discord_game_sdk/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+import os
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import can_run
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/discord_game_sdk/all/test_package/test_package.cpp
+++ b/recipes/discord_game_sdk/all/test_package/test_package.cpp
@@ -1,0 +1,22 @@
+#include <cstdlib>
+#include <iostream>
+
+#include <discord_game_sdk.h>
+#include <discord.h>
+
+int main()
+{
+    discord::Core *core{};
+    auto result = discord::Core::Create(310270644849737729, DiscordCreateFlags_Default, &core);
+    std::cout << "C++ wrapper Create result: " << static_cast<int>(result) << std::endl;
+
+    struct DiscordCreateParams params;
+    DiscordCreateParamsSetDefault(&params);
+    params.client_id = 310270644849737729;
+    params.flags = DiscordCreateFlags_Default;
+    struct IDiscordCore *c_core = nullptr;
+    enum EDiscordResult c_result = DiscordCreate(DISCORD_VERSION, &params, &c_core);
+    std::cout << "C API DiscordCreate result: " << static_cast<int>(c_result) << std::endl;
+
+    return EXIT_SUCCESS;
+}

--- a/recipes/discord_game_sdk/config.yml
+++ b/recipes/discord_game_sdk/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "3.2.1":
+    folder: "all"


### PR DESCRIPTION
### Summary
Adds the Discord Game SDK library https://discord.com/developers/docs/game-sdk/sdk-starter-guide

#### Motivation
Even though a newer version of Discord's SDK exists, the Game SDK is still the most commonly used by open source projects. For example, some of the more popular open source projects that use it include:

- https://github.com/diasurgical/DevilutionX
- https://github.com/OpenXRay/xray-16
- https://github.com/OpenStarbound/OpenStarbound

It also exists as a vcpkg package https://github.com/microsoft/vcpkg/tree/00d899c410b31467733472fc3a83a25729046b13/ports/discord-game-sdk


#### Details

I confirmed that it works locally on Windows and WSL with GCC, which required the patch.
It is a shared library, which on Windows requires `discord_game_sdk.dll` with the release

This line: `self.cpp_info.libs = ["discord_game_sdk_cpp", "discord_game_sdk"]`
ensures that either the `C` `<discord_game_sdk.h>` or `C++` wrapper `<discord.h>` can be included.

I'm unsure if the `arch.startswith("armv8")` is a proper detection for `aarch64` systems


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
