### PR TITLE
sdl_net: add new 3.x major

### DIFF
--- a/recipes/sdl_net/3.x/conandata.yml
+++ b/recipes/sdl_net/3.x/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "3.2.0":
-    url: "https://github.com/libsdl-org/SDL_net/archive/refs/tags/release-3.2.0.tar.gz"
+    url: "https://github.com/libsdl-org/SDL_net/releases/download/release-3.2.0/SDL3_net-3.2.0.tar.gz"
     sha256: "195036ba82322e03fd3562149634fb582e5e9298ccc6cb2c5e362bf40c5018be"

--- a/recipes/sdl_net/3.x/conandata.yml
+++ b/recipes/sdl_net/3.x/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "3.2.0":
+    url: "https://github.com/libsdl-org/SDL_net/archive/refs/tags/release-3.2.0.tar.gz"
+    sha256: "195036ba82322e03fd3562149634fb582e5e9298ccc6cb2c5e362bf40c5018be"

--- a/recipes/sdl_net/3.x/conandata.yml
+++ b/recipes/sdl_net/3.x/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "3.2.0":
     url: "https://github.com/libsdl-org/SDL_net/releases/download/release-3.2.0/SDL3_net-3.2.0.tar.gz"
-    sha256: "195036ba82322e03fd3562149634fb582e5e9298ccc6cb2c5e362bf40c5018be"
+    sha256: "098522fc26d4e302ef9348aee6e76e67fe504dfefd7f596236568f8330570c41"

--- a/recipes/sdl_net/3.x/conanfile.py
+++ b/recipes/sdl_net/3.x/conanfile.py
@@ -3,7 +3,6 @@ from conan.errors import ConanInvalidConfiguration
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir
 from conan.tools.microsoft import is_msvc
-from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=2.1"
@@ -36,8 +35,6 @@ class SdlnetConan(ConanFile):
         self.requires("sdl/[>=3.2.6 <4]", transitive_headers=True, transitive_libs=True)
 
     def validate(self):
-        if Version(self.version).major != Version(self.dependencies["sdl"].ref.version).major:
-            raise ConanInvalidConfiguration("sdl & sdl_net must have the same major version")
         if self.options.shared != self.dependencies["sdl"].options.shared:
             raise ConanInvalidConfiguration("sdl & sdl_net must be built with the same 'shared' option value")
 

--- a/recipes/sdl_net/3.x/conanfile.py
+++ b/recipes/sdl_net/3.x/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, get
+from conan.tools.files import copy, get, rmdir
 from conan.tools.microsoft import is_msvc
 from conan.tools.scm import Version
 import os
@@ -62,6 +62,10 @@ class SdlnetConan(ConanFile):
         copy(self, "LICENSE.txt", self.source_folder, os.path.join(self.package_folder, "licenses"))
         cmake = CMake(self)
         cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
 
     def package_info(self):
         lib_suffix = ""

--- a/recipes/sdl_net/3.x/conanfile.py
+++ b/recipes/sdl_net/3.x/conanfile.py
@@ -1,0 +1,77 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get
+from conan.tools.microsoft import is_msvc
+from conan.tools.scm import Version
+import os
+
+required_conan_version = ">=2.1"
+
+
+class SdlnetConan(ConanFile):
+    name = "sdl_net"
+    description = "A networking library for SDL"
+    license = "Zlib"
+    topics = ("sdl2", "sdl2_net", "sdl", "sdl_net", "net", "networking")
+    homepage = "https://www.libsdl.org/projects/SDL_net"
+    url = "https://github.com/conan-io/conan-center-index"
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+    implements = ["auto_shared_fpic"]
+    languages = "C"
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("sdl/[>=3.2.6 <4]", transitive_headers=True, transitive_libs=True)
+
+    def validate(self):
+        if Version(self.version).major != Version(self.dependencies["sdl"].ref.version).major:
+            raise ConanInvalidConfiguration("sdl & sdl_net must have the same major version")
+        if self.options.shared != self.dependencies["sdl"].options.shared:
+            raise ConanInvalidConfiguration("sdl & sdl_net must be built with the same 'shared' option value")
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.16]")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE.txt", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        lib_suffix = ""
+        if is_msvc(self) and not self.options.shared:
+            lib_suffix = "-static"
+        self.cpp_info.libs = [f"SDL3_net{lib_suffix}"]
+        self.cpp_info.set_property("cmake_file_name", "SDL3_net")
+        suffix = "-static" if not self.options.shared else ""
+        self.cpp_info.set_property("cmake_target_name", f"SDL3_net::SDL3_net{suffix}")
+        self.cpp_info.set_property("pkg_config_name", "sdl3-net")
+
+        if self.settings.os == "Windows":
+            self.cpp_info.system_libs.extend(["ws2_32", "iphlpapi"])

