### PR TITLE
librdkafka: add version 2.14.2

### DIFF
--- a/recipes/librdkafka/all/conandata.yml
+++ b/recipes/librdkafka/all/conandata.yml
@@ -2,9 +2,6 @@ sources:
   "2.14.2":
     url: "https://github.com/edenhill/librdkafka/archive/v2.14.2.tar.gz"
     sha256: "d7eec9c31c817fa44402f679c252dfbf97e4c338a849a25c3579a31fd127beb8"
-  "2.14.0":
-    url: "https://github.com/edenhill/librdkafka/archive/v2.14.0.tar.gz"
-    sha256: "c05c03ef00a13a8463fac3e8918c04843c416f11ced58c889d806a88ca92cf99"
   "2.13.0":
     url: "https://github.com/edenhill/librdkafka/archive/v2.13.0.tar.gz"
     sha256: "3bd351601d8ebcbc99b9a1316cae1b83b00edbcf9411c34287edf1791c507600"

--- a/recipes/librdkafka/all/conandata.yml
+++ b/recipes/librdkafka/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.14.2":
+    url: "https://github.com/edenhill/librdkafka/archive/v2.14.2.tar.gz"
+    sha256: "d7eec9c31c817fa44402f679c252dfbf97e4c338a849a25c3579a31fd127beb8"
   "2.14.0":
     url: "https://github.com/edenhill/librdkafka/archive/v2.14.0.tar.gz"
     sha256: "c05c03ef00a13a8463fac3e8918c04843c416f11ced58c889d806a88ca92cf99"
@@ -6,6 +9,10 @@ sources:
     url: "https://github.com/edenhill/librdkafka/archive/v2.13.0.tar.gz"
     sha256: "3bd351601d8ebcbc99b9a1316cae1b83b00edbcf9411c34287edf1791c507600"
 patches:
+  "2.14.2":
+    - patch_file: patches/0001-Change-library-names-1-9-1.patch
+    - patch_file: patches/0002-Change-library-targets-and-result-variables-2-5-0.patch
+    - patch_file: patches/0004-Fix_compilation_with_CMake_and_without_CURL.patch
   "2.14.0":
     - patch_file: patches/0001-Change-library-names-1-9-1.patch
     - patch_file: patches/0002-Change-library-targets-and-result-variables-2-5-0.patch

--- a/recipes/librdkafka/all/conandata.yml
+++ b/recipes/librdkafka/all/conandata.yml
@@ -10,10 +10,6 @@ patches:
     - patch_file: patches/0001-Change-library-names-1-9-1.patch
     - patch_file: patches/0002-Change-library-targets-and-result-variables-2-5-0.patch
     - patch_file: patches/0004-Fix_compilation_with_CMake_and_without_CURL.patch
-  "2.14.0":
-    - patch_file: patches/0001-Change-library-names-1-9-1.patch
-    - patch_file: patches/0002-Change-library-targets-and-result-variables-2-5-0.patch
-    - patch_file: patches/0004-Fix_compilation_with_CMake_and_without_CURL.patch
   "2.13.0":
     - patch_file: patches/0001-Change-library-names-1-9-1.patch
     - patch_file: patches/0002-Change-library-targets-and-result-variables-2-5-0.patch

--- a/recipes/librdkafka/config.yml
+++ b/recipes/librdkafka/config.yml
@@ -1,8 +1,6 @@
 versions:
   "2.14.2":
     folder: all
-  "2.14.0":
-    folder: all
   "2.13.0":
     folder: all
 

--- a/recipes/librdkafka/config.yml
+++ b/recipes/librdkafka/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.14.2":
+    folder: all
   "2.14.0":
     folder: all
   "2.13.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **librdkafka/2.14.2**

#### Motivation
latest version of librdkafka with [bugfixes](https://github.com/confluentinc/librdkafka/releases/tag/v2.14.2)

#### Details

No relevant cmake changes since 2.14.0: https://github.com/confluentinc/librdkafka/compare/v2.14.0...v2.14.2


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
