### PR TITLE
libcurl: build mingw with CMake

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -4,7 +4,7 @@ from conan.tools.apple import is_apple_os, fix_apple_shared_install_name
 from conan.tools.build import cross_building
 from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
 from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
-from conan.tools.files import copy, download, get, load, replace_in_file, rm, rmdir, save
+from conan.tools.files import copy, download, get, replace_in_file, rm, rmdir
 from conan.tools.gnu import Autotools, AutotoolsToolchain, AutotoolsDeps, PkgConfigDeps
 from conan.tools.layout import basic_layout
 from conan.tools.microsoft import is_msvc, unix_path
@@ -134,7 +134,7 @@ class LibcurlConan(ConanFile):
 
     @property
     def _is_using_cmake_build(self):
-        return is_msvc(self) or self._is_win_x_android
+        return is_msvc(self) or self._is_win_x_android or self._is_mingw
 
     def export_sources(self):
         copy(self, "lib_Makefile_add.am", self.recipe_folder, self.export_sources_folder)
@@ -283,31 +283,6 @@ class LibcurlConan(ConanFile):
         subdirs_to_build = "lib src" if self.options.build_executable else "lib"
         replace_in_file(self, top_makefile, "SUBDIRS = lib docs src scripts", f"SUBDIRS = {subdirs_to_build}")
 
-        if self._is_mingw and self.options.shared:
-            # patch for shared mingw build
-            lib_makefile = os.path.join(self.source_folder, "lib", "Makefile.am")
-            replace_in_file(self, lib_makefile,
-                                  "noinst_LTLIBRARIES = libcurlu.la",
-                                  "")
-            replace_in_file(self, lib_makefile,
-                                  "noinst_LTLIBRARIES =",
-                                  "")
-            replace_in_file(self, lib_makefile,
-                                  "lib_LTLIBRARIES = libcurl.la",
-                                  "noinst_LTLIBRARIES = libcurl.la")
-
-            if self.options.build_executable:
-                # Link libcurl.dll.a to curl.exe
-                replace_in_file(self, os.path.join(self.source_folder, "src", "Makefile.am"),
-                                        "curl_LDADD = $(top_builddir)/lib/libcurl.la",
-                                        "curl_LDADD = $(top_builddir)/lib/libcurl.la $(top_builddir)/lib/libcurl.dll.a")
-            # add directives to build dll
-            # used only for native mingw-make
-            if not cross_building(self) or self._is_mingw:
-                # The patch file is located in the base src folder
-                added_content = load(self, os.path.join(self.folders.base_source, "lib_Makefile_add.am"))
-                save(self, lib_makefile, added_content, append=True)
-
     def _yes_no(self, value):
         return "yes" if value else "no"
 
@@ -454,16 +429,6 @@ class LibcurlConan(ConanFile):
                 pass # this just works, conan is great!
 
         env = tc.environment()
-
-        # tweaks for mingw
-        if self._is_mingw:
-            rcflags = "-O COFF"
-            if self.settings.arch == "x86":
-                rcflags += " --target=pe-i386"
-            elif self.settings.arch == "x86_64":
-                rcflags += " --target=pe-x86-64"
-                tc.extra_defines.append("_AMD64_")
-            env.define("RCFLAGS", rcflags)
 
         if self.settings.os != "Windows":
             tc.fpic = self.options.get_safe("fPIC", True)
@@ -630,11 +595,6 @@ class LibcurlConan(ConanFile):
             autotools.install()
             rmdir(self, os.path.join(self.package_folder, "share"))
             rm(self, "*.la", os.path.join(self.package_folder, "lib"))
