### PR TITLE
cnats: add version 3.13.0

### DIFF
--- a/recipes/cnats/all/conandata.yml
+++ b/recipes/cnats/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "3.12.0":
-    url: "https://github.com/nats-io/nats.c/archive/refs/tags/v3.12.0.tar.gz"
-    sha256: "06b64d7045fd618c98e5608001b384bdbfa6a17718dba64e732ba72a6f00649b"
+  "3.13.0":
+    url: "https://github.com/nats-io/nats.c/archive/refs/tags/v3.13.0.tar.gz"
+    sha256: "f6ec9ee2ab367594b56dd3265e3561074ade7c3d7410a6f45a77704c5e537024"

--- a/recipes/cnats/config.yml
+++ b/recipes/cnats/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "3.12.0":
+  "3.13.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **cnats/3.13.0**

#### Motivation

cnats 3.13.0 is released.

#### Details

Release note: https://github.com/nats-io/nats.c/releases/tag/v3.13.0
Changes: https://github.com/nats-io/nats.c/compare/v3.12.0...v3.13.0

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
