### PR TITLE
dbwaller/0.1.0: add recipe

### DIFF
--- a/recipes/dbwaller/all/conandata.yml
+++ b/recipes/dbwaller/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.1.0":
+    url: "https://github.com/ericel/DBWaller/archive/refs/tags/v0.1.0.tar.gz"
+    sha256: "df2e712b8608f0993eaf152d1cc83a7d10af1767709c0a9541929ca835eb59dc"

--- a/recipes/dbwaller/all/conanfile.py
+++ b/recipes/dbwaller/all/conanfile.py
@@ -1,0 +1,97 @@
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, rmdir
+import os
+
+required_conan_version = ">=1.53.0"
+
+
+class DBWallerConan(ConanFile):
+    name = "dbwaller"
+    description = "C++20 data-plane gateway with policy-aware caching and access controls"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/ericel/DBWaller"
+    topics = ("cache", "gateway", "security", "data-plane")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    @property
+    def _min_cppstd(self):
+        return 20
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        # spdlog is a private implementation detail; pin its option for a
+        # deterministic package_id and to keep the static lib self-consistent.
+        self.options["spdlog"].header_only = False
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        # All three are implementation-only (not exposed in DBWaller's public
+        # headers), so they are private requirements.
+        self.requires("spdlog/1.15.3")
+        self.requires("openssl/3.5.6")
+        self.requires("nlohmann_json/3.12.0")
+
+    def validate(self):
+        check_min_cppstd(self, self._min_cppstd)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
+
+        tc = CMakeToolchain(self)
+        tc.variables["DBWALLER_BUILD_APPS"] = False
+        tc.variables["DBWALLER_BUILD_TESTS"] = False
+        tc.variables["DBWALLER_BUILD_BENCHMARKS"] = False
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE",
+             src=self.source_folder,
+             dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        # Conan generates its own CMake config/targets; drop the ones the
+        # project installs plus its data dir so they don't shadow them.
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["dbwaller"]
+        self.cpp_info.set_property("cmake_file_name", "DBWaller")
+        self.cpp_info.set_property("cmake_target_name", "DBWaller::dbwaller")
+        # Private deps must still propagate as transitive link requirements for
+        # static consumers.
+        self.cpp_info.requires = [
+            "openssl::crypto",
+            "spdlog::spdlog",
+            "nlohmann_json::nlohmann_json",
+        ]
+        if self.settings.os in ("Linux", "FreeBSD"):
+            self.cpp_info.system_libs = ["pthread", "m", "dl"]

--- a/recipes/dbwaller/all/test_package/CMakeLists.txt
+++ b/recipes/dbwaller/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.20)
+project(test_package LANGUAGES CXX)
+
+find_package(DBWaller CONFIG REQUIRED)
+
+add_executable(example src/example.cpp)
+target_compile_features(example PRIVATE cxx_std_20)
+target_link_libraries(example PRIVATE DBWaller::dbwaller)

--- a/recipes/dbwaller/all/test_package/conanfile.py
+++ b/recipes/dbwaller/all/test_package/conanfile.py
@@ -1,0 +1,33 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
+        tc = CMakeToolchain(self)
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "example")
+            self.run(bin_path, env="conanrun")

--- a/recipes/dbwaller/all/test_package/src/example.cpp
+++ b/recipes/dbwaller/all/test_package/src/example.cpp
@@ -1,0 +1,35 @@
+#include "dbwaller/core/sharded_engine.hpp"
+#include "dbwaller/security/claims.hpp"
+
+#include <map>
+#include <string>
+#include <vector>
+
+int main() {
+    const auto fingerprint = dbwaller::security::claims_fingerprint_hex(
+        std::vector<std::string>{"reader"},
+        std::vector<std::string>{"posts:read"},
+        std::map<std::string, std::string>{{"tenant", "example"}},
+        16
+    );
+
+    if (fingerprint.empty()) {
+        return 1;
+    }
+
+    dbwaller::core::ShardedEngine::Config config;
+    config.num_shards = 2;
+    config.enable_compute_pool = false;
+
+    dbwaller::core::ShardedEngine engine(config);
+
+    dbwaller::core::PutOptions options;
+    options.ttl_ms = 500;
+    options.tags = {"post:42"};
+
+    engine.put("post:42", "cached-value", options);
+    const auto cached = engine.get("post:42");
+    engine.shutdown();
+
+    return cached && *cached == "cached-value" ? 0 : 1;
+}

--- a/recipes/dbwaller/config.yml
+++ b/recipes/dbwaller/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.1.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version: **dbwaller/0.1.0**

Adds a recipe for [DBWaller](https://github.com/ericel/DBWaller), a C++20 data-plane gateway with policy-aware caching and access controls.

- Library-only build (apps/tests/benchmarks disabled via CMake options).
- Requirements: `spdlog/1.15.3`, `openssl/3.5.6`, `nlohmann_json/3.12.0` — all implementation-only (not exposed in public headers), declared as private link requirements.
- `shared`/`fPIC` options handled per CCI conventions; min C++ standard 20 enforced.
- The installed project CMake config is removed in `package()` so Conan-generated config is authoritative.

Validated locally with `conan create` for both static and shared builds, and the `test_package` exercises the public API (`dbwaller::security::claims_fingerprint_hex` and `dbwaller::core::ShardedEngine`).