### PR TITLE
qt/6.11.x Bump NodeJS requirement

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -428,7 +428,7 @@ class QtConan(ConanFile):
             self.tool_requires("pkgconf/[>=2.2 <3]")
 
         if self.options.get_safe("qtwebengine"):
-            self.tool_requires("nodejs/18.15.0")
+            self.tool_requires("nodejs/22.20.0")
             self.tool_requires("gperf/3.1")
             # gperf, bison, flex, python >= 2.7.5 & < 3
             if self.settings_build.os == "Windows":


### PR DESCRIPTION
### Summary
Changes to recipe:  **qt/6.11.***

#### Motivation
Starting with Qt 6.11, Qt WebEngine requires a NodeJS version of 20.0 or higher. 
Otherwise, Qt prints this during the configuration summary:
```
WARNING: QtWebEngine won't be built. The following configure errors were found:
 * 64-bit Node.js 20.0 version or later is required.
```

#### Details
See: https://doc.qt.io/qt-6.11/qtwebengine-platform-notes.html#all-platforms

I only tested this on Qt6.11.1. Not on 6.8.x or 6.10.x.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
