### PR TITLE
[Opus] Add Opus version 1.6.1

### DIFF
--- a/recipes/opus/all/conandata.yml
+++ b/recipes/opus/all/conandata.yml
@@ -1,10 +1,10 @@
 sources:
-  "1.5.2":
-    url: "https://github.com/xiph/opus/releases/download/v1.5.2/opus-1.5.2.tar.gz"
-    sha256: "65c1d2f78b9f2fb20082c38cbe47c951ad5839345876e46941612ee87f9a7ce1"
   "1.6.1":
     url: "https://downloads.xiph.org/releases/opus/opus-1.6.1.tar.gz"
     sha256: "6ffcb593207be92584df15b32466ed64bbec99109f007c82205f0194572411a1"
+  "1.5.2":
+    url: "https://github.com/xiph/opus/releases/download/v1.5.2/opus-1.5.2.tar.gz"
+    sha256: "65c1d2f78b9f2fb20082c38cbe47c951ad5839345876e46941612ee87f9a7ce1"
 patches:
   "1.5.2":
     - patch_file: "patches/1.5.2-add-sse4.1-flag-when-using-clang-cl.patch"

--- a/recipes/opus/all/conandata.yml
+++ b/recipes/opus/all/conandata.yml
@@ -2,6 +2,9 @@ sources:
   "1.5.2":
     url: "https://github.com/xiph/opus/releases/download/v1.5.2/opus-1.5.2.tar.gz"
     sha256: "65c1d2f78b9f2fb20082c38cbe47c951ad5839345876e46941612ee87f9a7ce1"
+  "1.6.1":
+    url: "https://downloads.xiph.org/releases/opus/opus-1.6.1.tar.gz"
+    sha256: "6ffcb593207be92584df15b32466ed64bbec99109f007c82205f0194572411a1"
 patches:
   "1.5.2":
     - patch_file: "patches/1.5.2-add-sse4.1-flag-when-using-clang-cl.patch"

--- a/recipes/opus/config.yml
+++ b/recipes/opus/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.6.1":
+    folder: all
   "1.5.2":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **opus/1.6.0** and **opus/1.6.1**

#### Motivation
Version of opus 1.5.4 is a bit old

#### Details
Add opus/1.6.0 and opus/1.6.1 version to the recipe

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
