### PR TITLE
ninja: statically link runtime on mingw too

### DIFF
--- a/recipes/ninja/all/conanfile.py
+++ b/recipes/ninja/all/conanfile.py
@@ -33,10 +33,12 @@ class NinjaConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.variables["BUILD_TESTING"] = False
-        if self.settings.os == "Linux" and "libstdc++" in self.settings.compiler.libcxx:
-            # Link C++ library statically on Linux so that it can run on systems
-            # with an older C++ runtime
-            tc.cache_variables["CMAKE_EXE_LINKER_FLAGS"] = "-static-libstdc++ -static-libgcc"
+        if "libstdc++" in self.settings.compiler.libcxx:
+            # Link C++ library statically so that it can run on systems with an older C++ runtime
+            if self.settings.os == "Linux":
+                tc.cache_variables["CMAKE_EXE_LINKER_FLAGS"] = "-static-libstdc++ -static-libgcc"
+            elif self.settings.os == "Windows":
+                tc.cache_variables["CMAKE_EXE_LINKER_FLAGS"] = "-static"
         tc.generate()
 
     def build(self):

--- a/recipes/ninja/all/conanfile.py
+++ b/recipes/ninja/all/conanfile.py
@@ -33,7 +33,7 @@ class NinjaConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.variables["BUILD_TESTING"] = False
-        if "libstdc++" in self.settings.compiler.libcxx:
+        if "libstdc++" in self.settings.compiler.get_safe("libcxx", ""):
             # Link C++ library statically so that it can run on systems with an older C++ runtime
             if self.settings.os == "Linux":
                 tc.cache_variables["CMAKE_EXE_LINKER_FLAGS"] = "-static-libstdc++ -static-libgcc"


### PR DESCRIPTION
### Summary
Changes to recipe:  **ninja/***

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

#### Details

on MinGW, `-static-libstdc++ -static-libgcc` is not enough to run without any runtime lib, because the dependency on winpthreads library remains. `-static` removes also this run time dependency.

Tested locally, run in an evnrionment without MinGW in PATH:
```
>C:\Users\el\.conan2\p\b\ninjab92a4f1d8388d\p\bin\ninja --version
1.13.2
```

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
