### PR TITLE
ccalg: add recipe v0.1.0

### DIFF
--- a/recipes/ccalg/all/conandata.yml
+++ b/recipes/ccalg/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.1.0":
+    url: "https://github.com/CandyMi/ccalg/archive/refs/tags/v0.1.0.tar.gz"
+    sha256: "49412bcd295631f6798bd1e0e84e6b25fdb0cb023cf7536aeba9629d32eeaf71"

--- a/recipes/ccalg/all/conanfile.py
+++ b/recipes/ccalg/all/conanfile.py
@@ -1,0 +1,52 @@
+from conan import ConanFile
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+import os
+
+required_conan_version = ">=2.0"
+
+
+class CcalgConan(ConanFile):
+    name = "ccalg"
+    license = "BSD-3-Clause"
+    author = "CandyMi"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://ccalg.dev"
+    description = (
+        "A header-only library for high-performance data structures in C/C++. "
+        "Provides intrusive red-black tree (ccmap), hashmap (cchashmap), "
+        "doubly/singly linked lists (cclist/cclink), d-ary heap (ccheap), "
+        "dynamic array (ccvector), sorted-array map (ccflatmap), "
+        "treap with order statistics (cctreap), and UTF-8 codec (ccunicode). "
+        "Compatible with C89/C99/C++/MSVC. Zero internal node allocation."
+    )
+    topics = ("data-structures", "header-only", "intrusive", "c", "c-plus-plus")
+    package_type = "header-library"
+    no_copy_source = True
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version],
+            strip_root=True)
+
+    def package(self):
+        copy(self, "include/*.h", src=self.source_folder,
+            dst=os.path.join(self.package_folder, "include"),
+            keep_path=False)
+        copy(self, "LICENSE", src=self.source_folder,
+            dst=os.path.join(self.package_folder, "licenses"))
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+
+        # Users include as <ccmap.h> or <ccalg/ccmap.h>
+        self.cpp_info.includedirs = ["include"]
+
+        self.cpp_info.set_property("cmake_file_name", "ccalg")
+        self.cpp_info.set_property("cmake_target_name", "ccalg::ccalg")

--- a/recipes/ccalg/all/test_package/CMakeLists.txt
+++ b/recipes/ccalg/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(PackageTest C)
+
+find_package(ccalg REQUIRED)
+
+add_executable(test_package test_package.c)
+target_link_libraries(test_package PRIVATE ccalg::ccalg)

--- a/recipes/ccalg/all/test_package/conanfile.py
+++ b/recipes/ccalg/all/test_package/conanfile.py
@@ -1,0 +1,19 @@
+from conan import ConanFile
+
+
+class CcalgTestConan(ConanFile):
+    settings = ["os", "arch", "compiler", "build_type"]
+    generators = ["CMakeDeps", "CMakeToolchain"]
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        from conan.tools.cmake import CMake
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        # header-only — compilation is sufficient to verify headers are accessible
+        pass

--- a/recipes/ccalg/all/test_package/test_package.c
+++ b/recipes/ccalg/all/test_package/test_package.c
@@ -1,0 +1,21 @@
+#include <stdio.h>
+#include "ccmap.h"
+#include "cclist.h"
+#include "ccheap.h"
+#include "ccvector.h"
+
+int main(void) {
+    ccmap_t     m;
+    cclist_t    l;
+    ccheap_t    h;
+    ccvector_t  v;
+
+    /* Verify headers are accessible and basic init compiles */
+    ccmap_init(&m, NULL);
+    cclist_init(&l);
+    (void)heap_init(&h, NULL);
+    (void)ccvector_init(&v);
+
+    printf("ccalg headers OK\n");
+    return 0;
+}

--- a/recipes/ccalg/config.yml
+++ b/recipes/ccalg/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.1.0":
+    folder: all


### PR DESCRIPTION
 # ccalg — header-only C/C++ high-performance data-structure

 A new recipe for [ccalg](https://ccalg.dev), a header-only high-performance data-structure
 library for C/C++. Intrusive red-black tree, hashmap, treap, doubly/singly linked lists,
 d-ary heap, dynamic array, sorted-array map, and UTF-8 codec.

 ## Package details

 | Field | Value |
 |-------|-------|
 | Name | `ccalg` |
 | Version | `0.1.0` |
 | License | BSD-3-Clause |
 | Homepage | https://ccalg.dev |
 | Repository | https://github.com/candymi/ccalg |
 | Package type | header-library |
 | Downloads | 0 (new recipe) |

 ## Recipe features

 - **Header-only**: `package_type = "header-library"`, no binary variants
 - **Minimal test_package**: verifies ccmap, cclist, ccheap, ccvector headers compile
 - **No patches**: sources match upstream tag `v0.1.0`

 ## Checklist

 - [x] Recipe follows [folder structure](https://github.com/conan-io/conan-center-index/blob/master/docs/adding_packages/folders_and_files.md)
 - [x] SHA256 verified against GitHub release tarball
 - [x] Tested locally with `conan create . -tf ""`
 - [x] License matches upstream (BSD-3-Clause)
