### PR TITLE
uni-algo: Fix lib name (Windows)

### DIFF
--- a/recipes/uni-algo/all/conandata.yml
+++ b/recipes/uni-algo/all/conandata.yml
@@ -2,27 +2,3 @@ sources:
   "1.2.0":
     url: "https://github.com/uni-algo/uni-algo/archive/v1.2.0.tar.gz"
     sha256: "f2a1539cd8635bc6088d05144a73ecfe7b4d74ee0361fabed6f87f9f19e74ca9"
-  "1.1.0":
-    url: "https://github.com/uni-algo/uni-algo/archive/v1.1.0.tar.gz"
-    sha256: "f9aa30df9766fbbc7007b206c6db122313194e75b159dc222cddce016372d2de"
-  "1.0.0":
-    url: "https://github.com/uni-algo/uni-algo/archive/v1.0.0.tar.gz"
-    sha256: "a59d61cd4a4fff08672831c7e5a8c204bb6e96c21506b6471771c01b38958a15"
-  "0.8.2":
-    url: "https://github.com/uni-algo/uni-algo/archive/v0.8.2.tar.gz"
-    sha256: "c0dab8ae1dbbab3e33b0c5bb512e927badb57f53e7ee96517c1dfd2e078b7669"
-  "0.8.1":
-    url: "https://github.com/uni-algo/uni-algo/archive/v0.8.1.tar.gz"
-    sha256: "11192280fa435a9d68131d5368d2b314201d7089e6d2f38f29a8591c9aafa776"
-  "0.8.0":
-    url: "https://github.com/uni-algo/uni-algo/archive/refs/tags/v0.8.0.tar.gz"
-    sha256: "657f124f4fb4705f948e9c0835ec88484ee4745d7b19cb2ddb772119a7ea024e"
-  "0.7.1":
-    url: "https://github.com/uni-algo/uni-algo/archive/refs/tags/v0.7.1.tar.gz"
-    sha256: "9ff1f03d6ffd81df7a2a21df353502db55d198a940da0aef0546b37ca934fdfb"
-  "0.7.0":
-    url: "https://github.com/uni-algo/uni-algo/archive/refs/tags/v0.7.0.tar.gz"
-    sha256: "c8d078461c77fa4e50013ea4e1263466163eac9102fca2e125bd5c992de6cc2f"
-  "0.6.0":
-    url: "https://github.com/uni-algo/uni-algo/archive/refs/tags/v0.6.0.tar.gz"
-    sha256: "b2b0cf62c8476895ce2dae51459f8df82cd27b6f199b014cb5b2dbb45a605187"

--- a/recipes/uni-algo/all/conanfile.py
+++ b/recipes/uni-algo/all/conanfile.py
@@ -117,10 +117,7 @@ class UniAlgoConan(ConanFile):
             lib_name = f"{self.name}-v{ver.major}-{ver.minor}" if (self.settings.os == "Windows" and self.options.shared) else f"{self.name}"
 
             if self.settings.build_type == "Debug":
-                if Version(self.version) < "0.7":
-                    self.cpp_info.libs = [f"{lib_name}d"]
-                else:
-                    self.cpp_info.libs = [f"{lib_name}-debug"]
+                self.cpp_info.libs = [f"{lib_name}-debug"]
             else:
                 self.cpp_info.libs = [f"{lib_name}"]
         if self.settings.os in ["Linux", "FreeBSD"]:

--- a/recipes/uni-algo/all/conanfile.py
+++ b/recipes/uni-algo/all/conanfile.py
@@ -4,11 +4,10 @@ from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir
 from conan.tools.layout import basic_layout
-from conan.tools.microsoft import is_msvc
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2"
 
 
 class UniAlgoConan(ConanFile):
@@ -68,17 +67,13 @@ class UniAlgoConan(ConanFile):
             self.info.clear()
 
     def validate(self):
-        if self.settings.compiler.get_safe("cppstd"):
-            check_min_cppstd(self, self._min_cppstd)
+        check_min_cppstd(self, self._min_cppstd)
 
         minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
         if minimum_version and Version(self.settings.compiler.version) < minimum_version:
             raise ConanInvalidConfiguration(
                 f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
             )
-
-        if is_msvc(self) and self.options.get_safe("shared"):
-            raise ConanInvalidConfiguration(f"{self.ref} can not be built as shared with msvc")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -115,6 +110,9 @@ class UniAlgoConan(ConanFile):
             self.cpp_info.bindirs = []
             self.cpp_info.libdirs = []
         else:
