### PR TITLE
package/luajit: fix static build for Intel CPUs, add option for GC64 mode

### DIFF
--- a/recipes/luajit/all/conandata.yml
+++ b/recipes/luajit/all/conandata.yml
@@ -11,3 +11,7 @@ patches:
     - patch_file: "patches/2.1.0-beta3-0001-remove-mac-deploy.patch"
       patch_type: "conan"
       patch_description: "Do not enforce default value for MACOSX_DEPLOYMENT_TARGET"
+    - patch_file: "patches/2.1.0-beta3-intel-static.diff"
+      patch_description: "Fix static build on Intel CPUs"
+      patch_source: "https://github.com/LuaJIT/LuaJIT/commit/2240d84464cc3dcb22fd976f1db162b36b5b52d5"
+      patch_type: "bugfix"

--- a/recipes/luajit/all/conanfile.py
+++ b/recipes/luajit/all/conanfile.py
@@ -22,8 +22,16 @@ class LuajitConan(ConanFile):
     topics = ("lua", "jit")
     provides = "lua"
     settings = "os", "arch", "compiler", "build_type"
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": False, "fPIC": True}
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "with_gc64": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "with_gc64": False, # note: on by default in later versions
+    }
 
     def export_sources(self):
         export_conandata_patches(self)
@@ -31,6 +39,8 @@ class LuajitConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+        if self._is_host_32bit:
+            del self.options.with_gc64
 
     def configure(self):
         if self.options.shared:
@@ -40,6 +50,10 @@ class LuajitConan(ConanFile):
 
     def layout(self):
         basic_layout(self, src_folder="src")
+
+    @property
+    def _is_host_32bit(self):
+        return self.settings.arch in ["armv7", "x86"]
 
     def validate(self):
         if self.settings.os == "Macos" and self.settings.arch == "armv8" and cross_building(self):
@@ -93,6 +107,8 @@ class LuajitConan(ConanFile):
     @property
     def _make_arguments(self):
         args = [f"PREFIX={unix_path(self, self.package_folder)}"]
+        if self.options.get_safe("with_gc64", False):
+            args.append("XCFLAGS=-DLUAJIT_ENABLE_GC64")
         if is_apple_os(self) and self._macosx_deployment_target:
             args.append(f"MACOSX_DEPLOYMENT_TARGET={self._macosx_deployment_target}")
         return args
@@ -109,8 +125,10 @@ class LuajitConan(ConanFile):
         self._patch_sources()
         if is_msvc(self):
             with chdir(self, os.path.join(self.source_folder, "src")):
-                variant = '' if self.options.shared else 'static'
-                self.run(f"msvcbuild.bat {variant}", env="conanbuild")
+                build_opts = "gc64" if self.options.get_safe("with_gc64", False) else ""
+                if not self.options.shared:
+                    build_opts += " static"
+                self.run(f"msvcbuild.bat {build_opts}", env="conanbuild")
         else:
             with chdir(self, self.source_folder):
                 autotools = Autotools(self)

--- a/recipes/luajit/all/patches/2.1.0-beta3-intel-static.diff
+++ b/recipes/luajit/all/patches/2.1.0-beta3-intel-static.diff
@@ -1,0 +1,24 @@
+diff --git a/src/vm_x64.dasc b/src/vm_x64.dasc
+index 8c46ea59e9..b8ecb8687c 100644
+--- a/src/vm_x64.dasc
++++ b/src/vm_x64.dasc
+@@ -4898,7 +4898,6 @@ static void emit_asm_debug(BuildCtx *ctx)
+ 	  "LEFDEY:\n\n", fcsize);
+     }
+ #endif
+-    fprintf(ctx->fp, ".subsections_via_symbols\n");
+     }
+     break;
+ #endif
+diff --git a/src/vm_x86.dasc b/src/vm_x86.dasc
+index 9c5ae384db..1994c0a0ca 100644
+--- a/src/vm_x86.dasc
++++ b/src/vm_x86.dasc
+@@ -5769,7 +5769,6 @@ static void emit_asm_debug(BuildCtx *ctx)
+ 	  fprintf(ctx->fp, "L_%s$stub:\n\t.indirect_symbol _%s\n\t.ascii \"\\364\\364\\364\\364\\364\"\n", *xn, *xn);
+     }
+ #endif
+-    fprintf(ctx->fp, ".subsections_via_symbols\n");
+     }
+     break;
+ #endif

--- a/recipes/luajit/all/test_package/CMakeLists.txt
+++ b/recipes/luajit/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.14)
 project(test_package C)
 
 find_package(luajit REQUIRED CONFIG)


### PR DESCRIPTION
### Summary
Changes to recipe:  **luajit/all**

#### Motivation

- fixes static build usage on Intel CPUs via upstream patch, but I had to adjust it a bit that it applies on 2.1.0-beta3
- adds option to enable GC64 mode. Keeping it off by default to match behavior of the source, but in later LuaJIT versions it's on by default.
- increases test package's `cmake_minimum_required` so that it can be configured on CMake >= 4 without any additional actions

#### Details

- the bug fix is taken from https://github.com/LuaJIT/LuaJIT/commit/2240d84464cc3dcb22fd976f1db162b36b5b52d5, current version doesn't require adjustment for arm64. Alternatively, consuming project must use `-Wl,-no_deduplicate` or shared lib.
- GC64 mode is highly recommended on 64-bit systems and is on by default in later LuaJIT versions

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
