### PR TITLE
add overhauled recipe for openssl 4.0.0

### DIFF
--- a/recipes/openssl/4.x.x/conandata.yml
+++ b/recipes/openssl/4.x.x/conandata.yml
@@ -4,19 +4,10 @@
 #  - The most recent FIPS validated version
 #  Note: please do not maintain multiple patch versions of the same minor,
 #        unless required by the above.
-
-versions:
-  "4.0.1":
-    folder: "4.x.x"
-  "3.6.3":
-    folder: "3.x.x"
-  "3.5.7":
-    folder: "3.x.x"
-  "3.4.6":
-    folder: "3.x.x"
-  "3.1.2":
-    folder: "3.x.x"
-  "3.0.21":
-    folder: "3.x.x"
-  "1.1.1w":
-    folder: "1.x.x"
+sources:
+  "4.0.0":
+    url: "https://github.com/openssl/openssl/releases/download/openssl-4.0.0/openssl-4.0.0.tar.gz"
+    sha256: c32cf49a959c4f345f9606982dd36e7d28f7c58b19c2e25d75624d2b3d2f79ac
+patches:
+  "4.0.0":
+    - patch_file: "patches/01-msvc-use-z7-to-enable-parallel-builds.patch"

--- a/recipes/openssl/4.x.x/conandata.yml
+++ b/recipes/openssl/4.x.x/conandata.yml
@@ -5,9 +5,9 @@
 #  Note: please do not maintain multiple patch versions of the same minor,
 #        unless required by the above.
 sources:
-  "4.0.0":
-    url: "https://github.com/openssl/openssl/releases/download/openssl-4.0.0/openssl-4.0.0.tar.gz"
-    sha256: c32cf49a959c4f345f9606982dd36e7d28f7c58b19c2e25d75624d2b3d2f79ac
+  "4.0.1":
+    url: "https://github.com/openssl/openssl/releases/download/openssl-4.0.1/openssl-4.0.1.tar.gz"
+    sha256: 2db3f3a0d6ea4b59e1f094ace2c8cd536dffb87cdc39084c5afa1e6f7f37dd09
 patches:
-  "4.0.0":
+  "4.0.1":
     - patch_file: "patches/01-msvc-use-z7-to-enable-parallel-builds.patch"

--- a/recipes/openssl/4.x.x/conanfile.py
+++ b/recipes/openssl/4.x.x/conanfile.py
@@ -1,5 +1,5 @@
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
+from conan.errors import ConanException
 from conan.tools.apple import fix_apple_shared_install_name, is_apple_os
 from conan.tools.build import build_jobs
 from conan.tools.files import apply_conandata_patches, export_conandata_patches, copy, get, replace_in_file, rename, rm, rmdir
@@ -101,7 +101,7 @@ class OpenSSLConan(ConanFile):
         }
         key = (str(self.settings.os), str(self.settings.arch))
         if key not in targets:
