### PR TITLE
[wiringpi] Fix ppoll usage with GCC-14

### DIFF
--- a/recipes/wiringpi/all/CMakeLists.txt
+++ b/recipes/wiringpi/all/CMakeLists.txt
@@ -14,6 +14,7 @@ list(FILTER SRC_FILES EXCLUDE REGEX "WiringpiV1.c")
 
 add_library(${PROJECT_NAME} ${SRC_FILES})
 target_include_directories(${PROJECT_NAME} PUBLIC ${WIRINGPI_SRC_DIR}/wiringPi)
+target_compile_definitions(${PROJECT_NAME} PRIVATE _GNU_SOURCE)
 
 if(WIRINGPI_WITH_DEV_LIB)
     file(GLOB SRC_FILES ${WIRINGPI_SRC_DIR}/devLib/*.c)


### PR DESCRIPTION
### Summary
Changes to recipe:  **wiringpi/3.18**

#### Motivation

The original PR #30288 misses the CLA, even after pinging its author. Two weeks have passed since we asked, so this PR should replace that one to fix WiringPi

close #30288

#### Details

As this recipe only works with Linux (we have a check in `validate()`), adding `_GNU_SOURCE` without guards in `CMakeLists.txt` is not a problem.

This patch was previously validated, including the reported but: https://github.com/conan-io/conan-center-index/pull/30288#issuecomment-4593271406


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
