### PR TITLE
Add tesults-gtest/1.0.2

### DIFF
--- a/recipes/tesults-gtest/all/conandata.yml
+++ b/recipes/tesults-gtest/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.0.2":
+    url: "https://github.com/tesults/tesults-gtest/archive/refs/tags/v1.0.2.tar.gz"
+    sha256: "e757dd90d95b96ba62e8bff7bbce1842f284c3fc45a10f77506d65815efbb206"

--- a/recipes/tesults-gtest/all/conanfile.py
+++ b/recipes/tesults-gtest/all/conanfile.py
@@ -1,0 +1,57 @@
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get
+import os
+
+required_conan_version = ">=1.53.0"
+
+
+class TesultsGtestConan(ConanFile):
+    name = "tesults-gtest"
+    description = "Google Test event listener for reporting test results to Tesults"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/tesults/tesults-gtest"
+    topics = ("tesults", "googletest", "testing", "test-results", "reporting")
+    package_type = "header-library"
+    settings = "os", "compiler", "build_type", "arch"
+    no_copy_source = True
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("gtest/[>=1.11.0 <2]")
+        self.requires("tesults-cpp/[>=1.0.2 <2]")
+
+    def validate(self):
+        check_min_cppstd(self, 17)
+
+    def package_id(self):
+        self.info.clear()
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.set_property("cmake_file_name", "tesults-gtest")
+        self.cpp_info.set_property("cmake_target_name", "tesults_gtest::tesults_gtest")

--- a/recipes/tesults-gtest/all/test_package/CMakeLists.txt
+++ b/recipes/tesults-gtest/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(tesults-gtest CONFIG REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE tesults_gtest::tesults_gtest)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/tesults-gtest/all/test_package/conanfile.py
+++ b/recipes/tesults-gtest/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+import os
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            self.run(os.path.join(self.cpp.build.bindirs[0], "test_package"), env="conanrun")

--- a/recipes/tesults-gtest/all/test_package/test_package.cpp
+++ b/recipes/tesults-gtest/all/test_package/test_package.cpp
@@ -1,0 +1,10 @@
+#include <tesults_gtest/tesults_gtest.h>
+
+#include <iostream>
+
+int main() {
+    tesults_gtest::TesultsListener::Config cfg;
+    cfg.target = "token";
+    std::cout << "tesults-gtest: listener config ready\n";
+    return 0;
+}


### PR DESCRIPTION
## Description

Add new package `tesults-gtest` version `1.0.2`.

`tesults-gtest` is a header-only Google Test event listener that automatically collects and uploads test results to [Tesults](https://www.tesults.com) when a GoogleTest suite runs.

- **License**: MIT
- **Homepage**: https://github.com/tesults/tesults-gtest
- **Package type**: header-library
- **Minimum C++ standard**: C++17

### Dependencies

- `gtest`
- `tesults-cpp` (submitted in https://github.com/conan-io/conan-center-index/pull/30315 — this PR depends on that one)

### Notes

- Header-only INTERFACE library; `package_id` cleared accordingly
- Auto-registers listener at startup when `TESULTS_TARGET` env var is set — no code changes required in test suites