### PR TITLE
Upgraded OpenE57 to 1.9.0

### DIFF
--- a/recipes/opene57/all/conandata.yml
+++ b/recipes/opene57/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "1.8.0":
     url: "https://github.com/openE57/openE57/archive/1.8.0.tar.gz"
     sha256: "20fef7fa6dcb6d3a5ea558e5b389e3ee9734ab42e939ae29d999a9268e3781bd"
+  "1.9.0":
+    url: "https://github.com/openE57/openE57/archive/1.9.0.tar.gz"
+    sha256: "43e702780d768dfadff9644afe08a3ffa666a495c7d82293bbdee0dcf5247c43"

--- a/recipes/opene57/all/conandata.yml
+++ b/recipes/opene57/all/conandata.yml
@@ -1,7 +1,4 @@
 sources:
-  "1.8.0":
-    url: "https://github.com/openE57/openE57/archive/1.8.0.tar.gz"
-    sha256: "20fef7fa6dcb6d3a5ea558e5b389e3ee9734ab42e939ae29d999a9268e3781bd"
   "1.9.0":
     url: "https://github.com/openE57/openE57/archive/1.9.0.tar.gz"
     sha256: "43e702780d768dfadff9644afe08a3ffa666a495c7d82293bbdee0dcf5247c43"

--- a/recipes/opene57/all/conanfile.py
+++ b/recipes/opene57/all/conanfile.py
@@ -63,8 +63,8 @@ class Opene57Conan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        # Versions prior to 1.9.0 require Boost Libraries for the tools
-        if self.options.with_tools and self.version < "1.9.0":
+        # The Version 1.8.0 require Boost Libraries for the tools, newer versions do not require it anymore
+        if self.options.with_tools and self.version == "1.8.0":
             self.requires("boost/1.90.0")
 
         if self.options.with_docs:

--- a/recipes/opene57/all/conanfile.py
+++ b/recipes/opene57/all/conanfile.py
@@ -63,7 +63,8 @@ class Opene57Conan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        if self.options.with_tools:
+        # Versions prior to 1.9.0 require Boost Libraries for the tools
+        if self.options.with_tools and self.version < "1.9.0":
             self.requires("boost/1.90.0")
 
         if self.options.with_docs:

--- a/recipes/opene57/all/conanfile.py
+++ b/recipes/opene57/all/conanfile.py
@@ -56,17 +56,11 @@ class Opene57Conan(ConanFile):
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
-        if self.options.with_tools:
-            self.options["boost"].multithreading = True
 
     def layout(self):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        # The Version 1.8.0 require Boost Libraries for the tools, newer versions do not require it anymore
-        if self.options.with_tools and self.version == "1.8.0":
-            self.requires("boost/1.90.0")
-
         if self.options.with_docs:
             self.requires("doxygen/[>=1.8 <2]")
 

--- a/recipes/opene57/config.yml
+++ b/recipes/opene57/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.8.0":
+  "1.9.0":
     folder: all


### PR DESCRIPTION
### Summary
Added new version for recipe:  **opene57/1.9.0**

#### Motivation
Added the new version of the library, updated the Recipe to include Boost libraries only if the recipe itself is building a version prior to 1.9.0 (currently: 1.8.0).

#### Details
A newer version of the library has been made available, thus this PR updates the conan-center-index to include it.


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
