### PR TITLE
libexif: publish version 0.6.26

### DIFF
--- a/recipes/libexif/all/conandata.yml
+++ b/recipes/libexif/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.6.26":
+    url: "https://github.com/libexif/libexif/releases/download/v0.6.26/libexif-0.6.26.tar.bz2"
+    sha256: "0830ed253fceeb60444fb309598bc8a9491d3007dc054aad3a50a347c5597c57"
   "0.6.24":
     url: "https://github.com/libexif/libexif/releases/download/v0.6.24/libexif-0.6.24.tar.bz2"
     sha256: "d47564c433b733d83b6704c70477e0a4067811d184ec565258ac563d8223f6ae"
@@ -6,6 +9,8 @@ sources:
     url: "https://github.com/libexif/libexif/releases/download/v0.6.23/libexif-0.6.23.tar.gz"
     sha256: "9271cf58cb46b00f9e2e9b968c7d81c008a69e5457f7d1a50dbf1786eac61b52"
 patches:
+  "0.6.26":
+    - patch_file: patches/replace_ssize_t_windows_0.6.26.patch
   "0.6.24":
     - patch_file: patches/replace_ssize_t_windows.patch
   "0.6.23":

--- a/recipes/libexif/all/patches/replace_ssize_t_windows_0.6.26.patch
+++ b/recipes/libexif/all/patches/replace_ssize_t_windows_0.6.26.patch
@@ -1,0 +1,15 @@
+diff --git a/libexif/exif-loader.c b/libexif/exif-loader.c
+--- a/libexif/exif-loader.c
++++ b/libexif/exif-loader.c
+@@ -31,6 +31,11 @@
+ #include <string.h>
+ #include <stdio.h>
+ 
++#if defined _MSC_VER
++#include <BaseTsd.h>
++typedef SSIZE_T ssize_t;
++#endif
++
+ #undef JPEG_MARKER_DCT
+ #define JPEG_MARKER_DCT  0xc0
+ #undef JPEG_MARKER_DHT

--- a/recipes/libexif/config.yml
+++ b/recipes/libexif/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.6.26":
+    folder: all
   "0.6.24":
     folder: all
   "0.6.23":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libexif/0.6.26**

#### Motivation
To fix #29852 and fix security vulnerabilities:
   - https://github.com/advisories/GHSA-p6wp-hhx9-7jj5: An unsigned integer underflow in Fuji and Olympus makernote handling
   - https://github.com/advisories/GHSA-j9xr-5c85-xjhm: An unsigned integer overflow on 32bit systems in Nikon makernote handling
   - https://github.com/advisories/GHSA-pq8m-942f-68cv: A buffer overwrite via integer underflow in makernote handling

#### Details
https://github.com/libexif/libexif/releases/tag/v0.6.26
https://github.com/libexif/libexif/releases/tag/v0.6.25


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
