### PR TITLE
libqasm: add version 1.4.0

### DIFF
--- a/recipes/libqasm/all/conandata.yml
+++ b/recipes/libqasm/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "1.3.0":
-    url: "https://github.com/QuTech-Delft/libqasm/releases/download/1.3.0/libqasm-1.3.0.tar.gz"
-    sha256: "d4f2ab9264537670451754c163ec694728850363883ed53cd5b7f3e77c05b850"
+  "1.4.0":
+    url: "https://github.com/QuTech-Delft/libqasm/releases/download/1.4.0/libqasm-1.4.0.tar.gz"
+    sha256: "570ecee2e43804f326120064de476488c1acfb4fdc96300503131b776e8d8b2e"

--- a/recipes/libqasm/config.yml
+++ b/recipes/libqasm/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.3.0":
+  "1.4.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **libqasm/1.4.0**

#### Motivation
Just a version bump.

#### Details
`config.yml` and `conandata.yml` point to the newly created libqasm/1.4.0.


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] Tested locally with at least one configuration using a recent version of Conan