### PR TITLE
libattr: publish version 2.5.2

### DIFF
--- a/recipes/libattr/all/conandata.yml
+++ b/recipes/libattr/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "2.5.1":
-    url: "http://download.savannah.nongnu.org/releases/attr/attr-2.5.1.tar.gz"
-    sha256: "bae1c6949b258a0d68001367ce0c741cebdacdd3b62965d17e5eb23cd78adaf8"
+  "2.5.2":
+    url: "https://download.savannah.nongnu.org/releases/attr/attr-2.5.2.tar.gz"
+    sha256: "39bf67452fa41d0948c2197601053f48b3d78a029389734332a6309a680c6c87"

--- a/recipes/libattr/config.yml
+++ b/recipes/libattr/config.yml
@@ -1,4 +1,3 @@
-versions: 
-  "2.5.1":
+versions:
+  "2.5.2":
     folder: all
-


### PR DESCRIPTION
### Summary
Changes to recipe:  **libattr/2.5.2**

#### Motivation
Update to the latest version and to fix mismatched SHA256 checksup for version 2.5.1
 
#### Details
https://lists.nongnu.org/archive/html/acl-devel/2024-01/msg00011.html


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