--- a/recipes/sdl_net/3.x/test_package/CMakeLists.txt
+++ b/recipes/sdl_net/3.x/test_package/CMakeLists.txt
@@ -5,8 +5,4 @@ find_package(SDL3_net REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.c)
 
-if(TARGET SDL3_net::SDL3_net)
-    target_link_libraries(${PROJECT_NAME} PRIVATE SDL3_net::SDL3_net)
-else()
-    target_link_libraries(${PROJECT_NAME} PRIVATE SDL3_net::SDL3_net-static)
-endif()
+target_link_libraries(${PROJECT_NAME} PRIVATE $<IF:$<TARGET_EXISTS:SDL3_net::SDL3_net>,SDL3_net::SDL3_net,SDL3_net::SDL3_net-static>)

--- a/recipes/sdl_net/3.x/test_package/CMakeLists.txt
+++ b/recipes/sdl_net/3.x/test_package/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES C)
+
+find_package(SDL3_net REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+
+if(TARGET SDL3_net::SDL3_net)
+    target_link_libraries(${PROJECT_NAME} PRIVATE SDL3_net::SDL3_net)
+else()
+    target_link_libraries(${PROJECT_NAME} PRIVATE SDL3_net::SDL3_net-static)
+endif()

--- a/recipes/sdl_net/3.x/test_package/conanfile.py
+++ b/recipes/sdl_net/3.x/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/sdl_net/3.x/test_package/test_package.c
+++ b/recipes/sdl_net/3.x/test_package/test_package.c
@@ -1,0 +1,7 @@
+#define SDL_MAIN_HANDLED
+#include <SDL3_net/SDL_net.h>
+#include <stdio.h>
+
+int main(int argc, char **argv) {
+    printf("SDL3_net version: %i", NET_Version());
+}

--- a/recipes/sdl_net/3.x/test_package/test_package.c
+++ b/recipes/sdl_net/3.x/test_package/test_package.c
@@ -1,4 +1,3 @@
-#define SDL_MAIN_HANDLED
 #include <SDL3_net/SDL_net.h>
 #include <stdio.h>
 

--- a/recipes/sdl_net/config.yml
+++ b/recipes/sdl_net/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "3.2.0":
+    folder: 3.x
   "2.2.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **sdl_net/3.x**

#### Motivation

Finally, after having having been following [this](https://github.com/libsdl-org/SDL_net/issues/125#event-26158575219) upstream thread for months, `sdl_net` has finally released the 3.x major!

This library has been requested in this ticket https://github.com/conan-io/conan-center-index/issues/28332. 
And we can finally mark it as done after merging this PR as all the SDL libraries in CCI will have a 3.x recipe now.

Close https://github.com/conan-io/conan-center-index/issues/28332
  
#### Details

This PR follows the same pattern as all other SDL_xxx PRs:
- sdl_image: https://github.com/conan-io/conan-center-index/pull/28361
- sdl_mixer: https://github.com/conan-io/conan-center-index/pull/30055
- sdl_ttf: https://github.com/conan-io/conan-center-index/pull/27166

Changes:
- New conanfile has been created in order to avoid several version conditional branches.
- This new major does not need a external `CMakeLists.txt`.
- As always, `SDL_net` and `SDL` must be in the same major and must be compiled with the same `shared` option.
- MSVC+static has `-static` suffix (see [upstream](https://github.com/libsdl-org/SDL_net/blob/main/CMakeLists.txt#L218) CMakeLists.txt)
- CMake targets also has `-static` suffix when building in static (same as other SDL_* libraries)
- Windows needs `ws2_32` and `iphlpapi` definition (same as SDL_net 2.x recipe)

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
