### PR TITLE
wuffs: add new package wuffs v0.3.4

### DIFF
--- a/recipes/wuffs/all/conandata.yml
+++ b/recipes/wuffs/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.3.4":
+    url: "https://github.com/google/wuffs/archive/refs/tags/v0.3.4.tar.gz"
+    sha256: "fec09526c9d86acb55cfc4742d8c0d298af16de8978ced336ea2071ee2ca6e18"

--- a/recipes/wuffs/all/conandata.yml
+++ b/recipes/wuffs/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "0.3.4":
-    url: "https://github.com/google/wuffs/archive/refs/tags/v0.3.4.tar.gz"
-    sha256: "fec09526c9d86acb55cfc4742d8c0d298af16de8978ced336ea2071ee2ca6e18"
+    url: "https://github.com/google/wuffs-mirror-release-c/archive/refs/tags/v0.3.4.tar.gz"
+    sha256: "d1c1e269ddbcef7c0452f8b9f645a4cb78b149f4bc679552d43b50fc41b549c3"

--- a/recipes/wuffs/all/conandata.yml
+++ b/recipes/wuffs/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.3.5":
+    url: "https://github.com/google/wuffs-mirror-release-c/archive/refs/tags/v0.3.5.tar.gz"
+    sha256: "BBF18C23F17F335DED7274E9FCFCF9B625226F1E6B3B2943992CF63033BBCDA4"
   "0.3.4":
     url: "https://github.com/google/wuffs-mirror-release-c/archive/refs/tags/v0.3.4.tar.gz"
     sha256: "d1c1e269ddbcef7c0452f8b9f645a4cb78b149f4bc679552d43b50fc41b549c3"

--- a/recipes/wuffs/all/conanfile.py
+++ b/recipes/wuffs/all/conanfile.py
@@ -1,0 +1,48 @@
+from conan import ConanFile
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+import os
+
+required_conan_version = ">=1.50.0"
+
+
+class WuffsConan(ConanFile):
+    name = "wuffs"
+    description = "Wrangling Untrusted File Formats Safely (Wuffs) is a memory-safe library for parsing/decoding/encoding images, audio, video, fonts and compressed archives."
+    license = "Apache-2.0 OR MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/google/wuffs"
+    topics = ("wuffs", "image", "parser", "decoder", "header-only")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        copy(
+            self,
+            "wuffs-*.c",
+            src=os.path.join(self.source_folder, "release", "c"),
+            dst=os.path.join(self.package_folder, "include"),
+        )
+        copy(
+            self,
+            "wuffs-*.c",
+            src=os.path.join(self.source_folder, "release", "c"),
+            dst=os.path.join(self.package_folder, "include", "wuffs"),
+        )
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.set_property("cmake_file_name", "wuffs")
+        self.cpp_info.set_property("cmake_target_name", "wuffs::wuffs")
+

--- a/recipes/wuffs/all/conanfile.py
+++ b/recipes/wuffs/all/conanfile.py
@@ -3,7 +3,7 @@ from conan.tools.files import copy, get
 from conan.tools.layout import basic_layout
 import os
 
-required_conan_version = ">=1.50.0"
+required_conan_version = ">=2.0"
 
 
 class WuffsConan(ConanFile):
@@ -43,6 +43,5 @@ class WuffsConan(ConanFile):
     def package_info(self):
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
-        self.cpp_info.set_property("cmake_file_name", "wuffs")
-        self.cpp_info.set_property("cmake_target_name", "wuffs::wuffs")
+
 

--- a/recipes/wuffs/all/test_package/CMakeLists.txt
+++ b/recipes/wuffs/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES C)
+
+find_package(wuffs REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE wuffs::wuffs)

--- a/recipes/wuffs/all/test_package/conanfile.py
+++ b/recipes/wuffs/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/wuffs/all/test_package/test_package.c
+++ b/recipes/wuffs/all/test_package/test_package.c
@@ -1,0 +1,8 @@
+#define WUFFS_IMPLEMENTATION
+#include <wuffs-v0.3.c>
+#include <stdio.h>
+
+int main() {
+    printf("Wuffs version: %s\n", WUFFS_VERSION_STRING);
+    return 0;
+}

--- a/recipes/wuffs/config.yml
+++ b/recipes/wuffs/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.3.4":
+    folder: all

--- a/recipes/wuffs/config.yml
+++ b/recipes/wuffs/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.3.5":
+    folder: all
   "0.3.4":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **wuffs/0.3.4**

#### Motivation
Add the new package [`wuffs` ](https://github.com/google/wuffs) (Wrangling Untrusted File Formats Safely) at version [`0.3.4`](https://github.com/google/wuffs/releases/tag/v0.3.4).

#### Details
- Initial recipe for [`wuffs`](https://github.com/google/wuffs).
- Packaged as a `header-library` since the library compiles/transpiles to a single C source/header file [wuffs-v0.3.c](https://github.com/google/wuffs/blob/main/release/c/wuffs-v0.3.c).
- Copied transpiled C files (`wuffs-*.c`) from the `release/c` folder to both `include` and `include/wuffs` so they can be consumed via `#include <wuffs-v0.3.c>` or `#include <wuffs/wuffs-v0.3.c>` after defining `WUFFS_IMPLEMENTATION`.
- Created a `test_package` verifying correct integration, compilation, and execution.

---

- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
