### PR TITLE
[mimalloc] Revert to use collect_libs again

### DIFF
--- a/recipes/mimalloc/all/conanfile.py
+++ b/recipes/mimalloc/all/conanfile.py
@@ -119,8 +119,6 @@ class MimallocConan(ConanFile):
         tc.variables["MI_WIN_REDIRECT"] = "ON" if self.options.get_safe("win_redirect") else "OFF"
         tc.variables["MI_INSTALL_TOPLEVEL"] = "ON"
         tc.variables["MI_GUARDED"] = self.options.get_safe("guarded", False)
-        # Make sure passing build type when using Visual Studio generator, otherwise it fallback to Release always
-        tc.cache_variables["CMAKE_BUILD_TYPE"] = str(self.settings.build_type)
         tc.generate()
 
         if is_msvc(self):

--- a/recipes/mimalloc/all/conanfile.py
+++ b/recipes/mimalloc/all/conanfile.py
@@ -119,6 +119,8 @@ class MimallocConan(ConanFile):
         tc.variables["MI_WIN_REDIRECT"] = "ON" if self.options.get_safe("win_redirect") else "OFF"
         tc.variables["MI_INSTALL_TOPLEVEL"] = "ON"
         tc.variables["MI_GUARDED"] = self.options.get_safe("guarded", False)
+        # Make sure passing build type when using Visual Studio generator, otherwise it fallback to Release always
+        tc.cache_variables["CMAKE_BUILD_TYPE"] = str(self.settings.build_type)
         tc.generate()
 
         if is_msvc(self):

--- a/recipes/mimalloc/all/conanfile.py
+++ b/recipes/mimalloc/all/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rm, rmdir, replace_in_file
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rm, rmdir, replace_in_file, collect_libs
 from conan.tools.microsoft import is_msvc, is_msvc_static_runtime, VCVars
 from conan.tools.scm import Version
 import os
@@ -179,18 +179,6 @@ class MimallocConan(ConanFile):
             name += "-{}".format(str(self.settings.build_type).lower())
         return name
 
-    @property
-    def _lib_name(self):
-        name = "mimalloc"
-
-        if Version(self.version) == "2.1.2" and self.settings.os == "Windows" and not self.options.shared:
-            name += "-static"
-        if self.options.secure:
-            name += "-secure"
-        if self.settings.build_type not in ("Release", "RelWithDebInfo", "MinSizeRel"):
-            name += "-{}".format(str(self.settings.build_type).lower())
-        return name
-
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "mimalloc")
         self.cpp_info.set_property("cmake_target_name", "mimalloc" if self.options.shared else "mimalloc-static")
@@ -210,7 +198,7 @@ class MimallocConan(ConanFile):
             self.cpp_info.libdirs = []
             self.cpp_info.bindirs = []
         else:
-            self.cpp_info.libs = [self._lib_name]
+            self.cpp_info.libs = collect_libs(self)
 
         if self.settings.os == "Linux":
             self.cpp_info.system_libs.append("pthread")


### PR DESCRIPTION
### Summary
Changes to recipe:  **mimalloc/3.3.2**

#### Motivation

After merging the PR #30340, @RazielXYZ commented about an error involving Debug profile when using the latest recipe revision: https://github.com/conan-io/conan-center-index/pull/30340#issuecomment-4721950819. The following comment comes with a build log confirming the case: https://github.com/conan-io/conan-center-index/pull/30340#issuecomment-4722497922

/cc @AbrilRBS 

#### Details

The CI and some maintainers (including me), use Ninja as default generator on Windows, which passes the build type to CMake configure step. The mimalloc project always expect that build type: https://github.com/microsoft/mimalloc/blob/v3.3.2/CMakeLists.txt#L114, otherwise, it will fallback to Release. As a result, when building using Debug as build type with Ninja, we will not spot that error:

```
RUN: cmake -G "Ninja" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="C:/Users/uilia/.conan2/p/b/mimal7015dd63cdf91/p" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Debug" -DCMAKE_C_COMPILER="cl" -DCMAKE_CXX_COMPILER="cl" "C:/Users/uilia/.conan2/p/b/mimal7015dd63cdf91/b/src" --loglevel=VERBOSE
...
-- Architecture: x64
-- The CXX compiler identification is MSVC 19.44.35207.1
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.44.35207/bin/Hostx64/x64/cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Use the C++ compiler to compile (MI_USE_CXX=ON)
-- Set debug level to internal assertion and invariant checking (CMAKE_BUILD_TYPE=Debug)
-- 
-- Library name     : mimalloc-debug
-- Version          : 3.3.2
-- Build type       : debug
-- C++ Compiler     : C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.44.35207/bin/Hostx64/x64/cl.exe
-- Compiler flags   : /Zc:__cplusplus
```