+
+            if self.options.shared:
+                self.cpp_info.defines.append("UNI_ALGO_DLL_IMPORT")
             ver = Version(self.version)
             lib_name = f"{self.name}-v{ver.major}-{ver.minor}" if (self.settings.os == "Windows" and self.options.shared) else f"{self.name}"
 

--- a/recipes/uni-algo/all/conanfile.py
+++ b/recipes/uni-algo/all/conanfile.py
@@ -115,13 +115,16 @@ class UniAlgoConan(ConanFile):
             self.cpp_info.bindirs = []
             self.cpp_info.libdirs = []
         else:
+            ver = Version(self.version)
+            lib_name = f"{self.name}" if self.settings.os != "Windows" else f"{self.name}-v{ver.major}-{ver.minor}"
+
             if self.settings.build_type == "Debug":
                 if Version(self.version) < "0.7":
-                    self.cpp_info.libs = [f"{self.name}d"]
+                    self.cpp_info.libs = [f"{lib_name}d"]
                 else:
-                    self.cpp_info.libs = [f"{self.name}-debug"]
+                    self.cpp_info.libs = [f"{lib_name}-debug"]
             else:
-                self.cpp_info.libs = [f"{self.name}"]
+                self.cpp_info.libs = [f"{lib_name}"]
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("m")
 

--- a/recipes/uni-algo/all/conanfile.py
+++ b/recipes/uni-algo/all/conanfile.py
@@ -116,7 +116,7 @@ class UniAlgoConan(ConanFile):
             self.cpp_info.libdirs = []
         else:
             ver = Version(self.version)
-            lib_name = f"{self.name}" if self.settings.os != "Windows" else f"{self.name}-v{ver.major}-{ver.minor}"
+            lib_name = f"{self.name}-v{ver.major}-{ver.minor}" if (self.settings.os == "Windows" and self.options.shared) else f"{self.name}"
 
             if self.settings.build_type == "Debug":
                 if Version(self.version) < "0.7":

--- a/recipes/uni-algo/config.yml
+++ b/recipes/uni-algo/config.yml
@@ -1,19 +1,3 @@
 versions:
   "1.2.0":
     folder: all
-  "1.1.0":
-    folder: all
-  "1.0.0":
-    folder: all
-  "0.8.2":
-    folder: all
-  "0.8.1":
-    folder: all
-  "0.8.0":
-    folder: all
-  "0.7.1":
-    folder: all
-  "0.7.0":
-    folder: all
-  "0.6.0":
-    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **uni-algo/\***

#### Motivation
When building the library in Shared mode on Windows, the output file is named "uni-algo-v1-2.lib" or "uni-algo-v1-2-debug.lib"
<img width="833" height="301" alt="image" src="https://github.com/user-attachments/assets/dc449f7b-d575-4891-87b3-9393d81dc41b" />
https://github.com/uni-algo/uni-algo/blob/main/CMakeLists.txt#L60-L65
<img width="1022" height="434" alt="image" src="https://github.com/user-attachments/assets/f3f8c105-8508-4a3d-8c4d-f1966830baff" />

However, the recipe simply specifies `self.cpp_info.libs = [f"{self.name}"]` and `self.cpp_info.libs = [f"{self.name}-debug"]`, which are equivalent to "uni-algo.lib" and "uni-algo-debug.lib" respectively.
https://github.com/conan-io/conan-center-index/blob/master/recipes/uni-algo/all/conanfile.py#L118-L124
<img width="671" height="354" alt="image" src="https://github.com/user-attachments/assets/131b892e-26c4-4626-9f5f-64f0a4f591a6" />

This naturally leads to an error.
<img width="629" height="108" alt="image" src="https://github.com/user-attachments/assets/dfbd4329-4a89-445e-9b83-443e9a10d16e" />


#### Details
The essence of the fix is simply to check: if the OS is Windows, use the name that includes the version. Otherwise, everything stays the same.

```python
ver = Version(self.version)
lib_name = f"{self.name}" if self.settings.os != "Windows" else f"{self.name}-v{ver.major}-{ver.minor}"

if self.settings.build_type == "Debug":
    self.cpp_info.libs = [f"{lib_name}-debug"]
else:
    self.cpp_info.libs = [f"{lib_name}"]
```

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
