### PR TITLE
unleash-client-cpp: add version 1.5.4

### DIFF
--- a/recipes/unleash-client-cpp/all/conandata.yml
+++ b/recipes/unleash-client-cpp/all/conandata.yml
@@ -2,6 +2,3 @@ sources:
   "1.5.2":
     url: "https://github.com/aruizs/unleash-client-cpp/archive/refs/tags/v1.5.2.tar.gz"
     sha256: "7a0cc927d8910ddcb46c2c0f566fa17ef1286bd4ea4e0dd3e79a85273a2f291e"
-  "1.3.0":
-    url: "https://github.com/aruizs/unleash-client-cpp/archive/refs/tags/v1.3.0.tar.gz"
-    sha256: "fa0b8d6101c6dbd08db23a3d353f386c17e9436a63d658f88c7d0b8619b8d501"

--- a/recipes/unleash-client-cpp/all/conandata.yml
+++ b/recipes/unleash-client-cpp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.5.2":
+    url: "https://github.com/aruizs/unleash-client-cpp/archive/refs/tags/v1.5.2.tar.gz"
+    sha256: "7a0cc927d8910ddcb46c2c0f566fa17ef1286bd4ea4e0dd3e79a85273a2f291e"
   "1.3.0":
     url: "https://github.com/aruizs/unleash-client-cpp/archive/refs/tags/v1.3.0.tar.gz"
     sha256: "fa0b8d6101c6dbd08db23a3d353f386c17e9436a63d658f88c7d0b8619b8d501"

--- a/recipes/unleash-client-cpp/all/conandata.yml
+++ b/recipes/unleash-client-cpp/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "1.5.2":
-    url: "https://github.com/aruizs/unleash-client-cpp/archive/refs/tags/v1.5.2.tar.gz"
-    sha256: "7a0cc927d8910ddcb46c2c0f566fa17ef1286bd4ea4e0dd3e79a85273a2f291e"
+  "1.5.4":
+    url: "https://github.com/aruizs/unleash-client-cpp/archive/refs/tags/v1.5.4.tar.gz"
+    sha256: "a9ca5962a45af4b608c800a7d1a47de52595044c9a179759ec38e4eaba545d6d"

--- a/recipes/unleash-client-cpp/all/conanfile.py
+++ b/recipes/unleash-client-cpp/all/conanfile.py
@@ -1,8 +1,11 @@
 from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir
 import os
+
+from conan.tools.scm import Version
 
 required_conan_version = ">=2.1"
 
@@ -41,6 +44,10 @@ class UnleashConan(ConanFile):
 
     def validate(self):
         check_min_cppstd(self, 17)
+        if self.settings.compiler == "msvc" and Version(self.settings.compiler.version) < "195":
+            raise ConanInvalidConfiguration(
+                f"{self.ref} uses std::regex::multiline which was not implemented until MSVC 19.5"
+            )
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/unleash-client-cpp/all/conanfile.py
+++ b/recipes/unleash-client-cpp/all/conanfile.py
@@ -72,8 +72,7 @@ class UnleashConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["ENABLE_TESTING"] = False
-        tc.variables["ENABLE_TESTING_COVERAGE"] = False
+        tc.variables["UNLEASH_ENABLE_TESTING"] = False
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()

--- a/recipes/unleash-client-cpp/all/conanfile.py
+++ b/recipes/unleash-client-cpp/all/conanfile.py
@@ -1,13 +1,10 @@
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir
 import os
 
-from conan.tools.scm import Version
-
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.1"
 
 class UnleashConan(ConanFile):
     name = "unleash-client-cpp"
@@ -27,21 +24,6 @@ class UnleashConan(ConanFile):
         "fPIC": True,
     }
 
-    @property
-    def _min_cppstd(self):
-        return "17"
-
-    @property
-    def _compilers_min_version(self):
-        return {
-            "Visual Studio": "15",  # Should we check toolset?
-            "msvc": "191",
-            "gcc": "7",
-            "clang": "4.0",
-            "apple-clang": "3.8",
-            "intel": "17",
-        }
-
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -54,25 +36,18 @@ class UnleashConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("cpr/1.10.5")
-        self.requires("nlohmann_json/3.11.3")
+        self.requires("cpr/[>=1.10.5 <1.15]")
+        self.requires("nlohmann_json/[>=3.11 <3.13]")
 
     def validate(self):
