### PR TITLE
sqlgen: Add new 0.6.0 version

### DIFF
--- a/recipes/sqlgen/all/conandata.yml
+++ b/recipes/sqlgen/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "0.4.0":
-    url: "https://github.com/getml/sqlgen/archive/refs/tags/v0.4.0.tar.gz"
-    sha256: "4db5316042b911ceeed5a5cd145b3259f9cd204e6db9faf92731be3c45602e63"
+  "0.6.0":
+    url: "https://github.com/getml/sqlgen/archive/refs/tags/v0.6.0.tar.gz"
+    sha256: "a872fdcbca290f0dd0e57905e032d676b0c1911b307573e9183d6fa5f37c21f2"

--- a/recipes/sqlgen/all/conanfile.py
+++ b/recipes/sqlgen/all/conanfile.py
@@ -24,6 +24,7 @@ class SQLGenConan(ConanFile):
         "with_mysql": [True, False],
         "with_postgres": [True, False],
         "with_sqlite3": [True, False],
+        "with_duckdb": [True, False],
     }
     default_options = {
         "shared": False,
@@ -31,18 +32,21 @@ class SQLGenConan(ConanFile):
         "with_mysql": False,
         "with_postgres": True,
         "with_sqlite3": True,
+        "with_duckdb": False,
     }
     implements = ["auto_shared_fpic"]
 
     def requirements(self):
         self.requires("reflect-cpp/0.22.0", transitive_headers=True)
-        # All three dependencies fail with undefined symbols without transitive_libs
+        # All dependencies fail with undefined symbols without transitive_libs
         if self.options.with_mysql:
             self.requires("mariadb-connector-c/3.4.3", transitive_headers=True, transitive_libs=True)
         if self.options.with_postgres:
             self.requires("libpq/[>=16.4 <18]", transitive_headers=True, transitive_libs=True)
         if self.options.with_sqlite3:
             self.requires("sqlite3/[>=3.49.1 <4]", transitive_headers=True, transitive_libs=True)
+        if self.options.with_duckdb:
+            self.requires("duckdb/[>=1.4.3 <2]", transitive_headers=True, transitive_libs=True)
 
     def build_requirements(self):
         self.tool_requires("cmake/[>=3.23]")
@@ -58,11 +62,16 @@ class SQLGenConan(ConanFile):
 
     def generate(self):
         deps = CMakeDeps(self)
+        if self.options.with_duckdb:
+            deps.set_property("duckdb", "cmake_file_name", "DuckDB")
+            deps.set_property("duckdb", "cmake_target_name", "duckdb")
         deps.generate()
         tc = CMakeToolchain(self)
+        tc.cache_variables["SQLGEN_BUILD_SHARED"] = self.options.shared
         tc.cache_variables["SQLGEN_MYSQL"] = self.options.with_mysql
         tc.cache_variables["SQLGEN_POSTGRES"] = self.options.with_postgres
         tc.cache_variables["SQLGEN_SQLITE3"] = self.options.with_sqlite3
+        tc.cache_variables["SQLGEN_DUCKDB"] = self.options.with_duckdb
         tc.cache_variables["SQLGEN_USE_VCPKG"] = False
         tc.generate()
 

--- a/recipes/sqlgen/all/test_package/conanfile.py
+++ b/recipes/sqlgen/all/test_package/conanfile.py
@@ -25,6 +25,9 @@ class TestPackageConan(ConanFile):
 
         if self.dependencies[self.tested_reference_str].options.with_sqlite3:
             tc.preprocessor_definitions["TEST_SQLITE3_ENABLED"] = True
+
+        if self.dependencies[self.tested_reference_str].options.with_duckdb:
+            tc.preprocessor_definitions["TEST_DUCKDB_ENABLED"] = True
         tc.generate()
 
     def build(self):

--- a/recipes/sqlgen/all/test_package/test_package.cpp
+++ b/recipes/sqlgen/all/test_package/test_package.cpp
@@ -8,6 +8,9 @@
 #ifdef TEST_POSTGRES_ENABLED
 #include <sqlgen/postgres.hpp>
 #endif
+#ifdef TEST_DUCKDB_ENABLED
+#include <sqlgen/duckdb.hpp>
+#endif
 
 #include <iostream>
 struct Person {
@@ -34,6 +37,9 @@ int main() {
     #endif
     #ifdef TEST_POSTGRES_ENABLED
     std::cout << "postgress: " << sqlgen::postgres::to_sql(query) << std::endl;
+    #endif
+    #ifdef TEST_DUCKDB_ENABLED
+    std::cout << "duckdb: " << sqlgen::duckdb::to_sql(query) << std::endl;
     #endif
 
     return 0;

--- a/recipes/sqlgen/config.yml
+++ b/recipes/sqlgen/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.4.0":
+  "0.6.0":
     folder: all


### PR DESCRIPTION
As follow-up for the [reflect-cpp PR](https://github.com/conan-io/conan-center-index/pull/30392)


* `conan create --version 0.6.0 -o="*:shared=True" -s="compiler.cppstd=20" -b="missing" -o="&:with_duckdb=True"`: [shared.txt](https://github.com/user-attachments/files/29090752/shared.txt)
* `conan create --version 0.6.0 -o="*:shared=False" -s="compiler.cppstd=20" -b="missing" -o="&:with_duckdb=True"`: [static.txt](https://github.com/user-attachments/files/29090755/static.txt)


<details>
<summary>
Not inluding the transitive_libs would have this error in shared builds of consumers:
</summary>

```
../build/apple-clang-17-armv8-20-release" -- -j12
[ 50%] Building CXX object CMakeFiles/test_package.dir/test_package.cpp.o
[100%] Linking CXX executable test_package
Undefined symbols for architecture arm64:
  "_duckdb_appender_close", referenced from:
      sqlgen::duckdb::DuckDBAppender::close() in libsqlgen.a[3](sqlgen_duckdb.cpp.o)
  "_duckdb_appender_create_query", referenced from:
      sqlgen::duckdb::DuckDBAppender::DuckDBAppender(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, rfl::Ref<sqlgen::duckdb::DuckDBConnection> const&, std::__1::vector<char const*, std::__1::allocator<char const*>>, std::__1::vector<_duckdb_logical_type*, std::__1::allocator<_duckdb_logical_type*>>) in libsqlgen.a[3](sqlgen_duckdb.cpp.o)
      sqlgen::duckdb::DuckDBAppender* std::__1::construct_at[abi:nqe210106]<sqlgen::duckdb::DuckDBAppender, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, rfl::Ref<sqlgen::duckdb::DuckDBConnection> const&, std::__1::vector<char const*, std::__1::allocator<char const*>> const&, std::__1::vector<_duckdb_logical_type*, std::__1::allocator<_duckdb_logical_type*>> const&, sqlgen::duckdb::DuckDBAppender*>(sqlgen::duckdb::DuckDBAppender*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, rfl::Ref<sqlgen::duckdb::DuckDBConnection> const&, std::__1::vector<char const*, std::__1::allocator<char const*>> const&, std::__1::vector<_duckdb_logical_type*, std::__1::allocator<_duckdb_logical_type*>> const&) in libsqlgen.a[3](sqlgen_duckdb.cpp.o)
```

</details>

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
