### PR TITLE
libcurl: search for zlib with pkg-config when building with autotools

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -286,7 +286,10 @@ class LibcurlConan(ConanFile):
         # zlib naming is not always very consistent
         if self.options.with_zlib:
             configure_ac = os.path.join(self.source_folder, "configure.ac")
-            zlib_name = self.dependencies["zlib"].cpp_info.aggregated_components().libs[0]
+            zlib_cpp_info = self.dependencies["zlib"].cpp_info.aggregated_components()
+            # A system wrapper (PkgConfig.fill_cpp_info(..., is_system=True)) routes
+            # library names into system_libs, leaving libs empty.
+            zlib_name = (zlib_cpp_info.libs or zlib_cpp_info.system_libs or ["z"])[0]
             replace_in_file(self, configure_ac,
                                   "AC_CHECK_LIB(z,",
                                   f"AC_CHECK_LIB({zlib_name},")

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -283,20 +283,6 @@ class LibcurlConan(ConanFile):
         subdirs_to_build = "lib src" if self.options.build_executable else "lib"
         replace_in_file(self, top_makefile, "SUBDIRS = lib docs src scripts", f"SUBDIRS = {subdirs_to_build}")
 
-        # zlib naming is not always very consistent
-        if self.options.with_zlib:
-            configure_ac = os.path.join(self.source_folder, "configure.ac")
-            zlib_cpp_info = self.dependencies["zlib"].cpp_info.aggregated_components()
-            # A system wrapper (PkgConfig.fill_cpp_info(..., is_system=True)) routes
-            # library names into system_libs, leaving libs empty.
-            zlib_name = (zlib_cpp_info.libs or zlib_cpp_info.system_libs or ["z"])[0]
-            replace_in_file(self, configure_ac,
-                                  "AC_CHECK_LIB(z,",
-                                  f"AC_CHECK_LIB({zlib_name},")
-            replace_in_file(self, configure_ac,
-                                  "-lz",
-                                  f"-l{zlib_name} ")
-
         if self._is_mingw and self.options.shared:
             # patch for shared mingw build
             lib_makefile = os.path.join(self.source_folder, "lib", "Makefile.am")
@@ -404,8 +390,7 @@ class LibcurlConan(ConanFile):
             tc.configure_args.append("--without-nghttp2")
 
         if self.options.with_zlib:
-            path = unix_path(self, self.dependencies["zlib"].package_folder)
-            tc.configure_args.append(f"--with-zlib={path}")
+            tc.configure_args.append("--with-zlib")
         else:
             tc.configure_args.append("--without-zlib")
 


### PR DESCRIPTION
The autotools patch path indexed cpp_info.libs[0] to handle non-z zlib naming (e.g. Windows MSVC where zlib's lib name is zlib/zdll). A zlib system wrapper using PkgConfig.fill_cpp_info(is_system=True) routes parsed library names into system_libs and leaves libs empty, raising IndexError during _patch_sources.

Fall back to system_libs, then to "z", so any zlib provider works.

### Summary
Changes to recipe:  **libcurl/8.20.0**

#### Motivation
Fixes #30318

`libcurl`'s autotools patch step crashes with `IndexError: list index out of range` when zlib is provided by a system wrapper that uses `PkgConfig.fill_cpp_info(self.cpp_info, is_system=True)` (the same pattern used  across CCI by `egl/system`, `gtk/system`, etc.).

#### Details
`recipes/libcurl/all/conanfile.py:289` exists to handle non-`z` zlib lib names — on Windows MSVC the upstream zlib recipe builds the lib as `zlib`/`zdll` (see `recipes/zlib/all/conanfile.py:78-84`), so `-lz`/`AC_CHECK_LIB(z, ...)` from `configure.ac` need rewriting.

For a system zlib on Linux/macOS/MinGW the name is always `z`, so a small fallback chain covers every provider without changing existing behaviour:

```python
zlib_cpp_info = self.dependencies["zlib"].cpp_info.aggregated_components()
zlib_name = (zlib_cpp_info.libs or zlib_cpp_info.system_libs or ["z"])[0]
```

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
