### PR TITLE
remove xss/xscrnsaver

### DIFF
--- a/recipes/xorg/all/conanfile.py
+++ b/recipes/xorg/all/conanfile.py
@@ -29,7 +29,7 @@ class XorgConan(ConanFile):
         apt.install(["libx11-dev", "libx11-xcb-dev", "libfontenc-dev", "libice-dev", "libsm-dev", "libxau-dev", "libxaw7-dev",
                      "libxcomposite-dev", "libxcursor-dev", "libxdamage-dev", "libxdmcp-dev", "libxext-dev", "libxfixes-dev",
                      "libxi-dev", "libxinerama-dev", "libxkbfile-dev", "libxmu-dev", "libxmuu-dev",
-                     "libxpm-dev", "libxrandr-dev", "libxrender-dev", "libxres-dev", "libxss-dev", "libxt-dev", "libxtst-dev",
+                     "libxpm-dev", "libxrandr-dev", "libxrender-dev", "libxres-dev", "libxt-dev", "libxtst-dev",
                      "libxv-dev", "libxxf86vm-dev", "libxcb-glx0-dev", "libxcb-render0-dev",
                      "libxcb-render-util0-dev", "libxcb-xkb-dev", "libxcb-icccm4-dev", "libxcb-image0-dev",
                      "libxcb-keysyms1-dev", "libxcb-randr0-dev", "libxcb-shape0-dev", "libxcb-sync-dev", "libxcb-xfixes0-dev",
@@ -42,7 +42,7 @@ class XorgConan(ConanFile):
         yum = package_manager.Yum(self)
         yum.install(["libxcb-devel", "libfontenc-devel", "libXaw-devel", "libXcomposite-devel",
                            "libXcursor-devel", "libXdmcp-devel", "libXtst-devel", "libXinerama-devel",
-                           "libxkbfile-devel", "libXrandr-devel", "libXres-devel", "libXScrnSaver-devel",
+                           "libxkbfile-devel", "libXrandr-devel", "libXres-devel",
                            "xcb-util-wm-devel", "xcb-util-image-devel", "xcb-util-keysyms-devel",
                            "xcb-util-renderutil-devel", "libXdamage-devel", "libXxf86vm-devel", "libXv-devel",
                            "xcb-util-devel", "libuuid-devel", "xcb-util-cursor-devel"], update=True, check=True)
@@ -50,7 +50,7 @@ class XorgConan(ConanFile):
         dnf = package_manager.Dnf(self)
         dnf.install(["libxcb-devel", "libfontenc-devel", "libXaw-devel", "libXcomposite-devel",
                            "libXcursor-devel", "libXdmcp-devel", "libXtst-devel", "libXinerama-devel",
-                           "libxkbfile-devel", "libXrandr-devel", "libXres-devel", "libXScrnSaver-devel",
+                           "libxkbfile-devel", "libXrandr-devel", "libXres-devel",
                            "xcb-util-wm-devel", "xcb-util-image-devel", "xcb-util-keysyms-devel",
                            "xcb-util-renderutil-devel", "libXdamage-devel", "libXxf86vm-devel", "libXv-devel",
                            "xcb-util-devel", "libuuid-devel", "xcb-util-cursor-devel"], update=True, check=True)
@@ -58,7 +58,7 @@ class XorgConan(ConanFile):
         zypper = package_manager.Zypper(self)
         zypper.install(["libxcb-devel", "libfontenc-devel", "libXaw-devel", "libXcomposite-devel",
                               "libXcursor-devel", "libXdmcp-devel", "libXtst-devel", "libXinerama-devel",
-                              "libxkbfile-devel", "libXrandr-devel", "libXres-devel", "libXss-devel",
+                              "libxkbfile-devel", "libXrandr-devel", "libXres-devel",
                               "xcb-util-wm-devel", "xcb-util-image-devel", "xcb-util-keysyms-devel",
                               "xcb-util-renderutil-devel", "libXdamage-devel", "libXxf86vm-devel", "libXv-devel",
                               "xcb-util-devel", "libuuid-devel", "xcb-util-cursor-devel"], update=True, check=True)
@@ -66,12 +66,12 @@ class XorgConan(ConanFile):
         pacman = package_manager.PacMan(self)
         pacman.install(["libxcb", "libfontenc", "libice", "libsm", "libxaw", "libxcomposite", "libxcursor",
                               "libxdamage", "libxdmcp", "libxtst", "libxinerama", "libxkbfile", "libxrandr", "libxres",
-                              "libxss", "xcb-util-wm", "xcb-util-image", "xcb-util-keysyms", "xcb-util-renderutil",
+                              "xcb-util-wm", "xcb-util-image", "xcb-util-keysyms", "xcb-util-renderutil",
                               "libxxf86vm", "libxv", "xcb-util", "util-linux-libs", "xcb-util-cursor"], update=True, check=True)
 
         package_manager.Pkg(self).install(["libX11", "libfontenc", "libice", "libsm", "libxaw", "libxcomposite", "libxcursor",
                            "libxdamage", "libxdmcp", "libxtst", "libxinerama", "libxkbfile", "libxrandr", "libxres",
-                           "libXScrnSaver", "xcb-util-wm", "xcb-util-image", "xcb-util-keysyms", "xcb-util-renderutil",
+                           "xcb-util-wm", "xcb-util-image", "xcb-util-keysyms", "xcb-util-renderutil",
                            "libxxf86vm", "libxv", "xkeyboard-config", "xcb-util", "xcb-util-cursor"], update=True, check=True)
 
         if Version(conan_version) >= "2.0.10":
@@ -79,7 +79,7 @@ class XorgConan(ConanFile):
             alpine.install(["libx11-dev", "	libxcb-dev", "libfontenc-dev", "libice-dev", "libsm-dev", "	libxau-dev", "libxaw-dev",
                             "libxcomposite-dev", "libxcursor-dev", "libxdamage-dev", "libxdmcp-dev", "	libxext-dev", "libxfixes-dev", "libxi-dev",
                             "libxinerama-dev", "libxkbfile-dev", "	libxmu-dev", "libxpm-dev", "libxrandr-dev", "libxrender-dev", "libxres-dev",
-                            "libxscrnsaver-dev", "libxt-dev", "libxtst-dev", "libxv-dev", "libxxf86vm-dev",
+                            "libxt-dev", "libxtst-dev", "libxv-dev", "libxxf86vm-dev",
                             "xcb-util-wm-dev", "xcb-util-image-dev", "xcb-util-keysyms-dev", "xcb-util-renderutil-dev",
                             "libxinerama-dev", "libxcb-dev", "xcb-util-dev", "xcb-util-cursor-dev"], update=True, check=True)
 
@@ -92,7 +92,7 @@ class XorgConan(ConanFile):
         for name in ["x11", "x11-xcb", "fontenc", "ice", "sm", "xau", "xaw7",
                      "xcomposite", "xcursor", "xdamage", "xdmcp", "xext", "xfixes", "xi",
                      "xinerama", "xkbfile", "xmu", "xmuu", "xpm", "xrandr", "xrender", "xres",
-                     "xscrnsaver", "xt", "xtst", "xv", "xxf86vm",
+                     "xt", "xtst", "xv", "xxf86vm",
                      "xcb-xkb", "xcb-icccm", "xcb-image", "xcb-keysyms", "xcb-randr", "xcb-render",
                      "xcb-renderutil", "xcb-shape", "xcb-shm", "xcb-sync", "xcb-xfixes",
                      "xcb-xinerama", "xcb", "xcb-atom", "xcb-aux", "xcb-event", "xcb-util",


### PR DESCRIPTION
### Summary
Changes to recipe:  **xorg/***
Remove xss/XScrnSaver, as it is removed from RedHat derivates
cf https://github.com/IsmaelMartinez/teams-for-linux/issues/1785#issuecomment-3180569696 and https://www.redhat.com/en/blog/rhel-10-plans-wayland-and-xorg-server

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

#### Details
current failure on centos stream10:

`conan create CCI/recipes/xorg/all --version system -c tools.system.package_manager:mode=install`
```
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=14
os=Linux


======== Exporting recipe to the cache ========
xorg/system: Exporting package recipe: /__w/system-packages-checks/system-packages-checks/CCI/recipes/xorg/all/conanfile.py
xorg/system: Copied 1 '.py' file: conanfile.py
xorg/system: Exported to cache folder: /github/home/.conan2/p/xorg11f999fd97c5f/e
xorg/system: Exported: xorg/system#98f82cb669e4ebc6b4d9d8a4f3f1faf4 (2026-06-11 17:13:37 UTC)

======== Input profiles ========
Profile host:
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=14
os=Linux
[options]
gtk/system:version=3
[conf]
tools.system.package_manager:mode=install

Profile build:
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=14
os=Linux


======== Computing dependency graph ========
Graph root
    cli
Requirements
    xorg/system#98f82cb669e4ebc6b4d9d8a4f3f1faf4 - Cache

======== Computing necessary packages ========
xorg/system: Forced build from source
Requirements
    xorg/system#98f82cb669e4ebc6b4d9d8a4f3f1faf4:da39a3ee5e6b4b0d3255bfef95601890afd80709 - Build
xorg/system: RUN: dnf check-update -y
Last metadata expiration check: 0:00:37 ago on Thu Jun 11 17:13:00 2026.

xorg/system: RUN: dnf install -y libxcb-devel libfontenc-devel libXaw-devel libXcomposite-devel libXcursor-devel libXdmcp-devel libXtst-devel libXinerama-devel libxkbfile-devel libXrandr-devel libXres-devel libXScrnSaver-devel xcb-util-wm-devel xcb-util-image-devel xcb-util-keysyms-devel xcb-util-renderutil-devel libXdamage-devel libXxf86vm-devel libXv-devel xcb-util-devel libuuid-devel xcb-util-cursor-devel
Last metadata expiration check: 0:00:37 ago on Thu Jun 11 17:13:00 2026.
No match for argument: libXScrnSaver-devel
Error: Unable to find a match: libXScrnSaver-devel

ERROR: xorg/system: Error in system_requirements() method, line 51
	dnf.install(["libxcb-devel", "libfontenc-devel", "libXaw-devel", "libXcomposite-devel",
	ConanException: Command 'dnf install -y libxcb-devel libfontenc-devel libXaw-devel libXcomposite-devel libXcursor-devel libXdmcp-devel libXtst-devel libXinerama-devel libxkbfile-devel libXrandr-devel libXres-devel libXScrnSaver-devel xcb-util-wm-devel xcb-util-image-devel xcb-util-keysyms-devel xcb-util-renderutil-devel libXdamage-devel libXxf86vm-devel libXv-devel xcb-util-devel libuuid-devel xcb-util-cursor-devel' failed with exit code 1
Error: Process completed with exit code 1.
```
https://github.com/bincrafters/system-packages-checks/actions/runs/27363895683/job/80858635100


After a quick investigation, _potential_ consumers of this lib are:
- SDL as an optional dependency https://github.com/search?q=repo%3Alibsdl-org%2FSDL%20SDL_X11_XSCRNSAVER&type=code
- tk as an optional dependency https://github.com/search?q=repo%3Atcltk%2Ftk+enable_xss&type=code

confirmed by https://github.com/search?q=repo%3Aconan-io%2Fconan-center-index+xscrnsaver&type=code

Some distros still provide an xss package, while no other package uses it:
- almalinux 9 https://almalinux.pkgs.org/9/almalinux-appstream-x86_64/libXScrnSaver-devel-1.2.3-10.el9.i686.rpm.html
- centos 9 stream https://centos.pkgs.org/9-stream/centos-appstream-aarch64/libXScrnSaver-devel-1.2.3-10.el9.aarch64.rpm.html

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