Full build log: [mimalloc-3.3.2-windows-amd64-msvc194-debug-static-ninja.log](https://github.com/user-attachments/files/29034364/mimalloc-3.3.2-windows-amd64-msvc194-debug-static-ninja.log)

However, when using Visual Studio as generator, the most common case is passing `--config=<build_type>` to the build step, and ignoring it from the configure step, and that's the case when using the CMake Conan generator with Visual Studio CMake generator. The result is the same as reported:

```
mimalloc/3.3.2: Building from source
mimalloc/3.3.2: Package mimalloc/3.3.2:f74f1dc826362285578fa41f21fe6f505c4670ab
mimalloc/3.3.2: settings: os=Windows arch=x86_64 compiler=msvc compiler.cppstd=17 compiler.runtime=dynamic compiler.runtime_type=Debug compiler.version=194 build_type=Debug
...
mimalloc/3.3.2: RUN: cmake -G "Visual Studio 17 2022" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="C:/Users/uilia/.conan2/p/b/mimal2f8d7aa1493cb/p" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" "C:/Users/uilia/.conan2/p/b/mimal2f8d7aa1493cb/b/src" --loglevel=VERBOSE
...
-- No build type selected, default to 'Release'
-- Note: when building with Visual Studio the build type is specified when building.
-- For example: 'cmake --build . --config=Release
...
-- Library name     : mimalloc
-- Version          : 3.3.2
-- Build type       : release
-- C++ Compiler     : C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.36.32532/bin/Hostx64/x64/cl.exe
-- Compiler flags   : /Zc:__cplusplus
-- Compiler defines : MI_WIN_NOREDIRECT=1;MI_CMAKE_BUILD_TYPE=release;MI_BUILD_RELEASE
```

Full build log: [mimalloc-3.3.2-windows-amd64-msvc194-debug-static-vs.log](https://github.com/user-attachments/files/29034424/mimalloc-3.3.2-windows-amd64-msvc194-debug-static-vs.log)

----

~In order to make sure mimalloc will have build type properly configured, this PR passes it always via CMake cache variables, so even when building using Visual Studio, it will be detected with the correct build type:~

<details>
<summary>Details</summary>

```
mimalloc/3.3.2: Package mimalloc/3.3.2:f74f1dc826362285578fa41f21fe6f505c4670ab
mimalloc/3.3.2: settings: os=Windows arch=x86_64 compiler=msvc compiler.cppstd=17 compiler.runtime=dynamic compiler.runtime_type=Debug compiler.version=194 build_type=Debug
...
mimalloc/3.3.2: RUN: cmake -G "Visual Studio 17 2022" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="C:/Users/uilia/.conan2/p/b/mimal91bdd2cb9d26b/p" -DCMAKE_BUILD_TYPE="Debug" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" "C:/Users/uilia/.conan2/p/b/mimal91bdd2cb9d26b/b/src" --loglevel=VERBOSE
...
-- Library name     : mimalloc-debug
-- Version          : 3.3.2
-- Build type       : debug
-- C++ Compiler     : C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.36.32532/bin/Hostx64/x64/cl.exe
-- Compiler flags   : /Zc:__cplusplus
-- Compiler defines : MI_WIN_NOREDIRECT=1;MI_DEBUG=2;MI_CMAKE_BUILD_TYPE=debug
```

</details>

~Full build log: [mimalloc-3.3.2-windows-amd64-msvc194-debug-static-vs-patched.log](https://github.com/user-attachments/files/29034594/mimalloc-3.3.2-windows-amd64-msvc194-debug-static-vs-patched.log)~

~Tested with Ninja as well: [mimalloc-3.3.2-windows-amd64-msvc194-debug-static-ninja-patched.log](https://github.com/user-attachments/files/29034598/mimalloc-3.3.2-windows-amd64-msvc194-debug-static-ninja-patched.log)~

----

**EDIT**: After discussing with team, was decided to revert back to `collect_libs`. Using the build type in an explicit way during the setup should fix the reported case, but it may result in uncovered bugs, because we usually don't do that for Visual Studio. The `collect_libs` was working before, except for a specific case involving `CMakeConfigDeps` (experimental), but should be fixed by Conan 2.30. 

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
