### PR TITLE
aws-c-cal: handle system-wrapper openssl in package_info

### DIFF
--- a/recipes/aws-c-cal/all/conanfile.py
+++ b/recipes/aws-c-cal/all/conanfile.py
@@ -81,7 +81,8 @@ class AwsCCal(ConanFile):
 
         if self._needs_openssl:
             self.cpp_info.requires.append("openssl::crypto")
-            if not self.dependencies["openssl"].options.shared:
+            # get_safe so system-wrapper openssl (which omits the `shared` option) works.
+            if not self.dependencies["openssl"].options.get_safe("shared", default=True):
                 # aws-c-cal does not statically link to openssl and searches dynamically for openssl symbols .
                 # Mark these as undefined so the linker will include them.
                 # This avoids dynamical look-up for a system crypto library.

--- a/recipes/aws-c-cal/all/conanfile.py
+++ b/recipes/aws-c-cal/all/conanfile.py
@@ -81,8 +81,7 @@ class AwsCCal(ConanFile):
 
         if self._needs_openssl:
             self.cpp_info.requires.append("openssl::crypto")
-            # get_safe so system-wrapper openssl (which omits the `shared` option) works.
-            if not self.dependencies["openssl"].options.get_safe("shared", default=True):
+            if not self.dependencies["openssl"].package_type == "shared-library":
                 # aws-c-cal does not statically link to openssl and searches dynamically for openssl symbols .
                 # Mark these as undefined so the linker will include them.
                 # This avoids dynamical look-up for a system crypto library.


### PR DESCRIPTION
### Summary
Changes to recipe:  **aws-c-cal/all**

Fixes #30432 

#### Motivation
`package_info()` reads `dep.options.shared` directly to decide whether to mark openssl crypto symbols as undefined for runtime resolution. When openssl is provided by a system-wrapper that follows the canonical Conan 2 pattern from the [ncurses example](https://docs.conan.io/2/examples/tools/system/system_package/package_manager.html) - which intentionally omits the `shared` option - this raises:

```
  ERROR: aws-c-cal/0.9.8: Error in package_info() method, line 84
          if not self.dependencies["openssl"].options.shared:
          ConanException: option 'shared' doesn't exist
          Possible options are []
```

#### Details
Switch to the `options.get_safe("shared", default=True)` defensive idiom already used in the aws-c-* family - see [`aws-c-common/all/conanfile.py:54`](https://github.com/conan-io/conan-center-index/blob/master/recipes/aws-c-common/all/conanfile.py#L54) (`self.options.get_safe("cpu_extensions", False)`).

- For stock conancenter openssl (`options.shared` always declared), `get_safe` returns the actual value - behavior unchanged.
- For system-wrapper openssl (no `shared` option),  `get_safe` returns the default `True` - the static-link symbol-marking branch is correctly skipped, which matches reality (system-installed openssl is shared on every platform aws-c-cal supports).

Two-line change to `recipes/aws-c-cal/all/conanfile.py`. No changes to `config.yml`, `conandata.yml`, patches, or `test_package`.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
