### PR TITLE
boost: handle system-wrapper compression deps in user-config.jam

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1537,14 +1537,16 @@ class BoostConan(ConanFile):
 
         def create_library_config(deps_name, name):
             aggregated_cpp_info = self.dependencies[deps_name].cpp_info.aggregated_components()
-            if len(aggregated_cpp_info.libs) == 0:
+            # Fall back to system_libs so system-wrapper deps (which omit cpp_info.libs) work.
+            libs = aggregated_cpp_info.libs or aggregated_cpp_info.system_libs
+            if not libs:
                 return ""
 
             includedir = aggregated_cpp_info.includedirs[0].replace("\\", "/")
             includedir = f"\"{includedir}\""
             libdir = aggregated_cpp_info.libdirs[0].replace("\\", "/")
             libdir = f"\"{libdir}\""
-            lib = aggregated_cpp_info.libs[0]
+            lib = libs[0]
             version = self.dependencies[deps_name].ref.version
             return f"\nusing {name} : {version} : " \
                    f"<include>{includedir} " \


### PR DESCRIPTION
### Summary
Changes to recipe:  **boost/all**

#### Motivation
`_create_user_config_jam` introspects `dep.cpp_info.aggregated_components().libs[0]` for each of four compression backends (zlib, bzip2, xz_utils, zstd) to [official ncurses example](https://docs.conan.io/2/examples/tools/system/system_package/package_manager.html)), the lib name lands in `cpp_info.system_libs` and `libs` is empty.
The current `len(libs) == 0: return ""` early-exit then **silently drops** that backend from user-config.jam - boost.iostreams compiles without the requested compression filter, and the failure only surfaces at link time if a downstream consumer instantiates `bio::gzip_decompressor` (or the bzip2/lzma/zstd equivalent), at which point they get undefined-reference link errors against the missing implementation in `libboost_iostreams`.

#### Details
Add `system_libs` as a fallback so the backend is correctly included:
```diff
-            if len(aggregated_cpp_info.libs) == 0:
+            libs = aggregated_cpp_info.libs or aggregated_cpp_info.system_libs
+            if not libs:
                 return ""
             ...
-            lib = aggregated_cpp_info.libs[0]
+            lib = libs[0]
```

Behavior under stock conancenter zlib/bzip2/xz_utils/zstd is unchanged (when libs is non-empty, (libs or system_libs)[0] returns libs[0]).
Strictly additive fallback.

Related: similar cpp_info.libs[0] / options.shared introspection issues in `libcurl` and `aws-c-cal` - same root cause (consumer recipe assuming conancenter-shape dep), fixed under separate PRs (#30322 and #30323 respectively).

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
