### PR TITLE
flashaccept/1.0.1: add recipe

### DIFF
--- a/recipes/flashaccept/all/conandata.yml
+++ b/recipes/flashaccept/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.0.1":
+    url: "https://github.com/thealonlevi/flashaccept/archive/refs/tags/v1.0.1.tar.gz"
+    sha256: "4e5528da4e856e51e8d049bbf9795b7afc9b109659a723ef8c739b0551117882"

--- a/recipes/flashaccept/all/conanfile.py
+++ b/recipes/flashaccept/all/conanfile.py
@@ -1,0 +1,86 @@
+import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, rmdir
+
+required_conan_version = ">=1.53.0"
+
+
+class FlashacceptConan(ConanFile):
+    name = "flashaccept"
+    description = "Fast io_uring TCP accept engine for Linux"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/thealonlevi/flashaccept"
+    topics = ("io_uring", "tcp", "accept", "networking", "performance", "linux")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        # Pure C library: no C++ runtime settings.
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        # flashaccept is built on liburing (>= 2.3); not exposed in public headers.
+        self.requires("liburing/2.6")
+
+    def validate(self):
+        if self.settings.os != "Linux":
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires Linux (built on io_uring)."
+            )
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["FLASHACCEPT_BUILD_EXAMPLES"] = False
+        tc.variables["FLASHACCEPT_BUILD_SHARED"] = bool(self.options.shared)
+        tc.variables["FLASHACCEPT_BUILD_STATIC"] = not bool(self.options.shared)
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE",
+             src=self.source_folder,
+             dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        # Conan generates its own CMake/pkg-config files from package_info().
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["flashaccept"]
+        self.cpp_info.system_libs = ["pthread"]
+
+        self.cpp_info.set_property("cmake_file_name", "flashaccept")
+        self.cpp_info.set_property("cmake_target_name", "flashaccept::flashaccept")
+        self.cpp_info.set_property("pkg_config_name", "flashaccept")

--- a/recipes/flashaccept/all/test_package/CMakeLists.txt
+++ b/recipes/flashaccept/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package C)
+
+find_package(flashaccept CONFIG REQUIRED)
+
+add_executable(test_package test_package.c)
+target_link_libraries(test_package PRIVATE flashaccept::flashaccept)

--- a/recipes/flashaccept/all/test_package/conanfile.py
+++ b/recipes/flashaccept/all/test_package/conanfile.py
@@ -1,0 +1,27 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/flashaccept/all/test_package/test_package.c
+++ b/recipes/flashaccept/all/test_package/test_package.c
@@ -1,0 +1,9 @@
+#include <flashaccept.h>
+#include <stdio.h>
+
+/* Link + symbol smoke test: just resolve a flashaccept symbol at runtime. */
+int main(void)
+{
+    printf("flashaccept %s\n", fa_version());
+    return 0;
+}

--- a/recipes/flashaccept/config.yml
+++ b/recipes/flashaccept/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.0.1":
+    folder: all


### PR DESCRIPTION
Specify library name and version: **flashaccept/1.0.1**

A fast io_uring TCP accept engine for Linux — accepts short-lived TCP connections for ~3× fewer CPU instructions than a goroutine-per-connection server and ~2.2× fewer than vanilla io_uring (multishot accept, registered/direct descriptors, per-worker connection freelist, MSG_MORE reply+FIN fusion, batched submit/harvest).

- Upstream: https://github.com/thealonlevi/flashaccept
- License: MIT
- Depends on `liburing`.
- **Linux-only** (built on io_uring) — `validate()` raises `ConanInvalidConfiguration` on non-Linux.

---

- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] Checked that the recipe builds: `conan create recipes/flashaccept/all --version 1.0.1 --build=missing` succeeds and the `test_package` runs.
- [x] Recipe exposes `flashaccept::flashaccept` (CMake) and `flashaccept` (pkg-config); links `pthread` as a system lib.
