### PR TITLE
abseil: Added version 20260526.0 to config.yml

### DIFF
--- a/recipes/abseil/all/conandata.yml
+++ b/recipes/abseil/all/conandata.yml
@@ -33,6 +33,8 @@ sources:
     url: "https://github.com/abseil/abseil-cpp/archive/20230125.3.tar.gz"
     sha256: "5366D7E7FA7BA0D915014D387B66D0D002C03236448E1BA9EF98122C13B35C36"
 patches:
+  "20260526.0":
+    - patch_file: "patches/20260526.0-fix-strings-self-reference.patch"
   "20260107.1":
     - patch_file: "patches/20260107.1-0001-fix-heterogeneous_lookup-flag.patch"
   "20240722.1":

--- a/recipes/abseil/all/conandata.yml
+++ b/recipes/abseil/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "20260526.0":
+    url: "https://github.com/abseil/abseil-cpp/archive/20260526.0.tar.gz"
+    sha256: "6e1aee535473414164bf83e4ebc40240dec71a4701f8a642d906e95bea1aea0c"
   "20260107.1":
     url: "https://github.com/abseil/abseil-cpp/archive/20260107.1.tar.gz"
     sha256: "4314e2a7cbac89cac25a2f2322870f343d81579756ceff7f431803c2c9090195"

--- a/recipes/abseil/all/conanfile.py
+++ b/recipes/abseil/all/conanfile.py
@@ -124,9 +124,7 @@ class AbseilConan(ConanFile):
                         values_list = target_property[1].replace('"', "").split(";")
                         for dependency in values_list:
                             if dependency.startswith("absl::"): # abseil targets
-                                dep_name = dependency.replace("absl::", "absl_")
-                                if dep_name != potential_lib_name:
-                                    components[potential_lib_name].setdefault("requires", []).append(dep_name)
+                                components[potential_lib_name].setdefault("requires", []).append(dependency.replace("absl::", "absl_"))
                             else: # system libs or frameworks
                                 if self.settings.os in ["Linux", "FreeBSD"]:
                                     if dependency == "Threads::Threads":

--- a/recipes/abseil/all/conanfile.py
+++ b/recipes/abseil/all/conanfile.py
@@ -124,7 +124,9 @@ class AbseilConan(ConanFile):
                         values_list = target_property[1].replace('"', "").split(";")
                         for dependency in values_list:
                             if dependency.startswith("absl::"): # abseil targets
-                                components[potential_lib_name].setdefault("requires", []).append(dependency.replace("absl::", "absl_"))
+                                dep_name = dependency.replace("absl::", "absl_")
+                                if dep_name != potential_lib_name:
+                                    components[potential_lib_name].setdefault("requires", []).append(dep_name)
                             else: # system libs or frameworks
                                 if self.settings.os in ["Linux", "FreeBSD"]:
                                     if dependency == "Threads::Threads":

--- a/recipes/abseil/all/patches/20260526.0-fix-strings-self-reference.patch
+++ b/recipes/abseil/all/patches/20260526.0-fix-strings-self-reference.patch
@@ -1,0 +1,28 @@
+Backport https://github.com/abseil/abseil-cpp/commit/d21659a5affab9def3333ae70c1123c3fe1a9873
+
+From d21659a5affab9def3333ae70c1123c3fe1a9873 Mon Sep 17 00:00:00 2001
+From: Derek Mauro
+Date: Wed, 1 Jul 2026 09:20:33 -0700
+Subject: [PATCH] Fix CMake target absl_strings so that it does not link to
+ itself
+
+Fixes #2091
+
+PiperOrigin-RevId: 941136680
+Change-Id: I7705296238d73d4d1619d27533cc5147fbad6d2c
+---
+ absl/strings/CMakeLists.txt | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/absl/strings/CMakeLists.txt b/absl/strings/CMakeLists.txt
+index b6f2aa715b1..964094f8a05 100644
+--- a/absl/strings/CMakeLists.txt
++++ b/absl/strings/CMakeLists.txt
+@@ -88,7 +88,6 @@ absl_cc_library(
+     absl::nullability
+     absl::raw_logging_internal
+     absl::source_location
+-    absl::strings
+     absl::throw_delegate
+     absl::type_traits
+   PUBLIC

--- a/recipes/abseil/config.yml
+++ b/recipes/abseil/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "20260526.0":
+    folder: all
   "20260107.1":
     folder: all
   "20250814.2":


### PR DESCRIPTION
### Summary
Changes to recipe:  **abseil/20260526.0**

#### Motivation
Add the new Abseil release `20260526.0` to the index (tag: `https://github.com/abseil/abseil-cpp/releases/tag/20260526.0`).

#### Details
* **Add new version**: Added version `20260526.0` to [config.yml](file:///home/dingle/code/github.com/conan-io/conan-center-index/recipes/abseil/config.yml) and [conandata.yml](file:///home/dingle/code/github.com/conan-io/conan-center-index/recipes/abseil/all/conandata.yml).
* **Fix dependency loop in `package_info()`**: In version `20260526.0`, the generated `abslTargets.cmake` includes self-references in its `INTERFACE_LINK_LIBRARIES` (specifically `absl::strings` links to `absl::strings`), which causes Conan to fail with a dependency loop error. Modified the target parser in conanfile to filter out self-dependencies (`if dep_name != potential_lib_name:`). https://github.com/abseil/abseil-cpp/commit/81f4d83f3813e69c607ed82e9c7ccc651ddefa60 
* **Local test**: Successfully ran `conan create` to build and verify the package locally with all configurations passing.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