-            raise ConanInvalidConfiguration(
+            raise ConanException(
                 f"Unable to map configuration for {key[0]}/{key[1]}.\n"
                 f"Set the user.openssl:target configuration to a built-in "
                 f"OpenSSL target to override, or open an issue at {self.url}."

--- a/recipes/openssl/4.x.x/conanfile.py
+++ b/recipes/openssl/4.x.x/conanfile.py
@@ -1,0 +1,208 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import fix_apple_shared_install_name, is_apple_os
+from conan.tools.build import build_jobs
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, copy, get, replace_in_file, rename, rm, rmdir
+from conan.tools.gnu import AutotoolsToolchain
+from conan.tools.layout import basic_layout
+from conan.tools.microsoft import is_msvc
+
+import os
+
+
+required_conan_version = ">=2.25"
+
+class OpenSSLConan(ConanFile):
+    name = "openssl"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/openssl/openssl"
+    license = "Apache-2.0"
+    topics = ("ssl", "tls", "encryption", "security")
+    description = "A toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols"
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "no_fips": [True, False],
+        "openssldir": [None, "ANY"],
+        "extra_build_opts": [None, "ANY"], # comma separated 
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "no_fips": False,
+        "openssldir": None,
+        "extra_build_opts": None,
+    }
+
+    @property
+    def _is_mingw(self):
+        is_gcc = self.settings.compiler == "gcc"
+        is_clang = self.settings.compiler == "clang" and self.settings.compiler.get_safe("runtime") is None
+        return self.settings.os == "Windows" and (is_gcc or is_clang)
+
+    @property
+    def _msvc_abi(self):
+        return self.settings.os == "Windows" and self.settings.compiler.get_safe("runtime")
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            self.options.rm_safe("fPIC")
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def build_requirements(self):
+        if self.settings_build.os == "Windows" and self._msvc_abi:
+            self.tool_requires("jom/[*]")
+            self.tool_requires("strawberryperl/[>=5.32 <6]")
+            if self.settings.arch in ["x86", "x86_64"]:
+                self.tool_requires("nasm/[*]")
+        else:
+            self.win_bash = True
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
+
+    @property
+    def _target(self):
+        # Map the Conan os/arch to a built-in OpenSSL Configure target (see `./Configure LIST`).
+        # Conan's "armv8" is arm64/aarch64. Anything not listed must be supplied explicitly
+        # via the user.openssl:target conf.     
+        custom_target = self.conf.get("user.openssl:target", check_type=str)
+        if custom_target:
+            return custom_target
+        
+        targets = {
+            ("Android", "armv8"): "android-arm64",
+            ("Linux", "x86_64"): "linux-x86_64",
+            ("Linux", "armv8"): "linux-aarch64",
+            ("Macos", "x86_64"): "darwin64-x86_64-cc",
+            ("Macos", "armv8"): "darwin64-arm64-cc",
+            ("iOS", "x86_64"): "iossimulator-x86_64-xcrun",
+            ("iOS", "armv8"): "ios64-xcrun",
+            ("Windows", "x86_64"): "mingw64" if self._is_mingw else "VC-WIN64A",
+            ("Windows", "armv8"): (
+                "mingwarm64" if self._is_mingw
+                else "VC-CLANG-WIN64-CLANGASM-ARM" if self.settings.compiler == "clang" and self._msvc_abi
+                else "VC-WIN64-CLANGASM-ARM"
+            ),
+        }
+        key = (str(self.settings.os), str(self.settings.arch))
+        if key not in targets:
+            raise ConanInvalidConfiguration(
+                f"Unable to map configuration for {key[0]}/{key[1]}.\n"
+                f"Set the user.openssl:target configuration to a built-in "
+                f"OpenSSL target to override, or open an issue at {self.url}."
+            )
+        return targets[key]
+
+    def generate(self):
+        tc = AutotoolsToolchain(self)
+        if is_msvc(self):
+            tc.extra_cflags.append("-nologo")
+        if is_apple_os(self) and self.options.shared:
+            tc.extra_ldflags.append("-headerpad_max_install_names")
+        tc.generate()
+
+    @property
+    def _configure_args(self):
+        args = [
+            f'"{self._target}"',
+            "shared" if self.options.shared else "no-shared",
+            "--debug" if self.settings.build_type == "Debug" else "--release",
+            "no-fips" if self.options.no_fips else "enable-fips",
+            "--prefix=C:/" if self._msvc_abi else "--prefix=/",
+            f"-D__ANDROID_API__={str(self.settings.os.api_level)}" if self.settings.os == "Android" else "",
+            "enable-static-vcruntime" if self.settings.get_safe("compiler.runtime") == "static" else "",
+            "--libdir=lib",
+            "no-docs",
+            "no-unit-test",
+            "no-tests",
+        ]
+
+        if self.settings.os != "Windows":
+            args.append("-fPIC" if self.options.get_safe("fPIC", True) else "no-pic")
+
+        if self.options.extra_build_opts:
+            args.extend(flag.strip() for flag in str(self.options.extra_build_opts).split(",") if flag.strip())
+
+        return args
+    
+    @property
+    def _make_program(self):
+        if self._msvc_abi:
+            return "jom"
+        else:
+            return self.conf.get("tools.gnu:make_program", default="make")
+
+    def build(self):
+        args = " ".join(self._configure_args)
+        perl = "perl" if "strawberryperl" in self.dependencies.build else ""
+        configure = os.path.join(self.source_folder, "Configure").replace('\\', '/')
+        self.run(f"{perl} {configure} {args}", env="conanbuild")
+        self.run(f"{perl} ./configdata.pm --dump", env="conanbuild")
+        self.run(f"{self._make_program} -j{build_jobs(self)}", env="conanbuild")
+        if self._msvc_abi:
+            # patch generated Makefile not correctly escaping a backslash
+            replace_in_file(self, "Makefile", "INSTALLTOP_dir=\\", "INSTALLTOP_dir=/")
+        if self._is_mingw and self.options.shared:
+            replace_in_file(self, "Makefile", "INSTALL_LIBS=libcrypto.a libssl.a", "INSTALL_LIBS=")
+
+    def package(self):
+        copy(self, "*LICENSE*", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        destdir = self.package_folder.replace('\\', '/')
+        self.run(f"{self._make_program} install -j1 DESTDIR={destdir}", env="conanbuild")
+        if is_apple_os(self):
+            fix_apple_shared_install_name(self)
+        if self._msvc_abi:
+            rename(self, os.path.join(self.package_folder, "Program Files/Common Files/SSL"),
+                        os.path.join(self.package_folder, "ssl"))
+
+        rm(self, "*.pdb", self.package_folder, "lib")
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "OpenSSL")
+        self.cpp_info.set_property("pkg_config_name", "openssl")
+
+        # Align with the definitions from CMake's FindOpenSSL module
+        self.cpp_info.set_property("cmake_additional_variables_prefixes", ["OPENSSL"])
+        self.cpp_info.set_property("cmake_extra_variables", {'OPENSSL_FOUND': 'TRUE',
+                                                             'OPENSSL_VERSION': self.version,
+                                                             'OPENSSL_CRYPTO_LIBRARY': 'OpenSSL::Crypto',
+                                                             'OPENSSL_CRYPTO_LIBRARIES': 'OpenSSL::Crypto',
+                                                             'OPENSSL_SSL_LIBRARY': 'OpenSSL::SSL',
+                                                             'OPENSSL_SSL_LIBRARIES': 'OpenSSL::SSL',
+                                                             'OPENSSL_LIBRARIES': 'OpenSSL::SSL;OpenSSL::Crypto'})
+        
+        prefix = "lib" if self._msvc_abi else ""
+        self.cpp_info.components["ssl"].libs = [f"{prefix}ssl"]
+        self.cpp_info.components["crypto"].libs = [f"{prefix}crypto"]
+        self.cpp_info.components["ssl"].requires = ["crypto"]
+
+        if self.settings.os == "Windows":
+            self.cpp_info.components["crypto"].system_libs.extend(["crypt32", "ws2_32", "advapi32", "user32", "bcrypt"])
+        elif self.settings.os == "Linux":
+            self.cpp_info.components["crypto"].system_libs.extend(["dl", "rt", "pthread"])
+            self.cpp_info.components["ssl"].system_libs.extend(["dl", "pthread"])
+
+        self.cpp_info.components["crypto"].set_property("cmake_target_name", "OpenSSL::Crypto")
+        self.cpp_info.components["crypto"].set_property("pkg_config_name", "libcrypto")
+        self.cpp_info.components["ssl"].set_property("cmake_target_name", "OpenSSL::SSL")
+        self.cpp_info.components["ssl"].set_property("pkg_config_name", "libssl")
+
+        openssl_modules_dir = os.path.join(self.package_folder, "lib", "ossl-modules")
+        self.runenv_info.define_path("OPENSSL_MODULES", openssl_modules_dir)

--- a/recipes/openssl/4.x.x/conanfile.py
+++ b/recipes/openssl/4.x.x/conanfile.py
@@ -151,7 +151,7 @@ class OpenSSLConan(ConanFile):
         args = " ".join(self._configure_args)
         perl = "perl" if "strawberryperl" in self.dependencies.build else ""
         configure = os.path.join(self.source_folder, "Configure").replace('\\', '/')
-        self.run(f"{perl} {configure} {args}", env="conanbuild")
+        self.run(f'{perl} "{configure}" {args}', env="conanbuild")
         self.run(f"{perl} ./configdata.pm --dump", env="conanbuild")
         self.run(f"{self._make_program} -j{build_jobs(self)}", env="conanbuild")
         if self._msvc_abi:
@@ -163,7 +163,7 @@ class OpenSSLConan(ConanFile):
     def package(self):
         copy(self, "*LICENSE*", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
         destdir = self.package_folder.replace('\\', '/')
-        self.run(f"{self._make_program} install -j1 DESTDIR={destdir}", env="conanbuild")
+        self.run(f'{self._make_program} install -j1 DESTDIR="{destdir}"', env="conanbuild")
         if is_apple_os(self):
             fix_apple_shared_install_name(self)
         if self._msvc_abi:

--- a/recipes/openssl/4.x.x/conanfile.py
+++ b/recipes/openssl/4.x.x/conanfile.py
@@ -157,7 +157,8 @@ class OpenSSLConan(ConanFile):
         if self._msvc_abi:
             # patch generated Makefile not correctly escaping a backslash
             replace_in_file(self, "Makefile", "INSTALLTOP_dir=\\", "INSTALLTOP_dir=/")
-        if self._is_mingw and self.options.shared:
+        if not self._msvc_abi and self.options.shared:
+            # supress installation of static libs when shared is enabled
             replace_in_file(self, "Makefile", "INSTALL_LIBS=libcrypto.a libssl.a", "INSTALL_LIBS=")
 
     def package(self):

--- a/recipes/openssl/4.x.x/patches/01-msvc-use-z7-to-enable-parallel-builds.patch
+++ b/recipes/openssl/4.x.x/patches/01-msvc-use-z7-to-enable-parallel-builds.patch
@@ -1,0 +1,90 @@
+Backport https://github.com/openssl/openssl/commit/be67880c1e6e37102a8488f81a8263554fa97d53
+
+From be67880c1e6e37102a8488f81a8263554fa97d53 Mon Sep 17 00:00:00 2001
+From: Milan Broz
+Date: Thu, 2 Apr 2026 12:51:46 +0200
+Subject: [PATCH] Windows: Use /Z7 compiler flag to enable parallel builds
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+MSVC compilation on Windows cannot be reliably parallelized
+with tools like jom (an nmake replacement) due to contention
+on shared .pdb files used for debug info. Writes to a shared
+.pdb must be serialized.
+
+The /FS compiler flag serializes concurrent compiler writes,
+but does not resolve contention when the compiler and linker
+access the same .pdb file. With shared .pdb files (e.g. app.pdb),
+the makefile does not prevent races between the linker and
+compilation of multiple targets.
+
+This can be resolved either by restructuring the makefile
+to introduce sentinel dependencies that serialize the conflicting
+steps, or by eliminating the shared .pdb entirely.
+
+This patch takes the latter approach: it replaces /Zi with /Z7,
+which embeds debug info directly into each .obj file and avoids
+any shared-file contention. /Z7 is supported by all MSVC versions.
+
+The linker-generated .pdb is unaffected.
+
+Side effects: object files are slightly larger, and all .pdb files
+are now named after their target — the shared app.pdb, ossl_static.pdb,
+and dso.pdb no longer exist.
+
+With this change, jom can be used to parallelize the build.
+
+Fixes: issue 9931
+
+Signed-off-by: Milan Broz
+
+Reviewed-by: Neil Horman
+Reviewed-by: Norbert Pocs
+MergeDate: Mon Apr 13 08:46:20 2026
+(Merged from https://github.com/openssl/openssl/pull/30703)
+---
+ Configurations/10-main.conf          | 6 +++---
+ Configurations/windows-makefile.tmpl | 4 +---
+ 2 files changed, 4 insertions(+), 6 deletions(-)
+
+diff --git a/Configurations/10-main.conf b/Configurations/10-main.conf
+index 76cbf0ffa0c1b..c7002eff39273 100644
+--- a/Configurations/10-main.conf
++++ b/Configurations/10-main.conf
+@@ -1541,10 +1541,10 @@ my %targets = (
+                                 "UNICODE", "_UNICODE",
+                                 "_CRT_SECURE_NO_DEPRECATE",
+                                 "_WINSOCK_DEPRECATED_NO_WARNINGS"),
+-        lib_cflags       => add("/Zi /Fdossl_static.pdb"),
++        lib_cflags       => add("/Z7"),
+         lib_defines      => add("L_ENDIAN"),
+-        dso_cflags       => "/Zi /Fddso.pdb",
+-        bin_cflags       => "/Zi /Fdapp.pdb",
++        dso_cflags       => "/Z7",
++        bin_cflags       => "/Z7",
+         # def_flag made to empty string so a .def file gets generated
+         shared_defflag   => '',
+         shared_ldflag    => "/dll",
+diff --git a/Configurations/windows-makefile.tmpl b/Configurations/windows-makefile.tmpl
+index a3c52ac19d44e..16fed4670d8e5 100644
+--- a/Configurations/windows-makefile.tmpl
++++ b/Configurations/windows-makefile.tmpl
+@@ -450,7 +450,7 @@ uninstall: {- "uninstall_docs" if !$disabled{docs}; -} uninstall_sw {- $disabled
+ 
+ libclean:
+ 	"$(PERL)" -e "map { m/(.*)\.dll$$/; unlink glob """{.,apps,test,fuzz}/$$1.*"""; } @ARGV" $(SHLIBS)
+-	-del /Q /F $(LIBS) libcrypto.* libssl.* ossl_static.pdb
++	-del /Q /F $(LIBS) libcrypto.* libssl.*
+ 
+ clean: libclean
+ 	{- join("\n\t", map { "-if exist $_ del /Q /F $_" } @HTMLDOCS1) || "\@rem" -}
+@@ -545,8 +545,6 @@ install_dev: install_runtime_libs
+ 				       "$(INSTALLTOP)\include\openssl"
+ 	@"$(PERL)" "$(SRCDIR)\util\mkdir-p.pl" "$(libdir)"
+ 	@"$(PERL)" "$(SRCDIR)\util\copy.pl" $(INSTALL_LIBS) "$(libdir)"
+-	@if "$(SHLIBS)"=="" \
+-	 "$(PERL)" "$(SRCDIR)\util\copy.pl" ossl_static.pdb "$(libdir)"
+ 	@"$(PERL)" "$(SRCDIR)\util\mkdir-p.pl" "$(CMAKECONFIGDIR)"
+ 	@"$(PERL)" "$(SRCDIR)\util\copy.pl" $(INSTALL_EXPORTERS_CMAKE) "$(CMAKECONFIGDIR)"
+ 

--- a/recipes/openssl/4.x.x/test_package/CMakeLists.txt
+++ b/recipes/openssl/4.x.x/test_package/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES C)
+
+find_package(OpenSSL REQUIRED)
+
+# Test whether variables from https://cmake.org/cmake/help/latest/module/FindOpenSSL.html
+# are properly defined in conan generators
+set(_custom_vars
+    OPENSSL_FOUND
+    OPENSSL_INCLUDE_DIR
+    OPENSSL_CRYPTO_LIBRARY
+    OPENSSL_CRYPTO_LIBRARIES
+    OPENSSL_SSL_LIBRARY
+    OPENSSL_SSL_LIBRARIES
+    OPENSSL_LIBRARIES
+    OPENSSL_VERSION
+)
+foreach(_custom_var ${_custom_vars})
+    if(DEFINED ${_custom_var})
+        message(STATUS "${_custom_var}: ${${_custom_var}}")
+    else()
+        message(FATAL_ERROR "${_custom_var} not defined")
+    endif()
+endforeach()
+
+add_executable(test_package test_package.c)
+target_link_libraries(test_package PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+

--- a/recipes/openssl/4.x.x/test_package/conanfile.py
+++ b/recipes/openssl/4.x.x/test_package/conanfile.py
@@ -1,0 +1,53 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+from conan.tools.env import Environment
+from conan.tools.files import save
+import os
+import textwrap
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def generate(self):
+        openssl_pkg = self.dependencies["openssl"].package_folder.replace("\\", "/")
+        fipsmodule_cnf = f"{openssl_pkg}/ssl/fipsmodule.cnf"
+        cnf = textwrap.dedent(f"""\
+            config_diagnostics = 1
+            openssl_conf = openssl_init
+            .include {fipsmodule_cnf}
+
+            [openssl_init]
+            providers = provider_sect
+
+            [provider_sect]
+            fips = fips_sect
+            base = base_sect
+
+            [base_sect]
+            activate = 1
+        """)
+        cnf_path = os.path.join(self.generators_folder, "openssl_fips.cnf")
+        save(self, cnf_path, cnf)
+
+        env = Environment()
+        env.define("OPENSSL_CONF", cnf_path.replace("\\", "/"))
+        env.vars(self, scope="run").save_script("openssl_conf")
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/openssl/4.x.x/test_package/test_package.c
+++ b/recipes/openssl/4.x.x/test_package/test_package.c
@@ -1,0 +1,114 @@
+#include <stdio.h>
+#include <string.h>
+#include <openssl/provider.h>
+#include <openssl/evp.h>
+#include <openssl/err.h>
+#include <openssl/conf.h>
+
+void print_openssl_error(void)
+{
+    unsigned long err;
+    while ((err = ERR_get_error()) != 0)
+        fprintf(stderr, "    OpenSSL: %s\n", ERR_error_string(err, NULL));
+}
+
+/*
+ * Compute a digest of `input` using `algorithm`, fetched specifically from
+ * `provider` (via a "provider=<name>" property query) so the test verifies
+ * the named provider rather than whichever one happens to be active.
+ * Returns 1 on success, 0 on failure.
+ */
+int test_digest(const char *provider, const char *algorithm, const char *input)
+{
+    char propq[64];
+    snprintf(propq, sizeof(propq), "provider=%s", provider);
+
+    EVP_MD *md = EVP_MD_fetch(NULL, algorithm, propq);
+    if (!md) {
+        print_openssl_error();
+        return 0;
+    }
+
+    unsigned char digest[EVP_MAX_MD_SIZE];
+    unsigned int  digest_len = 0;
+    int ok = 0;
+
+    EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+    if (ctx != NULL
+            && EVP_DigestInit_ex(ctx, md, NULL) == 1
+            && EVP_DigestUpdate(ctx, input, strlen(input)) == 1
+            && EVP_DigestFinal_ex(ctx, digest, &digest_len) == 1) {
+        /* Report which provider actually served the implementation. */
+        const OSSL_PROVIDER *served = EVP_MD_get0_provider(md);
+        const char *served_name = served ? OSSL_PROVIDER_get0_name(served) : "?";
+
+        printf("      digest(%s, \"%s\") [served by: %s] = ", algorithm, input, served_name);
+        /* Print first 8 bytes as hex */
+        for (unsigned int i = 0; i < digest_len && i < 8; i++)
+            printf("%02x", digest[i]);
+        printf("...  [PASS]\n");
+        ok = 1;
+    }
+
+    EVP_MD_CTX_free(ctx);
+    EVP_MD_free(md);
+    return ok;
+}
+
+/*
+ * Load `name` into the global context and report the result.
+ *  - digest_alg: if non-NULL, exercise the provider with one digest
+ *                (NULL for providers like "null" that expose no algorithms).
+ *  - required:   if the load fails, report [FAIL]; otherwise a missing
+ *                provider is reported as [SKIP]. A provider that is present
+ *                but fails to initialise (an ERR_LIB_PROV error, e.g. a
+ *                misconfigured fips) is always reported as [FAIL].
+ *  - show_conf:  print the active OPENSSL_CONF (useful for fips diagnostics).
+ */
+void test_provider(const char *name, const char *digest_alg,
+                   int required, int show_conf)
+{
+    printf("\n[Provider: %s]\n", name);
+
+    if (show_conf) {
+        char *conf_path = CONF_get1_default_config_file();
+        printf("  OPENSSL_CONF: %s\n", conf_path ? conf_path : "(none)");
+        OPENSSL_free(conf_path);
+    }
+
+    OSSL_PROVIDER *prov = OSSL_PROVIDER_load(NULL, name);
+    if (!prov) {
+        if (!required && ERR_GET_LIB(ERR_peek_error()) == ERR_LIB_PROV) {
+            printf("  Load:  [FAIL] (%s provider present but failed to initialise)\n", name);
+            printf("  Hint:  check OPENSSL_CONF / run 'openssl fipsinstall' for fips\n");
+        } else if (!required) {
+            printf("  Load:  [SKIP] (%s provider not installed)\n", name);
+        } else {
+            printf("  Load:  [FAIL]\n");
+        }
+        print_openssl_error();
+        return;
+    }
+    printf("  Load:  [PASS]\n");
+
+    if (digest_alg)
+        test_digest(name, digest_alg, "hello");
+
+    OSSL_PROVIDER_unload(prov);
+}
+
+/* ─── Entry point ──────────────────────────────────────────────── */
+
+int main(void)
+{
+    printf("OpenSSL version: %s\n", OpenSSL_version(OPENSSL_VERSION));
+
+    /* provider     digest    required  show_conf */
+    test_provider("default", "SHA256", 1, 0);  /* SHA256: from default provider */
+    test_provider("legacy",  "MD4",    0, 0);  /* MD4: legacy-only digest */
+    test_provider("fips",    "SHA256", 0, 1);  /* SHA256: FIPS-approved    */
+    test_provider("null",    NULL,     1, 0);  /* exposes no algorithms    */
+
+    printf("\nTest package successful\n");
+    return 0;
+}

--- a/recipes/openssl/4.x.x/test_package/test_package.c
+++ b/recipes/openssl/4.x.x/test_package/test_package.c
@@ -97,8 +97,6 @@ void test_provider(const char *name, const char *digest_alg,
     OSSL_PROVIDER_unload(prov);
 }
 
-/* ─── Entry point ──────────────────────────────────────────────── */
-
 int main(void)
 {
     printf("OpenSSL version: %s\n", OpenSSL_version(OPENSSL_VERSION));


### PR DESCRIPTION
### Summary
Changes to recipe:  Add recipe for OpenSSL 4.0.0

Recipe has been overhauled and simplified with respect to 1.x and 3.x

* Uses `jom` on windows by default for faster builds
* Fixes issues on Windows with clang-cl and the clang64 msys2 environment
* Most recipe options have been removed with respect to openssl 3.x for simplification (most of them can be transparently passed via the comman separated `extra_build_opts` - the `no-fips` option and`openssl-dir` dir are retained
* OpenSSL 4.0.0 may have breaking changes of its own, please check the OpenSSL documentation
* Simplified test package

⚠️  Due to OpenSSL 4.x having breaking changes with respect to 3.x, and the recipe having a different interface, for the time being we will not be extending the version range in other recipes to account for OpenSSL 4. You can use a [replace_requires](https://docs.conan.io/2/reference/config_files/profiles.html#replace-requires) to override the dependency to OpenSSL 4, or an override. Please Open a new issue if there are other behaviour changes that we need to account for, thanks.

#### Details
(when compared to 3.x)
* No longer generates an on the fly configuration by extending pre-existing OpenSSL ones. Instead, the profile settings are mapped to an existing configuration, and `CFLAGS`, `CXXFLAGS`, `CC` etc are all respected by OpenSSL.
* No observed issues with iOS+shared
* Simplified handling of make program and perl - invoking via `perl.exe` is only needed on Windows with msvc or clang-cl
* Very much simplified options - additional options can be passed via the comma separated `extra_build_opts`
  - `zlib` is no longer an optional dependency. This matches the default behaviour of the openssl build scripts, as well as the behaviour of homebrew and vcpkg
* `install` target is now used, so no need for separate manual handling
* Simplified test package logic - the test now tests more explicitly some algorithms from the different providers, but the test wont fail as long as the library links and the test runs.
* use `cmake_extra_variables` in package info to define the CMake compatibility variables with the `FindOpenSSL` modules - apart from cleaner code, this has the advantage that it *doesn't* rely on Conan private/undocumented variables and uses CMake targets

#### Additional CI checks

* Android
* iOS
* Windows with clang-cl
* Windows/msvc Debug
* Linux with clang22
* Msys2:
    - gcc15, ucrt64 environment
    - clang 21, clang64 environment

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
