### PR TITLE
sqlite3: publish version 3.53.2

### DIFF
--- a/recipes/sqlite3/all/conandata.yml
+++ b/recipes/sqlite3/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "3.53.1":
-    url: "https://sqlite.org/2026/sqlite-amalgamation-3530100.zip"
-    sha256: "36ad6e7f38540a3b21a2ac36340833f0a9e426bc1c752751c3ba669466827eae"
+  "3.53.2":
+    url: "https://sqlite.org/2026/sqlite-amalgamation-3530200.zip"
+    sha256: "8a310d0a16c7a90cacd4c884e70faa51c902afed2a89f63aaa0126ab83558a32"
   "3.51.3":
     url: "https://sqlite.org/2026/sqlite-amalgamation-3510300.zip"
     sha256: "acb1e6f5d832484bf6d32b681e858c38add8b2acdfd42ac5df24b8afb46552b4"

--- a/recipes/sqlite3/config.yml
+++ b/recipes/sqlite3/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "3.53.1":
+  "3.53.2":
     folder: all
   "3.51.3":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **sqlite3/3.53.2**
Closes #30402 30402

#### Motivation
A high severity vulnerability has been published which affects version 3.53.1 (latest available on conan-center):

* https://www.cve.org/CVERecord?id=CVE-2026-11824

#### Details
Updated `conandata.yml` and `config.yml` with the new version. Replaced 3.53.1 with 3.53.2.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
