### PR TITLE
[libpsl] Remove builtin from Conan recipe

### DIFF
--- a/recipes/libpsl/all/conanfile.py
+++ b/recipes/libpsl/all/conanfile.py
@@ -77,10 +77,7 @@ class LibPslConan(ConanFile):
         tc = MesonToolchain(self)
         tc.project_options["runtime"] = self._idna_option
         if Version(self.version) >= "0.21.5":
-            tc.project_options["builtin"] = "true" if self.options.with_idna else "false"
             tc.project_options["tests"] = "false"  # disable tests and fuzzes
-        else:
-            tc.project_options["builtin"] = self._idna_option
         if not self.options.shared:
             tc.preprocessor_definitions["PSL_STATIC"] = "1"
         tc.generate()

--- a/recipes/libpsl/all/conanfile.py
+++ b/recipes/libpsl/all/conanfile.py
@@ -79,6 +79,8 @@ class LibPslConan(ConanFile):
         if Version(self.version) >= "0.21.5":
             tc.project_options["tests"] = "false"  # disable tests and fuzzes
         else:
+            # INFO: Version 0.21.2 replaced idna with builtin option
+            # https://github.com/rockdaboot/libpsl/commit/aa4909766c24c17bd1d9000ca419f6dc6b32c238
             tc.project_options["builtin"] = self._idna_option
         if not self.options.shared:
             tc.preprocessor_definitions["PSL_STATIC"] = "1"

--- a/recipes/libpsl/all/conanfile.py
+++ b/recipes/libpsl/all/conanfile.py
@@ -78,6 +78,8 @@ class LibPslConan(ConanFile):
         tc.project_options["runtime"] = self._idna_option
         if Version(self.version) >= "0.21.5":
             tc.project_options["tests"] = "false"  # disable tests and fuzzes
+        else:
+            tc.project_options["builtin"] = self._idna_option
         if not self.options.shared:
             tc.preprocessor_definitions["PSL_STATIC"] = "1"
         tc.generate()


### PR DESCRIPTION
### Summary
Changes to recipe:  **libpsl/2.5.1**

#### Motivation

Related to PR #27529. As it was created by an organization, GitHub does not allow editing, so I opened this one.

close #27529

#### Details

The builtin option is enabled by default already: https://github.com/rockdaboot/libpsl/blob/0.21.5/meson_options.txt#L6
And consumed as a preprocessor definition: https://github.com/rockdaboot/libpsl/blob/0.21.5/meson.build#L93
Later, it configures whether it should or should not use an internal table: https://github.com/rockdaboot/libpsl/blob/0.21.5/src/psl.c#L175

It does not affect dependencies or extra libraries in the package.

Also, other package managers don't handle builtin option as well:

* https://github.com/NixOS/nixpkgs/blob/nixpkgs-unstable/pkgs/by-name/li/libpsl/package.nix
* https://github.com/spack/spack-packages/blob/develop/repos/spack_repo/builtin/packages/libpsl/package.py
* https://salsa.debian.org/debian/libpsl/-/blob/debian/unstable/debian/rules

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