-        if self.settings.compiler.get_safe("cppstd"):
-            check_min_cppstd(self, self._min_cppstd)
-
-        min_version = self._compilers_min_version.get(str(self.settings.compiler), False)
-        if min_version and Version(self.settings.compiler.version) < min_version:
-            raise ConanInvalidConfiguration(
-                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
-            )
+        check_min_cppstd(self, 17)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["UNLEASH_ENABLE_TESTING"] = False
+        tc.cache_variables["UNLEASH_ENABLE_TESTING"] = False
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()

--- a/recipes/unleash-client-cpp/all/conanfile.py
+++ b/recipes/unleash-client-cpp/all/conanfile.py
@@ -1,11 +1,8 @@
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir
 import os
-
-from conan.tools.scm import Version
 
 required_conan_version = ">=2.1"
 
@@ -44,10 +41,6 @@ class UnleashConan(ConanFile):
 
     def validate(self):
         check_min_cppstd(self, 17)
-        if self.settings.compiler == "msvc" and Version(self.settings.compiler.version) < "195":
-            raise ConanInvalidConfiguration(
-                f"{self.ref} uses std::regex::multiline which was not implemented until MSVC 19.5"
-            )
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/unleash-client-cpp/all/test_package/CMakeLists.txt
+++ b/recipes/unleash-client-cpp/all/test_package/CMakeLists.txt
@@ -5,4 +5,3 @@ find_package(unleash CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE unleash::unleash)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/unleash-client-cpp/all/test_package/conanfile.py
+++ b/recipes/unleash-client-cpp/all/test_package/conanfile.py
@@ -7,7 +7,6 @@ import os
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
 
     def requirements(self):
         self.requires(self.tested_reference_str)

--- a/recipes/unleash-client-cpp/config.yml
+++ b/recipes/unleash-client-cpp/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.5.2":
+  "1.5.4":
     folder: all

--- a/recipes/unleash-client-cpp/config.yml
+++ b/recipes/unleash-client-cpp/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.5.2":
+    folder: all
   "1.3.0":
     folder: all

--- a/recipes/unleash-client-cpp/config.yml
+++ b/recipes/unleash-client-cpp/config.yml
@@ -1,5 +1,3 @@
 versions:
   "1.5.2":
     folder: all
-  "1.3.0":
-    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe: unleash-client-cpp/1.5.4

#### Motivation
Adding new version 1.5.3 of unleash-client-cpp with several new features and bug fixes.


#### Details

Adds version 1.5.3. This is the first recipe update since 1.3.0, so the changes below cover everything between **1.3.0 and 1.5.3**.

  ##### Feature flag evaluation
  - Strategy constraints evaluated across all built-in strategies (incl. gradual rollout), with early constraint checking
  - Advanced constraint operators: string (`STR_STARTS_WITH`/`STR_ENDS_WITH`/`STR_CONTAINS`), numeric (`NUM_*`), date (`DATE_*`), SemVer (`SEMVER_*`), regex (`REGEX`), and CIDR (`IN_CIDR`, IPv4 + IPv6)
  - Segments (global constraints)
  - Strategy variants (stickiness inherited from the strategy)
  - Dependent features
  - Custom stickiness for the flexible rollout strategy
  - UTF-8 feature flag names
  - Delta API support (hydration snapshot and incremental event stream)
  - Opt-in usage metrics reporting to `/client/metrics`
  - Bootstrapping from a local cache file (offline resilience)

  The client now passes the full [Unleash Client Specification](https://github.com/Unleash/client-specification) test suite.

  ##### API additions
  - `UnleashClientBuilder::build()` — explicit, readable client construction
  - `isEnabled(flag, defaultValue)` and `isEnabled(flag, context, defaultValue)` — fallback value used only for unknown flags, matching the official SDKs

  1.5.3 is **source-compatible with 1.3.0**: existing code recompiles unchanged.

  ##### Build & tooling
  - Modernized to Conan 2 with CMake presets; dependencies updated (`cpr/1.10.5`, `nlohmann_json/3.11.3`)
  - C++17 modernization and numerous static-analysis (SonarCloud) fixes
  - Windows build/CI fixes (including networking headers for the CIDR operator)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
