### PR TITLE
glad/0.*: Avoid requiring an internet connection during build.

### DIFF
--- a/recipes/glad/0.x/conanfile.py
+++ b/recipes/glad/0.x/conanfile.py
@@ -108,7 +108,8 @@ class GladConan(ConanFile):
         tc.variables["GLAD_EXPORT"] = True
         tc.variables["GLAD_INSTALL"] = True
         tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5"  # CMake 4 support
-        tc.cache_variables["GLAD_REPRODUCIBLE"] = True  # Use bundled specs instead of downloading new ones.
+        if self.settings.os != "Windows":
+            tc.cache_variables["GLAD_REPRODUCIBLE"] = True  # Use bundled specs instead of downloading new ones.
         tc.generate()
 
     def build(self):

--- a/recipes/glad/0.x/conanfile.py
+++ b/recipes/glad/0.x/conanfile.py
@@ -108,6 +108,7 @@ class GladConan(ConanFile):
         tc.variables["GLAD_EXPORT"] = True
         tc.variables["GLAD_INSTALL"] = True
         tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5"  # CMake 4 support
+        tc.cache_variables["GLAD_REPRODUCIBLE"] = True  # Use bundled specs instead of downloading new ones.
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **glad/0.x**

#### Motivation
While trying to build all of our Conan dependencies inside an environment that doesn't have an internet connection (which is a common requirement for packaging), I noticed that glad tries to access the internet during the build, which causes the build to fail if there is no internet connection.

#### Details
Glad tries to download the latest OpenGL spec if GLAD_REPRODUCIBLE isn't set. If it is set, it will just use the OpenGL spec that it was shipped with. I would argue that getting a newer OpenGL spec doesn't make much sense, since, as far as I am aware OpenGL's spec doesn't get updated anymore and the latest version of glad 0.x already comes with the latest version.

https://github.com/Dav1dde/glad/blob/1ecd45775d96f35170458e6b148eb0708967e402/CMakeLists.txt#L47
https://github.com/Dav1dde/glad/blob/1ecd45775d96f35170458e6b148eb0708967e402/glad/__main__.py#L52


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
