### PR TITLE
Catch2: Allow enabling threadsafe test assertions

### DIFF
--- a/recipes/catch2/3.x.x/conandata.yml
+++ b/recipes/catch2/3.x.x/conandata.yml
@@ -1,7 +1,4 @@
 sources:
-  "3.15.0":
-    url: "https://github.com/catchorg/Catch2/archive/refs/tags/v3.15.0.tar.gz"
-    sha256: "9650c55e497759cc39b977e45524bc8acb15256061c112080916ab6cb0b1ea66"
-  "3.14.0":
-    url: "https://github.com/catchorg/Catch2/archive/refs/tags/v3.14.0.tar.gz"
-    sha256: "ba2a939efead3c833c499cf487e185762f419a71d30158cd1b43c6079c586490"
+  "3.15.1":
+    url: "https://github.com/catchorg/Catch2/archive/refs/tags/v3.15.1.tar.gz"
+    sha256: "be23a52b85cf04cd9587612147a10b023d59ed9757fa1843cc99e615d6c0893c"

--- a/recipes/catch2/3.x.x/conanfile.py
+++ b/recipes/catch2/3.x.x/conanfile.py
@@ -26,6 +26,7 @@ class Catch2Conan(ConanFile):
         "default_reporter": [None, "ANY"],
         "console_width": [None, "ANY"],
         "no_posix_signals": [True, False],
+        "thread_safe_assertions": [True, False],
     }
     default_options = {
         "shared": False,
@@ -34,6 +35,7 @@ class Catch2Conan(ConanFile):
         "default_reporter": None,
         "console_width": "80",
         "no_posix_signals": False,
+        "thread_safe_assertions": False,
     }
     # disallow cppstd compatibility, as it affects the ABI in this library
     # see https://github.com/conan-io/conan-center-index/issues/19008
@@ -88,6 +90,7 @@ class Catch2Conan(ConanFile):
         if self.options.default_reporter:
             tc.variables["CATCH_CONFIG_DEFAULT_REPORTER"] = self._default_reporter_str
         tc.variables["CATCH_CONFIG_NO_POSIX_SIGNALS"] = self.options.no_posix_signals
+        tc.variables["CATCH_CONFIG_THREAD_SAFE_ASSERTIONS"] = self.options.thread_safe_assertions
         tc.generate()
 
     def build(self):

--- a/recipes/catch2/config.yml
+++ b/recipes/catch2/config.yml
@@ -1,7 +1,5 @@
 versions:
-  "3.15.0":
-    folder: 3.x.x
-  "3.14.0":
+  "3.15.1":
     folder: 3.x.x
   "2.13.10":
     folder: 2.x.x


### PR DESCRIPTION
### Summary
Changes to recipe:  **catch2/3.12.0+**

#### Motivation

Catch2 [3.9](https://github.com/catchorg/Catch2/releases/tag/v3.9.0) brings _experimental_ support for optional threadsafe test assertions. In [3.12](https://github.com/catchorg/Catch2/releases/tag/v3.12.0) the experimental support became fully supported. The new `-o thread_safe_assertions` option exposes this feature in the recipe.

The default is "no thread safety" mirroring Catch2's default for optimal performance.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
