### PR TITLE
libjpeg: Defer injection of `conantoolchain_props`

### DIFF
--- a/recipes/libjpeg/all/conanfile.py
+++ b/recipes/libjpeg/all/conanfile.py
@@ -110,16 +110,6 @@ class LibjpegConan(ConanFile):
                 # Don't force LTO
                 replace_in_file(self, jpeg_vcxproj, "<WholeProgramOptimization>true</WholeProgramOptimization>", "")
 
-                # Inject conan-generated .props file
-                # Note: importing it right before Microsoft.Cpp.props also ensures we correctly
-                #       handle the toolset setting
-                conantoolchain_props = os.path.join(self.generators_folder, MSBuildToolchain.filename)
-                replace_in_file(
-                    self, jpeg_vcxproj,
-                    """<Import Project="$(VCTargetsPath)\\Microsoft.Cpp.props" />""",
-                    f"""<Import Project="{conantoolchain_props}" /><Import Project="$(VCTargetsPath)\\Microsoft.Cpp.props" />""",
-                )
-
                 # Patch settings for a different build type
                 if self.settings.build_type is not "Release":
                     replacements = {
@@ -134,6 +124,16 @@ class LibjpegConan(ConanFile):
                         replace_in_file(self, jpeg_vcxproj, key, value)
 
                     replace_in_file(self, os.path.join(self.source_folder, "jpeg.sln"), "Release", str(self.settings.build_type))
+
+                # Inject conan-generated .props file
+                # Note: importing it right before Microsoft.Cpp.props also ensures we correctly
+                #       handle the toolset setting
+                conantoolchain_props = os.path.join(self.generators_folder, MSBuildToolchain.filename)
+                replace_in_file(
+                    self, jpeg_vcxproj,
+                    """<Import Project="$(VCTargetsPath)\\Microsoft.Cpp.props" />""",
+                    f"""<Import Project="{conantoolchain_props}" /><Import Project="$(VCTargetsPath)\\Microsoft.Cpp.props" />""",
+                )
 
                 msbuild = MSBuild(self)
                 if self.settings.arch == "x86":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libjpeg/***

#### Motivation
Close: https://github.com/conan-io/conan-center-index/issues/30304

#### Details

To handle the case where `conantoolchain_props` contains the string `Release`, defer injection in `jpeg.vcxproj` until after replacing all other occurrences of `Release`. Because `conantoolchain_props` is already derived from Conan, its initial value will be the correct, valid path and does not require replacement.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
