### PR TITLE
tree-sitter: add 0.26.9 version

### DIFF
--- a/recipes/tree-sitter/all/conandata.yml
+++ b/recipes/tree-sitter/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.26.9":
+    url: "https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v0.26.9.tar.gz"
+    sha256: "8e14780500933f43d86662fcaa1b0ce99ebe9c220f4680bc929dce09a0e0cfc6"
   "0.25.9":
     url: "https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v0.25.9.tar.gz"
     sha256: "024a2478579acebbb8882d7c2c0f0e07fc0aa19a459b48d10469e4abb96cf16e"

--- a/recipes/tree-sitter/all/conandata.yml
+++ b/recipes/tree-sitter/all/conandata.yml
@@ -5,9 +5,6 @@ sources:
   "0.25.9":
     url: "https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v0.25.9.tar.gz"
     sha256: "024a2478579acebbb8882d7c2c0f0e07fc0aa19a459b48d10469e4abb96cf16e"
-  "0.25.1":
-    url: "https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v0.25.1.tar.gz"
-    sha256: "99a2446075c2edf60e82755c48415d5f6e40f2d9aacb3423c6ca56809b70fe59"
   "0.24.4":
     url: "https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v0.24.4.tar.gz"
     sha256: "d704832a6bfaac8b3cbca3b5d773cad613183ba8c04166638af2c6e5dfb9e2d2"

--- a/recipes/tree-sitter/all/conanfile.py
+++ b/recipes/tree-sitter/all/conanfile.py
@@ -3,6 +3,7 @@ import os
 from conan import ConanFile
 from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout
 from conan.tools.files import get, copy, rmdir
+from conan.tools.scm import Version
 
 required_conan_version = ">=1.53.0"
 
@@ -51,7 +52,11 @@ class TreeSitterConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
-        cmake.configure(build_script_folder=os.path.join(self.source_folder, "lib"))
+        # CMakeLists.txt moved from lib/ to root in 0.26.x
+        if Version(self.version) < "0.26":
+            cmake.configure(build_script_folder=os.path.join(self.source_folder, "lib"))
+        else:
+            cmake.configure()
         cmake.build()
 
     def package(self):

--- a/recipes/tree-sitter/config.yml
+++ b/recipes/tree-sitter/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.26.9":
+    folder: all
   "0.25.9":
     folder: all
   "0.25.1":

--- a/recipes/tree-sitter/config.yml
+++ b/recipes/tree-sitter/config.yml
@@ -3,8 +3,6 @@ versions:
     folder: all
   "0.25.9":
     folder: all
-  "0.25.1":
-    folder: all
   "0.24.4":
     folder: all
   "0.24.3":


### PR DESCRIPTION
### Summary
Changes to recipe: **tree-sitter/0.26.9**

#### Motivation
Add version 0.26.9 of tree-sitter.

#### Details
- In 0.26.x the `CMakeLists.txt` [moved from `lib/` to the repository root](https://github.com/tree-sitter/tree-sitter/blob/v0.26.9/CMakeLists.txt), whereas previous versions had it [at `lib/CMakeLists.txt`](https://github.com/tree-sitter/tree-sitter/blob/v0.25.9/lib/CMakeLists.txt). The recipe's `build()` method now selects the correct `build_script_folder` depending on the version.

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
