### PR TITLE
polylite: add version 4.5.0

### DIFF
--- a/recipes/polylite/all/conandata.yml
+++ b/recipes/polylite/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "4.5.0":
+    url: "https://github.com/kristianivarsson/polylite/archive/refs/tags/4.5.0.tar.gz"
+    sha256: "78e9bbc2429b30bc58e6c84a3f00aea6fe23d3d3d7101e495a769d8722b41438"

--- a/recipes/polylite/all/conanfile.py
+++ b/recipes/polylite/all/conanfile.py
@@ -1,0 +1,55 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+
+
+required_conan_version = ">=1.52.0"
+
+
+class PolyLiteConan(ConanFile):
+    name = "polylite"
+    description = (
+        "Header-only C++23 multiprotocol library for CBOR, JSON, TOML and YAML."
+    )
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/kristianivarsson/polylite"
+    topics = ("json", "yaml", "toml", "cbor", "header-only", "cpp23", "parser")
+    settings = "os", "arch", "compiler", "build_type"
+    package_type = "header-library"
+    no_copy_source = True
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def validate(self):
+        check_min_cppstd(self, 23)
+
+    def package_id(self):
+        self.info.clear()
+
+    def package(self):
+        copy(
+            self,
+            "*.hpp",
+            src=os.path.join(self.source_folder, "include"),
+            dst=os.path.join(self.package_folder, "include"),
+        )
+        copy(
+            self,
+            "LICENSE",
+            src=self.source_folder,
+            dst=os.path.join(self.package_folder, "licenses"),
+        )
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.set_property("cmake_file_name", "polylite")
+        self.cpp_info.set_property("cmake_target_name", "polylite::polylite")

--- a/recipes/polylite/all/test_package/CMakeLists.txt
+++ b/recipes/polylite/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(polylite CONFIG REQUIRED)
+
+add_executable(test_package test_package.cpp)
+target_link_libraries(test_package PRIVATE polylite::polylite)
+target_compile_features(test_package PRIVATE cxx_std_23)

--- a/recipes/polylite/all/test_package/conanfile.py
+++ b/recipes/polylite/all/test_package/conanfile.py
@@ -1,0 +1,27 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/polylite/all/test_package/test_package.cpp
+++ b/recipes/polylite/all/test_package/test_package.cpp
@@ -1,0 +1,9 @@
+#include <cassert>
+
+#include <poly/yaml.hpp>
+
+int main() {
+    auto root = poly::yaml::parse("ok: true");
+    assert(root.is_object());
+    return 0;
+}

--- a/recipes/polylite/config.yml
+++ b/recipes/polylite/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "4.5.0":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe: **polylite/4.5.0**

#### Motivation
Add a new recipe for [polylite](https://github.com/kristianivarsson/polylite), a header-only C++23 multiprotocol library supporting CBOR, JSON, TOML and YAML.

#### Details
- New recipe at `recipes/polylite/all/`.
- Header-only; `package_id().info.clear()` so a single binary covers all settings.
- Requires C++23, enforced via `check_min_cppstd`.
- `test_package` parses a minimal YAML document and asserts the resulting node is an object.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!