### PR TITLE
dspark: add recipe (1.7.0)

### DIFF
--- a/recipes/dspark/all/conandata.yml
+++ b/recipes/dspark/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.2.2":
+    url: "https://github.com/CristianMoresi/DSPark/archive/refs/tags/v1.2.2.tar.gz"
+    sha256: "2000a4d321d79e3f04c327643b77f1e8b7ba82e2e9a0fb3612e268dc151d47ed"

--- a/recipes/dspark/all/conandata.yml
+++ b/recipes/dspark/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "1.2.2":
-    url: "https://github.com/CristianMoresi/DSPark/archive/refs/tags/v1.2.2.tar.gz"
-    sha256: "2000a4d321d79e3f04c327643b77f1e8b7ba82e2e9a0fb3612e268dc151d47ed"
+  "1.6.0":
+    url: "https://github.com/CristianMoresi/DSPark/archive/refs/tags/v1.6.0.tar.gz"
+    sha256: "90fc70c833a4e39bd5cf7aff4830343696df4a8391af3198f59c4c4eca6089bd"

--- a/recipes/dspark/all/conandata.yml
+++ b/recipes/dspark/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.7.0":
+    url: "https://github.com/CristianMoresi/DSPark/archive/refs/tags/v1.7.0.tar.gz"
+    sha256: "5255d6a68efa708231be84c93dffe4458b87cfe73e8faa20c7abe3656b782dba"

--- a/recipes/dspark/all/conanfile.py
+++ b/recipes/dspark/all/conanfile.py
@@ -1,0 +1,50 @@
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+import os
+
+required_conan_version = ">=1.62.0"
+
+
+class DSParkConan(ConanFile):
+    name = "dspark"
+    description = ("Header-only audio DSP framework in pure C++20 with zero "
+                   "external dependencies: filters, dynamics, reverbs, physical "
+                   "analog models, pitch tools, EBU R128 metering and more.")
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/CristianMoresi/DSPark"
+    topics = ("audio", "dsp", "header-only", "filters", "effects", "loudness")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, 20)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder,
+             os.path.join(self.package_folder, "licenses"))
+        for module in ("Core", "Effects", "Analysis", "IO", "Music"):
+            copy(self, "*.h",
+                 os.path.join(self.source_folder, module),
+                 os.path.join(self.package_folder, "include", "DSPark", module))
+        copy(self, "DSPark.h", self.source_folder,
+             os.path.join(self.package_folder, "include", "DSPark"))
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.set_property("cmake_file_name", "DSPark")
+        self.cpp_info.set_property("cmake_target_name", "DSPark::DSPark")

--- a/recipes/dspark/all/conanfile.py
+++ b/recipes/dspark/all/conanfile.py
@@ -1,0 +1,59 @@
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, rmdir
+import os
+
+
+required_conan_version = ">=2.0.9"
+
+
+class DSParkConan(ConanFile):
+    name = "dspark"
+    description = "Header-only C++20 framework for real-time and offline audio DSP"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/CristianMoresi/DSPark"
+    topics = ("audio", "dsp", "signal-processing", "real-time", "simd", "header-only")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        check_min_cppstd(self, 20)
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.21 <4]")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.cache_variables["DSPARK_BUILD_CONFORMANCE"] = False
+        tc.cache_variables["DSPARK_BUILD_TESTS"] = False
+        tc.cache_variables["DSPARK_VERIFY_FLOAT_CAST_OVERFLOW_SANITIZER"] = False
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib"))
+
+    def package_info(self):
+        self.cpp_info.includedirs = [os.path.join("include", "dspark")]
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.set_property("cmake_file_name", "dspark")
+        self.cpp_info.set_property("cmake_target_name", "dspark::dspark")

--- a/recipes/dspark/all/test_package/CMakeLists.txt
+++ b/recipes/dspark/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(DSPark REQUIRED CONFIG)
+
+add_executable(test_package test_package.cpp)
+target_link_libraries(test_package PRIVATE DSPark::DSPark)
+target_compile_features(test_package PRIVATE cxx_std_20)

--- a/recipes/dspark/all/test_package/CMakeLists.txt
+++ b/recipes/dspark/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(dspark REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE dspark::dspark)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)

--- a/recipes/dspark/all/test_package/conanfile.py
+++ b/recipes/dspark/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/dspark/all/test_package/conanfile.py
+++ b/recipes/dspark/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/dspark/all/test_package/test_package.cpp
+++ b/recipes/dspark/all/test_package/test_package.cpp
@@ -1,0 +1,27 @@
+#include <DSPark/DSPark.h>
+
+#include <cstdio>
+
+int main()
+{
+    dspark::AudioSpec spec { 48000.0, 64, 2 };
+
+    dspark::Gain<float> gain;
+    gain.prepare(spec);
+    gain.setGainDb(-3.0f);
+
+    dspark::Biquad<float, 2> biquad;
+    biquad.setCoeffs(dspark::BiquadCoeffs<float>::makeLowPass(48000.0, 1000.0, 0.707));
+
+    float left[64] = {};
+    float right[64] = {};
+    left[0] = 1.0f;
+    right[0] = 1.0f;
+    float* channels[2] = { left, right };
+    dspark::AudioBufferView<float> view(channels, 2, 64);
+    gain.processBlock(view);
+
+    std::printf("DSPark test package: impulse through Gain -> %f\n",
+                static_cast<double>(left[0]));
+    return 0;
+}

--- a/recipes/dspark/all/test_package/test_package.cpp
+++ b/recipes/dspark/all/test_package/test_package.cpp
@@ -1,0 +1,9 @@
+#include <DSPark.h>
+
+#include <cstdlib>
+
+int main() {
+    dspark::Gain<float> gain;
+    gain.prepare({48000.0, 64, 2});
+    return EXIT_SUCCESS;
+}

--- a/recipes/dspark/config.yml
+++ b/recipes/dspark/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.2.2":
+    folder: all

--- a/recipes/dspark/config.yml
+++ b/recipes/dspark/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.7.0":
+    folder: all

--- a/recipes/dspark/config.yml
+++ b/recipes/dspark/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.2.2":
+  "1.6.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe: **dspark/1.7.0**

#### Motivation
Add the latest stable release of [DSPark](https://github.com/CristianMoresi/DSPark), a header-only C++20 framework for real-time and offline audio DSP. This refreshes the existing new-recipe pull request from 1.6.0 to the published 1.7.0 release.

#### Details

- Uses the immutable upstream `v1.7.0` tag and its verified SHA-256.
- Packages the upstream-installed 102 public headers and MIT license only.
- Requires C++20 and produces one header-only package ID.
- Exposes the upstream CMake contract: `find_package(dspark CONFIG REQUIRED)`, `dspark::dspark`, and `#include <DSPark.h>`.
- Keeps upstream tests, conformance checks, and sanitizer verification disabled while packaging.
- Uses Conan `CMakeDeps` for consumer integration.

Local validation used Conan 2.31.2 with GCC 13 and Clang 18 in Debug and Release. All four C++20 configurations built and ran the test package successfully; C++17 was rejected with the expected minimum-standard diagnostic. A separate consumer project also configured, built, and ran successfully, and the final payload was audited as exactly 102 headers plus `LICENSE`.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] This is a new recipe, not a bug fix
- [x] Tested locally with a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
