### PR TITLE
glm: add version 1.0.3

### DIFF
--- a/recipes/glm/all/conandata.yml
+++ b/recipes/glm/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.3":
+    url: "https://github.com/g-truc/glm/releases/download/1.0.3/glm-1.0.3.zip"
+    sha256: "1c0a0fced9b0d87c7b7bc94e40be490cff6d4c83c25db8488d8f33754e7fdeb2"
   "1.0.1":
     url: "https://github.com/g-truc/glm/releases/download/1.0.1/glm-1.0.1-light.zip"
     sha256: "9A995DE4DA09723BD33EF194E6B79818950E5A8F2E154792F02E4615277CFB8D"

--- a/recipes/glm/all/conandata.yml
+++ b/recipes/glm/all/conandata.yml
@@ -5,6 +5,3 @@ sources:
   "1.0.1":
     url: "https://github.com/g-truc/glm/releases/download/1.0.1/glm-1.0.1-light.zip"
     sha256: "9A995DE4DA09723BD33EF194E6B79818950E5A8F2E154792F02E4615277CFB8D"
-  "0.9.9.8":
-    url: "https://github.com/g-truc/glm/releases/download/0.9.9.8/glm-0.9.9.8.zip"
-    sha256: "37e2a3d62ea3322e43593c34bae29f57e3e251ea89f4067506c94043769ade4c"

--- a/recipes/glm/all/conanfile.py
+++ b/recipes/glm/all/conanfile.py
@@ -25,16 +25,16 @@ class GlmConan(ConanFile):
         self.info.clear()
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version], strip_root=self.version < Version("1.0.0"))
+        get(self, **self.conan_data["sources"][self.version], strip_root=Version(self.version) != "1.0.1")
 
     def build(self):
         pass
 
     def package(self):
-        if self.version < Version("1.0.0"):
-            copy(self, "copying.txt", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
-        else:
+        if Version(self.version) == "1.0.1":
             copy(self, "copying.txt", src=os.path.join(self.source_folder, "glm"), dst=os.path.join(self.package_folder, "licenses"))
+        else:
+            copy(self, "copying.txt", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
         for headers in ("*.hpp", "*.inl", "*.h", "*.cppm"):
             copy(self, headers, src=os.path.join(self.source_folder, "glm"),
                                 dst=os.path.join(self.package_folder, "include", "glm"))

--- a/recipes/glm/all/conanfile.py
+++ b/recipes/glm/all/conanfile.py
@@ -41,6 +41,7 @@ class GlmConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "glm")
-        self.cpp_info.set_property("cmake_target_name", "glm::glm")
+        self.cpp_info.set_property("cmake_target_name", "glm::glm-header-only")
+        self.cpp_info.set_property("cmake_target_aliases", ["glm::glm"])
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []

--- a/recipes/glm/config.yml
+++ b/recipes/glm/config.yml
@@ -3,5 +3,3 @@ versions:
     folder: all
   "1.0.1":
     folder: all
-  "0.9.9.8":
-    folder: all

--- a/recipes/glm/config.yml
+++ b/recipes/glm/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.0.3":
+    folder: all
   "1.0.1":
     folder: all
   "0.9.9.8":


### PR DESCRIPTION
### Summary
Changes to recipe:  **glm/1.0.3**

#### Motivation
Add the latest version of OpenGL Mathematics (GLM), version 1.0.3, which includes reflection matrix calculations, quaternion rotation fixes, and other compatibility updates.

#### Details
* Added version `1.0.3` to [config.yml](file:///home/dingle/code/github.com/conan-io/conan-center-index/recipes/glm/config.yml) and [conandata.yml](file:///home/dingle/code/github.com/conan-io/conan-center-index/recipes/glm/all/conandata.yml).
* Updated [conanfile.py](file:///home/dingle/code/github.com/conan-io/conan-center-index/recipes/glm/all/conanfile.py) to differentiate the packaging logic based on the version:
  - Version `1.0.1` uses a special `glm-1.0.1-light.zip` layout containing headers directly under the root folder `glm/` (`strip_root=False`, and license in `glm/copying.txt`).
  - Other versions (including `0.9.9.8` and `1.0.3`) use standard release zip layout containing the full repository structure (`strip_root=True`, and license in the root directory).
* Tested locally on Linux with GCC 15 and Conan 2.29.0 for versions `1.0.3`, `1.0.1`, and `0.9.9.8`.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
