### PR TITLE
QuickJS-NG Recipe

### DIFF
--- a/recipes/quickjs-ng/all/conandata.yml
+++ b/recipes/quickjs-ng/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.15.1":
+    url: "https://github.com/quickjs-ng/quickjs/archive/refs/tags/v0.15.1.tar.gz"
+    sha256: "c4e813951b7c46845096a948e978c620b11ab4cf5fd622ca09c727ec31f42623"

--- a/recipes/quickjs-ng/all/conanfile.py
+++ b/recipes/quickjs-ng/all/conanfile.py
@@ -1,0 +1,67 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, rmdir
+import os
+
+required_conan_version = ">=2.0"
+
+class QuickjsNgConan(ConanFile):
+    name = "quickjs-ng"
+    description = "QuickJS NG is a small and embeddable Javascript engine"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/quickjs-ng/quickjs"
+    topics = ("javascript", "embeddable", "es2020", "interpreter", "compiler")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["BUILD_SHARED_LIBS"] = self.options.shared
+        tc.variables["QJS_BUILD_LIBC"] = True
+        tc.variables["QJS_BUILD_EXAMPLES"] = False
+        tc.variables["QJS_BUILD_WERROR"] = False
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder,
+             dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "qjs")
+        self.cpp_info.set_property("cmake_target_name", "qjs::qjs")
+        self.cpp_info.libs = ["qjs"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.extend(["dl", "m", "pthread"])

--- a/recipes/quickjs-ng/all/test_package/CMakeLists.txt
+++ b/recipes/quickjs-ng/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES C)
+
+find_package(qjs REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE qjs::qjs)

--- a/recipes/quickjs-ng/all/test_package/conanfile.py
+++ b/recipes/quickjs-ng/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/quickjs-ng/all/test_package/test_package.c
+++ b/recipes/quickjs-ng/all/test_package/test_package.c
@@ -1,0 +1,8 @@
+#include "quickjs.h"
+
+int main()
+{
+    JSRuntime *rt = JS_NewRuntime();
+    JS_FreeRuntime(rt);
+    return 0;
+}

--- a/recipes/quickjs-ng/config.yml
+++ b/recipes/quickjs-ng/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.15.1":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **quickjs-ng/0.15.1**

#### Motivation
Add the quickjs-ng library to conan. The original quickjs is in conan but it doesn't support Windows. quickjs-ng is a fork with more active developer community. It has been adopted by major projects such as DuckDB.

#### Details
Very straight forward CMake recipe with a test, tested on Ubuntu 24 and Windows VS 2022.

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
