### PR TITLE
gperftools, util-linux-libuuid: remove redundant access to private attribute

### DIFF
--- a/recipes/gperftools/all/conanfile.py
+++ b/recipes/gperftools/all/conanfile.py
@@ -139,21 +139,6 @@ class GperftoolsConan(ConanFile):
         args["with-tcmalloc-alignment"] = self.options.tcmalloc_alignment
         args["with-tcmalloc-pagesize"] = self.options.tcmalloc_pagesize
 
-        # Based on https://github.com/conan-io/conan-center-index/blob/c647b1/recipes/libx264/all/conanfile.py#L94
-        if is_apple_os(self) and self.settings.arch == "armv8":
-            args["host"] = "aarch64-apple-darwin"
-            tc.extra_asflags = ["-arch arm64"]
-            tc.extra_ldflags = ["-arch arm64"]
-            if self.settings.os != "Macos":
-                xcrun = XCRun(self)
-                platform_flags = ["-isysroot", xcrun.sdk_path]
-                apple_min_version_flag = AutotoolsToolchain(self).apple_min_version_flag
-                if apple_min_version_flag:
-                    platform_flags.append(apple_min_version_flag)
-                tc.extra_asflags.extend(platform_flags)
-                tc.extra_cflags.extend(platform_flags)
-                tc.extra_ldflags.extend(platform_flags)
-
         for k, v in args.items():
             if v in [True, False]:
                 v = "yes" if v else "no"

--- a/recipes/gperftools/all/conanfile.py
+++ b/recipes/gperftools/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.apple import fix_apple_shared_install_name, is_apple_os, XCRun
+from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.build import cross_building, check_min_cppstd, stdcpp_library
 from conan.tools.cmake import cmake_layout
 from conan.tools.env import VirtualRunEnv

--- a/recipes/util-linux-libuuid/all/conanfile.py
+++ b/recipes/util-linux-libuuid/all/conanfile.py
@@ -91,21 +91,6 @@ class UtilLinuxLibuuidConan(ConanFile):
         if "x86" in self.settings.arch:
             tc.extra_cflags.append("-mstackrealign")
 
-        # Based on https://github.com/conan-io/conan-center-index/blob/c647b1/recipes/libx264/all/conanfile.py#L94
-        if is_apple_os(self) and self.settings.arch == "armv8":
-            tc.configure_args.append("--host=aarch64-apple-darwin")
-            tc.extra_asflags = ["-arch arm64"]
-            tc.extra_ldflags = ["-arch arm64"]
-            if self.settings.os != "Macos":
-                xcrun = XCRun(self)
-                platform_flags = ["-isysroot", xcrun.sdk_path]
-                apple_min_version_flag = AutotoolsToolchain(self).apple_min_version_flag
-                if apple_min_version_flag:
-                    platform_flags.append(apple_min_version_flag)
-                tc.extra_asflags.extend(platform_flags)
-                tc.extra_cflags.extend(platform_flags)
-                tc.extra_ldflags.extend(platform_flags)
-
         tc.generate()
 
         deps = AutotoolsDeps(self)

--- a/recipes/util-linux-libuuid/all/conanfile.py
+++ b/recipes/util-linux-libuuid/all/conanfile.py
@@ -1,6 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.apple import fix_apple_shared_install_name, is_apple_os, XCRun
+from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.files import copy, get, rm, rmdir
 from conan.tools.gnu import Autotools, AutotoolsToolchain, AutotoolsDeps
 from conan.tools.layout import basic_layout


### PR DESCRIPTION

### Summary

- Remove use of `AutotoolsToolchain(self).apple_min_version_flag`, which is an undocumented (and private) attribute
- in `gperftools` and `util-linux-libuuid`, the flag is _already_ propagated by `AutotoolsToolchain` in the relevant environment variables (e.g. `CFLAGS`)
- FIx iOS build (`--host` is already passed correctly by Conan)

Beforel this PR:
- flags are passed twice, and the build is broken for iOS
e.g.
```
        ldflags:                   -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS26.5.sdk -arch arm64 -mios-version-min=26.0 -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS26.5.sdk -mios-version-min=26.0
```



---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
