### PR TITLE
opencore-amr: Compile with -fwrapv to ensure integer overflow is treated as wrap-around

### DIFF
--- a/recipes/opencore-amr/all/conanfile.py
+++ b/recipes/opencore-amr/all/conanfile.py
@@ -69,6 +69,8 @@ class OpencoreAmrConan(ConanFile):
             tc.extra_cxxflags.append("-EHsc")
             if check_min_vs(self, "180", raise_invalid=False):
                 tc.extra_cxxflags.append("-FS")
+        else:
+            tc.extra_cxxflags.append("-fwrapv")
         tc.generate()
 
         if is_msvc(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **opencore-amr/1.6.0**

#### Motivation

After compiling opencore-amr library with clang 18 i got different audio output depending on the build type. When building with Debug i got the same as on the older gcc version i used previously. But on RelWithDebInfo i got slightly different output.

It turns out that opencore-amr relies on integer overflow resulting in a wrap-around. But integer overflow is undefined behaviour in C++. So it looks like clang did some unexpected optimization that caused the differing output.

For examle this line in the opencore-amr source code could easily overflow i think:

```cpp
i = ((Word32) i * 10923) >> 15;
```
https://github.com/BelledonneCommunications/opencore-amr/blob/3b67218fb8efb776bcd79e7445774e02d778321d/opencore/codecs_v2/audio/gsm_amr/amr_nb/dec/src/dec_lag3.cpp#L202-L203

#### Details

The fix is to set the `-fwrapv` flag in non-msvc compilers:

##### gcc

> -fwrapv: This option instructs the compiler to assume that signed arithmetic overflow of addition, subtraction and multiplication wraps around using twos-complement representation.

see: https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#index-fwrapv

##### clang

> fwrapv: Treat signed integer overflow as two’s complement

see: https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-fwrapv

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