-            if self._is_mingw and self.options.shared:
-                # Handle only mingw libs
-                copy(self, pattern="*.dll", src=self.build_folder, dst=os.path.join(self.package_folder, "bin"), keep_path=False)
-                copy(self, pattern="*.dll.a", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"), keep_path=False)
-                copy(self, pattern="*.lib", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"), keep_path=False)
             fix_apple_shared_install_name(self)
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **libcurl/***
Use CMake instead of autotools for mingw
#### Motivation
it avoids pulling a lot of dependencies (autotools, msys etc.)
https://everything.curl.dev/build/windows.html says `If you use mingw, you might want to use the [autotools](https://everything.curl.dev/build/autotools.html) build system.` and `You can build curl with the mingw compiler suite. Use [CMake](https://everything.curl.dev/build/cmake.html) to generate the set of Makefiles for you`

#### Details
<details><summary>build log </summary>
<p>

```
$ conan create .\recipes\libcurl\all\ --version 8.20.0 -o */*:with_ssl=False -b missing -s build_type=Release -o */*:shared=True
                                                                                                                                                               
======== Exporting recipe to the cache ========
libcurl/8.20.0: Exporting package recipe: C:\pf\conan-center-index-pf\recipes\libcurl\all\conanfile.py
libcurl/8.20.0: exports: File 'conandata.yml' found. Exporting it...
libcurl/8.20.0: Calling export_sources()
libcurl/8.20.0: Copied 1 '.yml' file: conandata.yml
libcurl/8.20.0: Copied 1 '.py' file: conanfile.py
libcurl/8.20.0: Copied 1 '.am' file: lib_Makefile_add.am
libcurl/8.20.0: Exported to cache folder: C:\Users\el\.conan2\p\libcu9f854a4b42900\e
libcurl/8.20.0: Exported: libcurl/8.20.0#f4cee1fe6fe1c82aa1991508e452b1bb (2026-06-09 09:22:20 UTC)

======== Input profiles ========
Profile host:
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=gnu17
compiler.cstd=99
compiler.libcxx=libstdc++11
compiler.version=14
os=Windows
[options]
*/*:shared=True
*/*:with_ssl=False
[tool_requires]
*: cmake/[>=3 <4]
[platform_tool_requires]
ninja/1.13.0
[platform_requires]
ninja/1.13.0
[conf]
tools.build:compiler_executables={'c': 'C:/Qt/Tools/mingw1420_64/bin/gcc.exe', 'cpp': 'C:/Qt/Tools/mingw1420_64/bin/g++.exe'}
[buildenv]
PATH=+(path)C:/Qt/Tools/mingw1420_64/bin
[runenv]
PATH=+(path)C:/Qt/Tools/mingw1420_64/bin

Profile build:
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=gnu17
compiler.cstd=99
compiler.libcxx=libstdc++11
compiler.version=14
os=Windows
[tool_requires]
*: cmake/[>=3 <4]
[platform_tool_requires]
ninja/1.13.0
[platform_requires]
ninja/1.13.0
[conf]
tools.build:compiler_executables={'c': 'C:/Qt/Tools/mingw1420_64/bin/gcc.exe', 'cpp': 'C:/Qt/Tools/mingw1420_64/bin/g++.exe'}
[buildenv]
PATH=+(path)C:/Qt/Tools/mingw1420_64/bin
[runenv]
PATH=+(path)C:/Qt/Tools/mingw1420_64/bin


======== Computing dependency graph ========
Graph root
    cli
Requirements
    libcurl/8.20.0#f4cee1fe6fe1c82aa1991508e452b1bb - Cache
    zlib/1.3.2#1cb806da49011867778ffb6ac7190fcb - Cache
Build requirements
    cmake/3.31.11#f325c933f618a1fcebc1e1c0babfd1ba - Cache
Replaced requires
    cmake/[>=3 <4]: cmake/[>=3 <4]
Resolved version ranges
    cmake/[>=3 <4]: cmake/3.31.11
    zlib/[>=1.2.11 <2]: zlib/1.3.2

======== Computing necessary packages ========
Connecting to remote 'gitea' anonymously
Requirements
    libcurl/8.20.0#f4cee1fe6fe1c82aa1991508e452b1bb:ff44e9ac0c581c74423ac1ad3c3f42eedf7056a3 - Build
    zlib/1.3.2#1cb806da49011867778ffb6ac7190fcb:0c4b6f6539851384385aac6bcb78741c44b9b0e4#13bd8f94ab3b99bd503fc606137e2d23 - Download (gitea)
Build requirements
    cmake/3.31.11#f325c933f618a1fcebc1e1c0babfd1ba:522dcea5982a3f8a5b624c16477e47195da2f84f#eacef9885b96e5616582c65683dd1553 - Cache

======== Installing packages ========

-------- Downloading 1 package --------
Downloading binary packages in 22 parallel threads
zlib/1.3.2: Retrieving package 0c4b6f6539851384385aac6bcb78741c44b9b0e4 from remote 'gitea'
zlib/1.3.2: Package installed 0c4b6f6539851384385aac6bcb78741c44b9b0e4
zlib/1.3.2: Downloaded package revision 13bd8f94ab3b99bd503fc606137e2d23
cmake/3.31.11: Already installed! (1 of 3)
libcurl/8.20.0: Calling source() in C:\Users\el\.conan2\p\libcu9f854a4b42900\s\src
libcurl/8.20.0: Sources correctly downloaded from https://curl.se/download/curl-8.20.0.tar.xz
libcurl/8.20.0: Uncompressing curl-8.20.0.tar.xz to .
libcurl/8.20.0: Sources correctly downloaded from https://curl.se/ca/cacert-2025-11-04.pem

-------- Installing package libcurl/8.20.0 (3 of 3) --------
libcurl/8.20.0: Building from source
libcurl/8.20.0: Package libcurl/8.20.0:ff44e9ac0c581c74423ac1ad3c3f42eedf7056a3
libcurl/8.20.0: settings: os=Windows arch=x86_64 compiler=gcc compiler.version=14 build_type=Release
libcurl/8.20.0: options: build_executable=False shared=True with_brotli=False with_c_ares=False with_ca_bundle=auto with_ca_fallback=False with_ca_path=auto with_cookies=True with_crypto_auth=True with_dict=True with_docs=False with_file=True with_form_api=True with_ftp=True with_gopher=True with_http=True with_imap=True with_ipv6=True with_largemaxwritesize=False with_ldap=False with_libidn=False with_libpsl=False with_libssh2=False with_misc_docs=False with_mqtt=True with_nghttp2=False with_ntlm=False with_pop3=True with_proxy=True with_rtsp=True with_smb=False with_smtp=True with_ssl=False with_symbol_hiding=False with_telnet=True with_tftp=True with_threaded_resolver=True with_unix_sockets=True with_verbose_debug=True with_verbose_strings=True with_websockets=True with_zlib=True with_zstd=False
libcurl/8.20.0: requires: zlib/1.3.Z
libcurl/8.20.0: Copying sources to build folder
libcurl/8.20.0: Building your package in C:\Users\el\.conan2\p\b\libcu0e643855c752e\b
libcurl/8.20.0: Calling generate()
libcurl/8.20.0: Generators folder: C:\Users\el\.conan2\p\b\libcu0e643855c752e\b\build\Release\generators
libcurl/8.20.0: CMakeToolchain generated: conan_toolchain.cmake
libcurl/8.20.0: CMakeToolchain generated: C:\Users\el\.conan2\p\b\libcu0e643855c752e\b\build\Release\generators\CMakePresets.json
libcurl/8.20.0: CMakeToolchain generated: C:\Users\el\.conan2\p\b\libcu0e643855c752e\b\src\CMakeUserPresets.json
libcurl/8.20.0: CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(ZLIB)
    target_link_libraries(... ZLIB::ZLIB)
libcurl/8.20.0: Generating aggregated env files
libcurl/8.20.0: Generated aggregated env files: ['conanbuild.bat', 'conanrun.bat']
libcurl/8.20.0: Calling build()
libcurl/8.20.0: Running CMake.configure()
libcurl/8.20.0: RUN: cmake -G "MinGW Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="C:/Users/el/.conan2/p/b/libcu0e643855c752e/p" -DENABLE_CURL_MANUAL="OFF" -DCURL_CA_BUNDLE="auto" -DCURL_CA_PATH="auto" -DCURL_CA_FALLBACK="OFF" -DCMAKE_SH="CMAKE_SH-NOTFOUND" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "C:/Users/el/.conan2/p/b/libcu0e643855c752e/b/src"
-- Using CMake version 3.31.11
-- curl version=[8.20.0]
-- Using Conan toolchain: C:/Users/el/.conan2/p/b/libcu0e643855c752e/b/build/Release/generators/conan_toolchain.cmake
-- Conan toolchain: Defining architecture flag: -m64
-- Conan toolchain: Setting BUILD_SHARED_LIBS = ON
-- The C compiler identification is GNU 14.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: C:/Qt/Tools/mingw1420_64/bin/gcc.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- CMake platform flags: WIN32 GCC MINGW
-- Performing Test HAVE_WIN32_WINNT
-- Performing Test HAVE_WIN32_WINNT - Success
-- Found _WIN32_WINNT=0x0a00
-- Performing Test MINGW64_VERSION
-- Performing Test MINGW64_VERSION - Success
-- Found MINGW64_VERSION=12.0
-- Picky compiler options: -Werror-implicit-function-declaration -W -Wall -Wpedantic -Wbad-function-cast -Wconversion -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-long-long -Wno-multichar -Wpointer-arith -Wshadow -Wsign-compare -Wundef -Wunused -Wwrite-strings -Waddress -Wattributes -Wcast-align -Wcast-qual -Wdeclaration-after-statement -Wdiv-by-zero -Wempty-body -Wendif-labels -Wfloat-equal -Wformat-security -Wignored-qualifiers -Wmissing-field-initializers -Wmissing-noreturn -Wno-padded -Wno-sign-conversion -Wno-switch-default -Wno-switch-enum -Wno-system-headers -Wold-style-definition -Wredundant-decls -Wstrict-prototypes -Wtype-limits -Wunreachable-code -Wunused-parameter -Wvla -Wclobbered -Wmissing-parameter-type -Wold-style-declaration -Wpragmas -Wstrict-aliasing=3 -ftree-vrp -Wjump-misses-init -Wno-pedantic-ms-format -Wdouble-promotion -Wformat=2 -Wtrampolines -Warray-bounds=2 -Wno-format-signedness -Wduplicated-cond -Wnull-dereference -fdelete-null-pointer-checks -Wshift-negative-value -Wshift-overflow=2 -Wunused-const-variable -Walloc-zero -Wduplicated-branches -Wformat-truncation=2 -Wimplicit-fallthrough -Wrestrict -Warith-conversion -Wenum-conversion -Warray-compare -Wenum-int-mismatch -Wxor-used-as-pow
-- Could NOT find Perl (missing: PERL_EXECUTABLE) 
CMake Warning at CMakeLists.txt:595 (message):
  Perl not found.  Will not build manuals.


-- Conan: Target declared 'ZLIB::ZLIB'
-- Check size of time_t
-- Check size of time_t - done
-- Protocols: dict file ftp gopher http imap ipfs ipns mqtt pop3 rtsp smtp telnet tftp ws
-- Features: alt-svc AsynchDNS IPv6 Largefile libz threadsafe TLS-SRP Unicode UnixSockets
-- Enabled SSL backends:
-- Configuring done (4.3s)
-- Generating done (3.2s)
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_SH


-- Build files have been written to: C:/Users/el/.conan2/p/b/libcu0e643855c752e/b/build/Release

libcurl/8.20.0: Running CMake.build()
libcurl/8.20.0: RUN: cmake --build "C:\Users\el\.conan2\p\b\libcu0e643855c752e\b\build\Release" -- -j22
[  2%] Building C object lib/CMakeFiles/libcurl_object.dir/altsvc.c.obj
[  2%] Building C object lib/CMakeFiles/libcurl_object.dir/amigaos.c.obj
[  2%] Building C object lib/CMakeFiles/libcurl_object.dir/asyn-ares.c.obj
[  2%] Building C object lib/CMakeFiles/libcurl_object.dir/asyn-base.c.obj
[  2%] Building C object lib/CMakeFiles/libcurl_object.dir/asyn-thrdd.c.obj
[  5%] Building C object lib/CMakeFiles/libcurl_object.dir/bufq.c.obj
[  5%] Building C object lib/CMakeFiles/libcurl_object.dir/bufref.c.obj
[  5%] Building C object lib/CMakeFiles/libcurl_object.dir/cf-dns.c.obj
[  5%] Building C object lib/CMakeFiles/libcurl_object.dir/cf-h1-proxy.c.obj
[  5%] Building C object lib/CMakeFiles/libcurl_object.dir/cf-h2-proxy.c.obj
[  8%] Building C object lib/CMakeFiles/libcurl_object.dir/cf-haproxy.c.obj
[  8%] Building C object lib/CMakeFiles/libcurl_object.dir/cf-https-connect.c.obj
[  8%] Building C object lib/CMakeFiles/libcurl_object.dir/cf-ip-happy.c.obj
[  8%] Building C object lib/CMakeFiles/libcurl_object.dir/cfilters.c.obj
[  8%] Building C object lib/CMakeFiles/libcurl_object.dir/cf-socket.c.obj
[  8%] Building C object lib/CMakeFiles/libcurl_object.dir/conncache.c.obj
[ 11%] Building C object lib/CMakeFiles/libcurl_object.dir/connect.c.obj
[ 11%] Building C object lib/CMakeFiles/libcurl_object.dir/cookie.c.obj
[ 11%] Building C object lib/CMakeFiles/libcurl_object.dir/content_encoding.c.obj
[ 13%] Building C object lib/CMakeFiles/libcurl_object.dir/curl_endian.c.obj
[ 13%] Building C object lib/CMakeFiles/libcurl_object.dir/cshutdn.c.obj
[ 13%] Building C object lib/CMakeFiles/libcurl_object.dir/curl_addrinfo.c.obj
[ 13%] Building C object lib/CMakeFiles/libcurl_object.dir/curl_fnmatch.c.obj
[ 13%] Building C object lib/CMakeFiles/libcurl_object.dir/curl_fopen.c.obj
[ 13%] Building C object lib/CMakeFiles/libcurl_object.dir/curl_get_line.c.obj
[ 13%] Building C object lib/CMakeFiles/libcurl_object.dir/curl_gethostname.c.obj
[ 16%] Building C object lib/CMakeFiles/libcurl_object.dir/curl_gssapi.c.obj
[ 16%] Building C object lib/CMakeFiles/libcurl_object.dir/curl_memrchr.c.obj
[ 16%] Building C object lib/CMakeFiles/libcurl_object.dir/curl_ntlm_core.c.obj
[ 16%] Building C object lib/CMakeFiles/libcurl_object.dir/curl_sasl.c.obj
[ 16%] Building C object lib/CMakeFiles/libcurl_object.dir/curl_range.c.obj
[ 16%] Building C object lib/CMakeFiles/libcurl_object.dir/curl_sha512_256.c.obj
[ 16%] Building C object lib/CMakeFiles/libcurl_object.dir/curl_sspi.c.obj
[ 19%] Building C object lib/CMakeFiles/libcurl_object.dir/curl_share.c.obj
[ 19%] [ 19%] Building C object lib/CMakeFiles/libcurl_object.dir/cw-out.c.obj
Building C object lib/CMakeFiles/libcurl_object.dir/curl_threads.c.obj
[ 19%] Building C object lib/CMakeFiles/libcurl_object.dir/curl_trc.c.obj
[ 22%] Building C object lib/CMakeFiles/libcurl_object.dir/cw-pause.c.obj
[ 22%] [ 22%] Building C object lib/CMakeFiles/libcurl_object.dir/doh.c.objBuilding C object lib/CMakeFiles/libcurl_object.dir/dnscache.c.obj

[ 22%] Building C object lib/CMakeFiles/libcurl_object.dir/dict.c.obj
[ 25%] Building C object lib/CMakeFiles/libcurl_object.dir/easy.c.obj
[ 25%] Building C object lib/CMakeFiles/libcurl_object.dir/dynhds.c.obj
[ 25%] Building C object lib/CMakeFiles/libcurl_object.dir/easyoptions.c.obj
[ 25%] Building C object lib/CMakeFiles/libcurl_object.dir/escape.c.obj
[ 25%] Building C object lib/CMakeFiles/libcurl_object.dir/easygetopt.c.obj
[ 25%] Building C object lib/CMakeFiles/libcurl_object.dir/fileinfo.c.obj[ 25%] Building C object lib/CMakeFiles/libcurl_object.dir/fake_addrinfo.c.obj

[ 25%] Building C object lib/CMakeFiles/libcurl_object.dir/formdata.c.obj
[ 27%] Building C object lib/CMakeFiles/libcurl_object.dir/file.c.obj
[ 27%] Building C object lib/CMakeFiles/libcurl_object.dir/ftp.c.obj
[ 27%] Building C object lib/CMakeFiles/libcurl_object.dir/ftplistparser.c.obj
[ 27%] Building C object lib/CMakeFiles/libcurl_object.dir/getenv.c.obj
[ 30%] Building C object lib/CMakeFiles/libcurl_object.dir/getinfo.c.obj
[ 30%] Building C object lib/CMakeFiles/libcurl_object.dir/gopher.c.obj
[ 30%] Building C object lib/CMakeFiles/libcurl_object.dir/hash.c.obj
[ 30%] Building C object lib/CMakeFiles/libcurl_object.dir/headers.c.obj
[ 30%] Building C object lib/CMakeFiles/libcurl_object.dir/hmac.c.obj
[ 33%] Building C object lib/CMakeFiles/libcurl_object.dir/hostip.c.obj
[ 33%] Building C object lib/CMakeFiles/libcurl_object.dir/hostip4.c.obj
[ 33%] Building C object lib/CMakeFiles/libcurl_object.dir/hostip6.c.obj
[ 33%] Building C object lib/CMakeFiles/libcurl_object.dir/hsts.c.obj
[ 33%] Building C object lib/CMakeFiles/libcurl_object.dir/http.c.obj
[ 33%] Building C object lib/CMakeFiles/libcurl_object.dir/http2.c.obj
[ 36%] Building C object lib/CMakeFiles/libcurl_object.dir/http1.c.obj
[ 36%] Building C object lib/CMakeFiles/libcurl_object.dir/http_chunks.c.obj
[ 36%] Building C object lib/CMakeFiles/libcurl_object.dir/http_aws_sigv4.c.obj
[ 36%] Building C object lib/CMakeFiles/libcurl_object.dir/http_digest.c.obj
[ 38%] Building C object lib/CMakeFiles/libcurl_object.dir/http_ntlm.c.obj
[ 38%] Building C object lib/CMakeFiles/libcurl_object.dir/http_proxy.c.obj
[ 38%] Building C object lib/CMakeFiles/libcurl_object.dir/http_negotiate.c.obj
[ 38%] Building C object lib/CMakeFiles/libcurl_object.dir/httpsrr.c.obj
[ 38%] Building C object lib/CMakeFiles/libcurl_object.dir/idn.c.obj
[ 41%] Building C object lib/CMakeFiles/libcurl_object.dir/imap.c.obj
[ 41%] Building C object lib/CMakeFiles/libcurl_object.dir/if2ip.c.obj
[ 41%] Building C object lib/CMakeFiles/libcurl_object.dir/ldap.c.obj
[ 41%] Building C object lib/CMakeFiles/libcurl_object.dir/macos.c.obj
[ 41%] [ 41%] Building C object lib/CMakeFiles/libcurl_object.dir/md4.c.obj
Building C object lib/CMakeFiles/libcurl_object.dir/llist.c.obj
[ 44%] Building C object lib/CMakeFiles/libcurl_object.dir/md5.c.obj
[ 44%] Building C object lib/CMakeFiles/libcurl_object.dir/memdebug.c.obj
[ 44%] Building C object lib/CMakeFiles/libcurl_object.dir/mime.c.obj
[ 44%] Building C object lib/CMakeFiles/libcurl_object.dir/mqtt.c.obj
[ 44%] Building C object lib/CMakeFiles/libcurl_object.dir/mprintf.c.obj
[ 44%] Building C object lib/CMakeFiles/libcurl_object.dir/multi.c.obj
[ 47%] Building C object lib/CMakeFiles/libcurl_object.dir/multi_ev.c.obj
[ 47%] Building C object lib/CMakeFiles/libcurl_object.dir/multi_ntfy.c.obj
[ 47%] Building C object lib/CMakeFiles/libcurl_object.dir/netrc.c.obj
[ 47%] Building C object lib/CMakeFiles/libcurl_object.dir/openldap.c.obj
[ 47%] Building C object lib/CMakeFiles/libcurl_object.dir/pingpong.c.obj
[ 50%] [ 50%] Building C object lib/CMakeFiles/libcurl_object.dir/parsedate.c.objBuilding C object lib/CMakeFiles/libcurl_object.dir/noproxy.c.obj

[ 50%] Building C object lib/CMakeFiles/libcurl_object.dir/progress.c.obj
[ 50%] Building C object lib/CMakeFiles/libcurl_object.dir/pop3.c.obj
[ 50%] Building C object lib/CMakeFiles/libcurl_object.dir/protocol.c.obj
[ 52%] Building C object lib/CMakeFiles/libcurl_object.dir/psl.c.obj
[ 52%] Building C object lib/CMakeFiles/libcurl_object.dir/rand.c.obj
[ 52%] Building C object lib/CMakeFiles/libcurl_object.dir/request.c.obj
[ 52%] Building C object lib/CMakeFiles/libcurl_object.dir/ratelimit.c.obj
[ 52%] Building C object lib/CMakeFiles/libcurl_object.dir/rtsp.c.obj
[ 55%] Building C object lib/CMakeFiles/libcurl_object.dir/sendf.c.obj
[ 55%] Building C object lib/CMakeFiles/libcurl_object.dir/select.c.obj
[ 55%] Building C object lib/CMakeFiles/libcurl_object.dir/setopt.c.obj
[ 55%] Building C object lib/CMakeFiles/libcurl_object.dir/slist.c.obj
[ 55%] Building C object lib/CMakeFiles/libcurl_object.dir/sha256.c.obj
[ 55%] Building C object lib/CMakeFiles/libcurl_object.dir/smb.c.obj
[ 58%] Building C object lib/CMakeFiles/libcurl_object.dir/smtp.c.obj
[ 58%] Building C object lib/CMakeFiles/libcurl_object.dir/socks.c.obj
[ 58%] Building C object lib/CMakeFiles/libcurl_object.dir/socketpair.c.obj
[ 58%] Building C object lib/CMakeFiles/libcurl_object.dir/socks_gssapi.c.obj
[ 58%] Building C object lib/CMakeFiles/libcurl_object.dir/socks_sspi.c.obj
[ 61%] Building C object lib/CMakeFiles/libcurl_object.dir/splay.c.obj
[ 61%] Building C object lib/CMakeFiles/libcurl_object.dir/strcase.c.obj
[ 61%] Building C object lib/CMakeFiles/libcurl_object.dir/strequal.c.obj
[ 61%] Building C object lib/CMakeFiles/libcurl_object.dir/strerror.c.obj
[ 61%] [ 61%] Building C object lib/CMakeFiles/libcurl_object.dir/tftp.c.objBuilding C object lib/CMakeFiles/libcurl_object.dir/system_win32.c.obj

[ 63%] Building C object lib/CMakeFiles/libcurl_object.dir/telnet.c.obj
[ 63%] Building C object lib/CMakeFiles/libcurl_object.dir/thrdpool.c.obj
[ 63%] Building C object lib/CMakeFiles/libcurl_object.dir/transfer.c.obj
[ 63%] Building C object lib/CMakeFiles/libcurl_object.dir/thrdqueue.c.obj
[ 63%] Building C object lib/CMakeFiles/libcurl_object.dir/uint-bset.c.obj
[ 63%] Building C object lib/CMakeFiles/libcurl_object.dir/uint-spbset.c.obj
[ 66%] Building C object lib/CMakeFiles/libcurl_object.dir/uint-hash.c.obj
[ 66%] Building C object lib/CMakeFiles/libcurl_object.dir/uint-table.c.obj
[ 66%] Building C object lib/CMakeFiles/libcurl_object.dir/url.c.obj
[ 66%] Building C object lib/CMakeFiles/libcurl_object.dir/urlapi.c.obj
[ 69%] Building C object lib/CMakeFiles/libcurl_object.dir/version.c.obj
[ 69%] Building C object lib/CMakeFiles/libcurl_object.dir/ws.c.obj
[ 69%] Building C object lib/CMakeFiles/libcurl_object.dir/vauth/cleartext.c.obj
[ 69%] Building C object lib/CMakeFiles/libcurl_object.dir/vauth/digest.c.obj
[ 69%] Building C object lib/CMakeFiles/libcurl_object.dir/vauth/cram.c.obj
[ 72%] Building C object lib/CMakeFiles/libcurl_object.dir/vauth/digest_sspi.c.obj
[ 72%] Building C object lib/CMakeFiles/libcurl_object.dir/vauth/krb5_gssapi.c.obj
[ 72%] Building C object lib/CMakeFiles/libcurl_object.dir/vauth/gsasl.c.obj
[ 72%] Building C object lib/CMakeFiles/libcurl_object.dir/vauth/krb5_sspi.c.obj
[ 72%] Building C object lib/CMakeFiles/libcurl_object.dir/vauth/ntlm.c.obj
[ 72%] Building C object lib/CMakeFiles/libcurl_object.dir/vauth/ntlm_sspi.c.obj
[ 75%] Building C object lib/CMakeFiles/libcurl_object.dir/vauth/oauth2.c.obj
[ 75%] Building C object lib/CMakeFiles/libcurl_object.dir/vauth/spnego_gssapi.c.obj
[ 75%] Building C object lib/CMakeFiles/libcurl_object.dir/vauth/spnego_sspi.c.obj
[ 75%] Building C object lib/CMakeFiles/libcurl_object.dir/vauth/vauth.c.obj
[ 75%] Building C object lib/CMakeFiles/libcurl_object.dir/vtls/apple.c.obj
[ 77%] [ 77%] Building C object lib/CMakeFiles/libcurl_object.dir/vtls/gtls.c.obj
Building C object lib/CMakeFiles/libcurl_object.dir/vtls/cipher_suite.c.obj
[ 77%] Building C object lib/CMakeFiles/libcurl_object.dir/vtls/hostcheck.c.obj
[ 77%] Building C object lib/CMakeFiles/libcurl_object.dir/vtls/keylog.c.obj
[ 77%] Building C object lib/CMakeFiles/libcurl_object.dir/vtls/mbedtls.c.obj
[ 80%] Building C object lib/CMakeFiles/libcurl_object.dir/vtls/openssl.c.obj
[ 80%] Building C object lib/CMakeFiles/libcurl_object.dir/vtls/rustls.c.obj
[ 80%] Building C object lib/CMakeFiles/libcurl_object.dir/vtls/schannel.c.obj
[ 80%] Building C object lib/CMakeFiles/libcurl_object.dir/vtls/vtls.c.obj
[ 80%] Building C object lib/CMakeFiles/libcurl_object.dir/vtls/vtls_scache.c.obj
[ 80%] Building C object lib/CMakeFiles/libcurl_object.dir/vtls/schannel_verify.c.obj
[ 83%] Building C object lib/CMakeFiles/libcurl_object.dir/vtls/vtls_spack.c.obj
[ 83%] Building C object lib/CMakeFiles/libcurl_object.dir/vtls/wolfssl.c.obj
[ 83%] Building C object lib/CMakeFiles/libcurl_object.dir/vtls/x509asn1.c.obj
[ 83%] Building C object lib/CMakeFiles/libcurl_object.dir/vquic/curl_quiche.c.obj[ 83%] Building C object lib/CMakeFiles/libcurl_object.dir/vquic/curl_ngtcp2.c.obj

[ 86%] Building C object lib/CMakeFiles/libcurl_object.dir/vquic/vquic.c.obj
[ 86%] Building C object lib/CMakeFiles/libcurl_object.dir/vquic/vquic-tls.c.obj
[ 86%] Building C object lib/CMakeFiles/libcurl_object.dir/vssh/libssh.c.obj
[ 86%] Building C object lib/CMakeFiles/libcurl_object.dir/vssh/libssh2.c.obj
[ 88%] [ 88%] Building C object lib/CMakeFiles/libcurl_object.dir/curlx/base64.c.obj
Building C object lib/CMakeFiles/libcurl_object.dir/vssh/vssh.c.obj
[ 88%] Building C object lib/CMakeFiles/libcurl_object.dir/curlx/basename.c.obj
[ 88%] Building C object lib/CMakeFiles/libcurl_object.dir/curlx/dynbuf.c.obj
[ 88%] Building C object lib/CMakeFiles/libcurl_object.dir/curlx/fopen.c.obj
[ 88%] Building C object lib/CMakeFiles/libcurl_object.dir/curlx/inet_ntop.c.obj
[ 88%] Building C object lib/CMakeFiles/libcurl_object.dir/curlx/inet_pton.c.obj
[ 91%] Building C object lib/CMakeFiles/libcurl_object.dir/curlx/multibyte.c.obj
[ 91%] Building C object lib/CMakeFiles/libcurl_object.dir/curlx/nonblock.c.obj
[ 91%] Building C object lib/CMakeFiles/libcurl_object.dir/curlx/strcopy.c.obj
[ 91%] Building C object lib/CMakeFiles/libcurl_object.dir/curlx/snprintf.c.obj
[ 91%] Building C object lib/CMakeFiles/libcurl_object.dir/curlx/strdup.c.obj
[ 94%] [ 94%] Building C object lib/CMakeFiles/libcurl_object.dir/curlx/strparse.c.obj
Building C object lib/CMakeFiles/libcurl_object.dir/curlx/strerr.c.obj
[ 94%] Building C object lib/CMakeFiles/libcurl_object.dir/curlx/timeval.c.obj
[ 94%] Building C object lib/CMakeFiles/libcurl_object.dir/curlx/timediff.c.obj
[ 97%] Building C object lib/CMakeFiles/libcurl_object.dir/curlx/wait.c.obj
[ 97%] Building C object lib/CMakeFiles/libcurl_object.dir/curlx/version_win32.c.obj
[ 97%] Building C object lib/CMakeFiles/libcurl_object.dir/curlx/warnless.c.obj
[ 97%] Building C object lib/CMakeFiles/libcurl_object.dir/curlx/winapi.c.obj
[ 97%] Built target libcurl_object
[ 97%] Building C object lib/CMakeFiles/libcurl_shared.dir/dllmain.c.obj
[ 97%] Building RC object lib/CMakeFiles/libcurl_shared.dir/libcurl.rc.obj
[100%] Linking C shared library libcurl.dll
[100%] Built target libcurl_shared

libcurl/8.20.0: Package 'ff44e9ac0c581c74423ac1ad3c3f42eedf7056a3' built
libcurl/8.20.0: Build folder C:\Users\el\.conan2\p\b\libcu0e643855c752e\b\build\Release
libcurl/8.20.0: Generating the package
libcurl/8.20.0: Packaging in folder C:\Users\el\.conan2\p\b\libcu0e643855c752e\p
libcurl/8.20.0: Calling package()
libcurl/8.20.0: Running CMake.install()
libcurl/8.20.0: RUN: cmake --install "C:/Users/el/.conan2/p/b/libcu0e643855c752e/b/build/Release" --prefix "C:/Users/el/.conan2/p/b/libcu0e643855c752e/p"
-- Install configuration: "Release"
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/lib/libcurl.dll.a
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/bin/libcurl.dll
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/bin/curl-config
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/lib/pkgconfig/libcurl.pc
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/include/curl
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/include/curl/curl.h
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/include/curl/curlver.h
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/include/curl/easy.h
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/include/curl/header.h
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/include/curl/mprintf.h
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/include/curl/multi.h
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/include/curl/options.h
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/include/curl/stdcheaders.h
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/include/curl/system.h
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/include/curl/typecheck-gcc.h
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/include/curl/urlapi.h
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/include/curl/websockets.h
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/lib/cmake/CURL/CURLTargets.cmake
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/lib/cmake/CURL/CURLTargets-release.cmake
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/lib/cmake/CURL/CURLConfigVersion.cmake
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/lib/cmake/CURL/CURLConfig.cmake
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/lib/cmake/CURL/FindBrotli.cmake
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/lib/cmake/CURL/FindCares.cmake
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/lib/cmake/CURL/FindGSS.cmake
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/lib/cmake/CURL/FindGnuTLS.cmake
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/lib/cmake/CURL/FindLDAP.cmake
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/lib/cmake/CURL/FindLibbacktrace.cmake
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/lib/cmake/CURL/FindLibgsasl.cmake
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/lib/cmake/CURL/FindLibidn2.cmake
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/lib/cmake/CURL/FindLibpsl.cmake
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/lib/cmake/CURL/FindLibssh.cmake
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/lib/cmake/CURL/FindLibssh2.cmake
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/lib/cmake/CURL/FindLibuv.cmake
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/lib/cmake/CURL/FindMbedTLS.cmake
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/lib/cmake/CURL/FindNGHTTP2.cmake
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/lib/cmake/CURL/FindNGHTTP3.cmake
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/lib/cmake/CURL/FindNGTCP2.cmake
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/lib/cmake/CURL/FindNettle.cmake
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/lib/cmake/CURL/FindQuiche.cmake
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/lib/cmake/CURL/FindRustls.cmake
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/lib/cmake/CURL/FindWolfSSL.cmake
-- Installing: C:/Users/el/.conan2/p/b/libcu0e643855c752e/p/lib/cmake/CURL/FindZstd.cmake

libcurl/8.20.0: package(): Packaged 2 files: curl-config, COPYING
libcurl/8.20.0: package(): Packaged 1 '.dll' file: libcurl.dll
libcurl/8.20.0: package(): Packaged 12 '.h' files
libcurl/8.20.0: package(): Packaged 1 '.a' file: libcurl.dll.a
libcurl/8.20.0: package(): Packaged 1 '.pem' file: cacert.pem
libcurl/8.20.0: Created package revision b55199010883ff3eb7433abdda7a31b1
libcurl/8.20.0: Package 'ff44e9ac0c581c74423ac1ad3c3f42eedf7056a3' created
libcurl/8.20.0: Full package reference: libcurl/8.20.0#f4cee1fe6fe1c82aa1991508e452b1bb:ff44e9ac0c581c74423ac1ad3c3f42eedf7056a3#b55199010883ff3eb7433abdda7a31b1
libcurl/8.20.0: Package folder C:\Users\el\.conan2\p\b\libcu0e643855c752e\p

======== Launching test_package ========

======== Computing dependency graph ========
Graph root
    libcurl/8.20.0 (test package): C:\pf\conan-center-index-pf\recipes\libcurl\all\test_package\conanfile.py
Requirements
    libcurl/8.20.0#f4cee1fe6fe1c82aa1991508e452b1bb - Cache
    zlib/1.3.2#1cb806da49011867778ffb6ac7190fcb - Cache
Build requirements
    cmake/3.31.11#f325c933f618a1fcebc1e1c0babfd1ba - Cache
Replaced requires
    cmake/[>=3 <4]: cmake/[>=3 <4]

======== Computing necessary packages ========
Requirements
    libcurl/8.20.0#f4cee1fe6fe1c82aa1991508e452b1bb:ff44e9ac0c581c74423ac1ad3c3f42eedf7056a3#b55199010883ff3eb7433abdda7a31b1 - Cache
    zlib/1.3.2#1cb806da49011867778ffb6ac7190fcb:0c4b6f6539851384385aac6bcb78741c44b9b0e4#13bd8f94ab3b99bd503fc606137e2d23 - Cache
Build requirements
    cmake/3.31.11#f325c933f618a1fcebc1e1c0babfd1ba:522dcea5982a3f8a5b624c16477e47195da2f84f#eacef9885b96e5616582c65683dd1553 - Cache

======== Installing packages ========
cmake/3.31.11: Already installed! (1 of 3)
zlib/1.3.2: Already installed! (2 of 3)
libcurl/8.20.0: Already installed! (3 of 3)

======== Testing the package ========
Removing previously existing 'test_package' build folder: C:\pf\conan-center-index-pf\recipes\libcurl\all\test_package\build\gcc-14-x86_64-gnu17-release       
libcurl/8.20.0 (test package): Test package build: build\gcc-14-x86_64-gnu17-release
libcurl/8.20.0 (test package): Test package build folder: C:\pf\conan-center-index-pf\recipes\libcurl\all\test_package\build\gcc-14-x86_64-gnu17-release       
libcurl/8.20.0 (test package): Writing generators to C:\pf\conan-center-index-pf\recipes\libcurl\all\test_package\build\gcc-14-x86_64-gnu17-release\generators 
libcurl/8.20.0 (test package): Generator 'CMakeDeps' calling 'generate()'
libcurl/8.20.0 (test package): CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(CURL)
    target_link_libraries(... CURL::libcurl)
libcurl/8.20.0 (test package): Generator 'CMakeToolchain' calling 'generate()'
libcurl/8.20.0 (test package): CMakeToolchain generated: conan_toolchain.cmake
libcurl/8.20.0 (test package): CMakeToolchain generated: C:\pf\conan-center-index-pf\recipes\libcurl\all\test_package\build\gcc-14-x86_64-gnu17-release\generators\CMakePresets.json
libcurl/8.20.0 (test package): CMakeToolchain generated: C:\pf\conan-center-index-pf\recipes\libcurl\all\test_package\CMakeUserPresets.json
libcurl/8.20.0 (test package): Generator 'VirtualRunEnv' calling 'generate()'
libcurl/8.20.0 (test package): Generating aggregated env files
libcurl/8.20.0 (test package): Generated aggregated env files: ['conanrun.bat', 'conanbuild.bat']

======== Testing the package: Building ========
libcurl/8.20.0 (test package): Calling build()
libcurl/8.20.0 (test package): Running CMake.configure()
libcurl/8.20.0 (test package): RUN: cmake -G "MinGW Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="C:/pf/conan-center-index-pf/recipes/libcurl/all/test_package" -DCMAKE_SH="CMAKE_SH-NOTFOUND" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "C:/pf/conan-center-index-pf/recipes/libcurl/all/test_package"
-- Using Conan toolchain: C:/pf/conan-center-index-pf/recipes/libcurl/all/test_package/build/gcc-14-x86_64-gnu17-release/generators/conan_toolchain.cmake
-- Conan toolchain: Defining architecture flag: -m64
-- Conan toolchain: C++ Standard 17 with extensions ON
-- The C compiler identification is GNU 14.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: C:/Qt/Tools/mingw1420_64/bin/gcc.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Conan: Component target declared 'CURL::libcurl'
-- Conan: Target declared 'ZLIB::ZLIB'
-- Configuring done (1.0s)
-- Generating done (0.0s)
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_SH


-- Build files have been written to: C:/pf/conan-center-index-pf/recipes/libcurl/all/test_package/build/gcc-14-x86_64-gnu17-release

libcurl/8.20.0 (test package): Running CMake.build()
libcurl/8.20.0 (test package): RUN: cmake --build "C:\pf\conan-center-index-pf\recipes\libcurl\all\test_package\build\gcc-14-x86_64-gnu17-release" -- -j22     
[ 50%] Building C object CMakeFiles/test_package.dir/test_package.c.obj
[100%] Linking C executable test_package.exe
[100%] Built target test_package


======== Testing the package: Executing test ========
libcurl/8.20.0 (test package): Running test()
libcurl/8.20.0 (test package): RUN: .\test_package
libcurl version libcurl/8.20.0 zlib/1.3.2
```

</p>
</details> 

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
