### PR TITLE
 onnxruntime: Add ability to compile with tensorrt

### DIFF
--- a/recipes/onnxruntime/all/cmake/onnxruntime_external_deps.cmake
+++ b/recipes/onnxruntime/all/cmake/onnxruntime_external_deps.cmake
@@ -93,6 +93,16 @@ if (onnxruntime_USE_MIMALLOC)
   add_definitions(-DUSE_MIMALLOC)
 endif()
 
+if (onnxruntime_USE_CUDA)
+  find_package(CUDAToolkit REQUIRED)
+
+  if(onnxruntime_CUDNN_HOME)
+    file(TO_CMAKE_PATH ${onnxruntime_CUDNN_HOME} onnxruntime_CUDNN_HOME)
+    set(CUDNN_PATH ${onnxruntime_CUDNN_HOME})
+  endif()
+
+  include(cuDNN)
+endif()
 
 set(onnxruntime_EXTERNAL_LIBRARIES ${onnxruntime_EXTERNAL_LIBRARIES_XNNPACK} ${WIL_TARGET} nlohmann_json::nlohmann_json
                                    onnx onnx_proto ${PROTOBUF_LIB} re2::re2 Boost::mp11 safeint_interface

--- a/recipes/onnxruntime/all/conandata.yml
+++ b/recipes/onnxruntime/all/conandata.yml
@@ -5,3 +5,4 @@ sources:
 patches:
   "1.24.4":
     - patch_file: "patches/fix-cutlass-cuda-provider.patch"
+    - patch_file: "patches/fix-cpuid-info.patch"

--- a/recipes/onnxruntime/all/conanfile.py
+++ b/recipes/onnxruntime/all/conanfile.py
@@ -52,7 +52,7 @@ class OnnxRuntimeConan(ConanFile):
     def requirements(self):
         self.requires("onnx/[>=1.20.1 <1.21]")
         self.requires("abseil/[>=20240116.1 <=20260107.1]")
-        self.requires("protobuf/[>=3.21.12 <7]")
+        self.requires("protobuf/[>=3.21.12 <5]")
         self.requires("date/[>=3.0.1 <3.1]")
         self.requires("re2/[>=20231101]")
         self.requires("flatbuffers/23.5.26")

--- a/recipes/onnxruntime/all/conanfile.py
+++ b/recipes/onnxruntime/all/conanfile.py
@@ -52,7 +52,7 @@ class OnnxRuntimeConan(ConanFile):
     def requirements(self):
         self.requires("onnx/[>=1.20.1 <1.21]")
         self.requires("abseil/[>=20240116.1 <=20260107.1]")
-        self.requires("protobuf/[>=3.21.12 <5]")
+        self.requires("protobuf/[>=3.21.12 <7]")
         self.requires("date/[>=3.0.1 <3.1]")
         self.requires("re2/[>=20231101]")
         self.requires("flatbuffers/23.5.26")

--- a/recipes/onnxruntime/all/patches/fix-cpuid-info.patch
+++ b/recipes/onnxruntime/all/patches/fix-cpuid-info.patch
@@ -1,0 +1,30 @@
+diff --git a/onnxruntime/core/common/cpuid_info.cc b/onnxruntime/core/common/cpuid_info.cc
+index 00711e416e..22d051ab08 100644
+--- a/onnxruntime/core/common/cpuid_info.cc
++++ b/onnxruntime/core/common/cpuid_info.cc
+@@ -213,6 +213,10 @@ void CPUIDInfo::ArmLinuxInit() {
+         continue;
+       }
+       auto coreid = proc->linux_id;
++      if (coreid < 0 || static_cast<size_t>(coreid) >= core_uarchs_.size()) {
++        continue;
++      }
++
+       auto uarch = corep->uarch;
+       core_uarchs_[coreid] = uarch;
+       if (uarch == cpuinfo_uarch_cortex_a53 || uarch == cpuinfo_uarch_cortex_a55r0 ||
+@@ -365,12 +369,8 @@ CPUIDInfo::CPUIDInfo() {
+   }
+ #endif  // defined(CPUINFO_SUPPORTED)
+ 
+-  // Note: This should be run after cpuinfo initialization if cpuinfo is enabled.
+-  // On Wasm/Emscripten, cpuinfo cannot detect the CPU vendor so skip to avoid
+-  // an unhelpful "Unknown CPU vendor" warning.
+-#if !defined(__wasm__)
+-  VendorInfoInit();
+-#endif
++// Note: This should be run after cpuinfo initialization if cpuinfo is enabled.
++VendorInfoInit();
+ 
+ #ifdef CPUIDINFO_ARCH_X86
+   X86Init();

--- a/recipes/onnxruntime/all/patches/fix-cutlass-cuda-provider.patch
+++ b/recipes/onnxruntime/all/patches/fix-cutlass-cuda-provider.patch
@@ -1,15 +1,34 @@
 diff --git a/cmake/onnxruntime_providers_cuda.cmake b/cmake/onnxruntime_providers_cuda.cmake
-index cd7324d..c591d03 100644
+index cd7324d65d6..bf6a758d86d 100644
 --- a/cmake/onnxruntime_providers_cuda.cmake
 +++ b/cmake/onnxruntime_providers_cuda.cmake
-@@ -253,8 +253,8 @@
+@@ -207,6 +207,9 @@
+                   "$<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:-Wno-reorder>")
+       target_compile_options(${target} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -Wno-error=sign-compare>"
+                   "$<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:-Wno-error=sign-compare>")
++      # Suppress template-body warnings from abseil headers when compiled with nvcc + modern GCC
++      target_compile_options(${target} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler -Wno-template-body>"
++                  "$<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:-Wno-template-body>")
+     else()
+       #mutex.cuh(91): warning C4834: discarding return value of function with 'nodiscard' attribute
+       target_compile_options(${target} PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-Xcompiler /wd4834>")
+@@ -241,7 +244,7 @@
+       target_compile_definitions(${target} PRIVATE USE_CUDA_MINIMAL)
+       target_link_libraries(${target} PRIVATE ${ABSEIL_LIBS} ${ONNXRUNTIME_PROVIDERS_SHARED} Boost::mp11 safeint_interface CUDA::cudart)
+     else()
+-      include(cudnn_frontend) # also defines CUDNN::*
++      find_package(cudnn_frontend REQUIRED) # also defines CUDNN::*
+       if (onnxruntime_USE_CUDA_NHWC_OPS)
+         if(CUDNN_MAJOR_VERSION GREATER 8)
+           add_compile_definitions(ENABLE_CUDA_NHWC_OPS)
+@@ -253,8 +256,8 @@
                ${ABSEIL_LIBS} ${ONNXRUNTIME_PROVIDERS_SHARED} Boost::mp11 safeint_interface)
      endif()
-
+ 
 -    include(cutlass)
 -    target_include_directories(${target} PRIVATE ${cutlass_SOURCE_DIR}/include ${cutlass_SOURCE_DIR}/examples ${cutlass_SOURCE_DIR}/tools/util/include)
 +    find_package(NvidiaCutlass)
 +    target_link_libraries(${target} PRIVATE nvidia::cutlass::cutlass)
      target_link_libraries(${target} PRIVATE Eigen3::Eigen)
      target_include_directories(${target} PRIVATE ${ONNXRUNTIME_ROOT} ${CMAKE_CURRENT_BINARY_DIR} PUBLIC ${CUDAToolkit_INCLUDE_DIRS})
-
+ 


### PR DESCRIPTION
### Summary
Changes to recipe:  **onnxruntime/[1.24.4]**

#### Motivation
This allows compilation with tensorrt cuda options. Closes #30365

#### Details
Adds a small patch to use `find_package(cudnn_frontend)` instead of `include(cudnn_frontend)`.
Adds `include(cuDNN)` to onnxruntime_external_deps.cmake replacement. This is a direct copy from the replaced upstream file in the onnxruntime package. 
~~Downgrades protobuf version compatibility to <5. This is inline with the [default version downloaded by onnxruntime](https://github.com/microsoft/onnxruntime/blob/2d924974ef147392ced8409d36bd6d2e7fcc8a74/cmake/deps.txt#L40).~~
Adds a patch so unknown ARM architectures (eg Nvidia Orin) don't fail. PR from parent [here](https://github.com/microsoft/onnxruntime/pull/28344).

Tested with:
```
[conf]
tools.cmake.cmaketoolchain:extra_variables={'onnxruntime_USE_TENSORRT': True, 'onnxruntime_TENSORRT_HOME': '/usr/lib/aarch64-linux-gnu', 'onnxruntime_CUDA_HOME': '/usr/local/cuda', 'onnxruntime_CUDNN_HOME': '/etc/alternatives', 'onnxruntime_USE_CUDA_NHWC_OPS': True, 'onnxruntime_USE_TENSORRT_BUILTIN_PARSER': True}
```


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
