### PR TITLE
cpp-smtpclient-library: Add version 1.1.14

### DIFF
--- a/recipes/cpp-smtpclient-library/all/conandata.yml
+++ b/recipes/cpp-smtpclient-library/all/conandata.yml
@@ -1,5 +1,5 @@
 sources:
-  "1.1.13":
-    url: "https://github.com/jeremydumais/CPP-SMTPClient-library/archive/refs/tags/v1.1.13.zip"
-    sha256: "fea5c463a9d5717adcc62760527c180d09b556f0119468ed934429e6e15f0096"
+  "1.1.14":
+    url: "https://github.com/jeremydumais/CPP-SMTPClient-library/archive/refs/tags/v1.1.14.zip"
+    sha256: "d4684325a0a667cb760dd259f60a82dfe99c341f3beabf450e1e32abf78407ae"
 

--- a/recipes/cpp-smtpclient-library/config.yml
+++ b/recipes/cpp-smtpclient-library/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.1.13":
+  "1.1.14":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **cpp-smtpclient-library/1.1.14**

#### Motivation
v1.1.14 released on 2026-06-20

#### Details
https://github.com/jeremydumais/CPP-SMTPClient-library/releases/tag/v1.1.14

##### Fixed
- Fixed an endless recursion issue in batch mode when the SMTP server connection was lost during a send operation. 
- Fixed a crash during authentication when no compatible authentication protocol was found by the SMTP server. 
- Fixed a missing stdint.h include that prevented the library from building on musl-based Linux distributions such as Alpine Linux.
- Fixed a small memory leak in SMTPClientBase::extractAuthenticationOptions() that could occur while parsing SMTP server authentication capabilities from the EHLO response.
##### Enhancement
- Added support for configuring the domain used in the EHLO command instead of always using localhost. Some SMTP servers reject EHLO localhost; the library now exposes accessors and mutators to configure the EHLO domain while keeping localhost as the default value to preserve existing behavior.

- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
