### PR TITLE
expat: Fix definition of XML_UNICODE_WCHAR_T

### DIFF
--- a/recipes/expat/all/conanfile.py
+++ b/recipes/expat/all/conanfile.py
@@ -90,7 +90,7 @@ class ExpatConan(ConanFile):
             self.cpp_info.defines = ["XML_STATIC"]
         if self.options.get_safe("char_type") in ("wchar_t", "ushort"):
             self.cpp_info.defines.append("XML_UNICODE")
-        elif self.options.get_safe("char_type") == "wchar_t":
+        if self.options.get_safe("char_type") == "wchar_t":
             self.cpp_info.defines.append("XML_UNICODE_WCHAR_T")
         if self.options.large_size:
             self.cpp_info.defines.append("XML_LARGE_SIZE")

--- a/recipes/expat/all/conanfile.py
+++ b/recipes/expat/all/conanfile.py
@@ -62,8 +62,6 @@ class ExpatConan(ConanFile):
             tc.variables["EXPAT_MSVC_STATIC_CRT"] = is_msvc_static_runtime(self)
         tc.variables["EXPAT_BUILD_PKGCONFIG"] = False
         tc.variables["EXPAT_LARGE_SIZE"] = self.options.large_size
-        if self.options.char_type == "wchar_t" and self.settings.os != "Windows":
-            tc.extra_cflags.append("-fshort-wchar")
         tc.generate()
 
     def build(self):
@@ -94,9 +92,6 @@ class ExpatConan(ConanFile):
             self.cpp_info.defines.append("XML_UNICODE")
         if self.options.get_safe("char_type") == "wchar_t":
             self.cpp_info.defines.append("XML_UNICODE_WCHAR_T")
-            if self.settings.os != "Windows":
-                self.cpp_info.cflags.append("-fshort-wchar")
-                self.cpp_info.cxxflags.append("-fshort-wchar")
         if self.options.large_size:
             self.cpp_info.defines.append("XML_LARGE_SIZE")
 

--- a/recipes/expat/all/conanfile.py
+++ b/recipes/expat/all/conanfile.py
@@ -62,6 +62,8 @@ class ExpatConan(ConanFile):
             tc.variables["EXPAT_MSVC_STATIC_CRT"] = is_msvc_static_runtime(self)
         tc.variables["EXPAT_BUILD_PKGCONFIG"] = False
         tc.variables["EXPAT_LARGE_SIZE"] = self.options.large_size
+        if self.options.char_type == "wchar_t" and self.settings.os != "Windows":
+            tc.extra_cflags.append("-fshort-wchar")
         tc.generate()
 
     def build(self):
@@ -92,6 +94,9 @@ class ExpatConan(ConanFile):
             self.cpp_info.defines.append("XML_UNICODE")
         if self.options.get_safe("char_type") == "wchar_t":
             self.cpp_info.defines.append("XML_UNICODE_WCHAR_T")
+            if self.settings.os != "Windows":
+                self.cpp_info.cflags.append("-fshort-wchar")
+                self.cpp_info.cxxflags.append("-fshort-wchar")
         if self.options.large_size:
             self.cpp_info.defines.append("XML_LARGE_SIZE")
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **libexpat/[*]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Closes https://github.com/conan-io/conan-center-index/issues/30226

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
`XML_UNICODE_WCHAR_T` is specialization of `XML_UNICODE`, not an alternative.

Note that upstream libexpat does **not** propagate the definitions automatically, which seem to be intended to be definied by the consumer (even with the risk of abi issues). As the recipe already propagates them and removing it would be breaking for users, let's keep them around and fixing them, knowing that outside of Conan, the definition would come from the consumer

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
