### PR TITLE
Add tesults-cpp/1.0.2

### DIFF
--- a/recipes/tesults-cpp/all/conandata.yml
+++ b/recipes/tesults-cpp/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.0.2":
+    url: "https://github.com/tesults/cpp/archive/refs/tags/v1.0.2.tar.gz"
+    sha256: "be0c4713699ce122c7185c3d2ff30055406def324eebbaae0dca2cf10d34a107"

--- a/recipes/tesults-cpp/all/conanfile.py
+++ b/recipes/tesults-cpp/all/conanfile.py
@@ -1,0 +1,53 @@
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get
+import os
+
+required_conan_version = ">=1.53.0"
+
+
+class TesultsCppConan(ConanFile):
+    name = "tesults-cpp"
+    description = "C++ library for uploading test results to Tesults"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/tesults/cpp"
+    topics = ("tesults", "testing", "test-results", "reporting")
+    package_type = "static-library"
+    settings = "os", "compiler", "build_type", "arch"
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("libcurl/[>=7.64.0 <9]")
+        self.requires("openssl/[>=1.1 <4]")
+        self.requires("nlohmann_json/[>=3.9.0 <4]")
+
+    def validate(self):
+        check_min_cppstd(self, 17)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["tesults"]
+        self.cpp_info.set_property("cmake_file_name", "tesults")
+        self.cpp_info.set_property("cmake_target_name", "tesults::tesults")

--- a/recipes/tesults-cpp/all/test_package/CMakeLists.txt
+++ b/recipes/tesults-cpp/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(tesults CONFIG REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE tesults::tesults)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/tesults-cpp/all/test_package/conanfile.py
+++ b/recipes/tesults-cpp/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+import os
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            self.run(os.path.join(self.cpp.build.bindirs[0], "test_package"), env="conanrun")

--- a/recipes/tesults-cpp/all/test_package/test_package.cpp
+++ b/recipes/tesults-cpp/all/test_package/test_package.cpp
@@ -1,0 +1,18 @@
+#include <tesults/tesults.h>
+
+#include <iostream>
+#include <string>
+
+int main() {
+    tesults::Case c;
+    c.name = "example";
+    c.suite = "ExampleSuite";
+    c.result = "pass";
+
+    tesults::Data data;
+    data.target = "token";
+    data.cases.push_back(c);
+
+    std::cout << "tesults-cpp: " << data.cases.size() << " case(s) ready\n";
+    return 0;
+}


### PR DESCRIPTION
## Description

Add new package `tesults-cpp` version `1.0.2`.

`tesults-cpp` is a C++ static library for uploading test results to [Tesults](https://www.tesults.com). It provides a simple API for reporting test case results, custom fields, steps, and file uploads.

- **License**: MIT
- **Homepage**: https://github.com/tesults/cpp
- **Package type**: static-library
- **Minimum C++ standard**: C++17

### Dependencies

- `libcurl`
- `openssl`
- `nlohmann_json`

### Notes

- Uses CMake as build system with standard `find_package` for all dependencies
- No FetchContent is triggered when dependencies are provided by Conan
- `tesults-cpp` is a prerequisite for `tesults-gtest` (submitted separately, depends on this PR)