### PR TITLE
boost: fix error with toolchain comparison

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -1633,6 +1633,10 @@ class BoostConan(ConanFile):
 
     @property
     def _toolset_version(self):
+        # Return empty string for non-MSVC builds
+        if not is_msvc(self):
+            return ""
+
         toolset = MSBuildToolchain(self).toolset
         if toolset:
             match = re.match(r"v(\d+)(\d)$", toolset)


### PR DESCRIPTION
It is possible that conan profile will not contain necessary compiler for Windows build that will cause error:

```sh
  File "/var/work/my-conan-index/.pyenv/lib/python3.12/site-packages/conans/client/conanfile/build.py", line 16, in run_build_method
    conanfile.build()
  File "/home/user/my-conan-index/.local/env/.conan/data/boost/1.91.0/user/remote/export/conanfile.py", line 1166, in build
    self._create_user_config_jam(self._boost_build_dir)
  File "/home/user/conan-index/.local/env/.conan/data/boost/1.91.0/user/remote/export/conanfile.py", line 1591, in _create_user_config_jam
    contents += f'\nusing "{self._toolset}" : {self._toolset_version} : '
                                               ^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/my-conan-index/.local/env/.conan/data/boost/1.91.0/user/remote/export/conanfile.py", line 1653, in _toolset_version
    toolset = MSBuildToolchain(self).toolset
              ^^^^^^^^^^^^^^^^^^^^^^
  File "/var/work/my-conan-index/.pyenv/lib/python3.12/site-packages/conan/tools/microsoft/toolchain.py", line 55, in __init__
    self.runtime_library = self._runtime_library(conanfile.settings)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/work/my-conan-index/.pyenv/lib/python3.12/site-packages/conan/tools/microsoft/toolchain.py", line 89, in _runtime_library
    if compiler == "msvc" or compiler == "intel-cc":
                             ^^^^^^^^^^^^^^^^^^^^^^
  File "/var/work/my-conan-index/.pyenv/lib/python3.12/site-packages/conans/model/settings.py", line 99, in __eq__
    raise ConanException(bad_value_msg(self._name, other, self.values_range))
conans.errors.ConanException: Invalid setting 'intel-cc' is not a valid 'settings.compiler' value.
Possible values are ['Visual Studio', 'apple-clang', 'clang', 'gcc', 'msvc']
Read "http://docs.conan.io/en/latest/faq/troubleshooting.html#error-invalid-setting"
```


### Summary
Changes to recipe:  **boost** (all versions).

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
It is possible that conan profile will not contain necessary compiler for Windows build that will cause error. For example, I has conan profile that does not define intel-cc compiler and boost recipe fails on build with following error
```sh
  File "/var/work/my-conan-index/.pyenv/lib/python3.12/site-packages/conans/client/conanfile/build.py", line 16, in run_build_method
    conanfile.build()
  File "/home/user/my-conan-index/.local/env/.conan/data/boost/1.91.0/user/remote/export/conanfile.py", line 1166, in build
    self._create_user_config_jam(self._boost_build_dir)
  File "/home/user/conan-index/.local/env/.conan/data/boost/1.91.0/user/remote/export/conanfile.py", line 1591, in _create_user_config_jam
    contents += f'\nusing "{self._toolset}" : {self._toolset_version} : '
                                               ^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/my-conan-index/.local/env/.conan/data/boost/1.91.0/user/remote/export/conanfile.py", line 1653, in _toolset_version
    toolset = MSBuildToolchain(self).toolset
              ^^^^^^^^^^^^^^^^^^^^^^
  File "/var/work/my-conan-index/.pyenv/lib/python3.12/site-packages/conan/tools/microsoft/toolchain.py", line 55, in __init__
    self.runtime_library = self._runtime_library(conanfile.settings)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/work/my-conan-index/.pyenv/lib/python3.12/site-packages/conan/tools/microsoft/toolchain.py", line 89, in _runtime_library
    if compiler == "msvc" or compiler == "intel-cc":
                             ^^^^^^^^^^^^^^^^^^^^^^
  File "/var/work/my-conan-index/.pyenv/lib/python3.12/site-packages/conans/model/settings.py", line 99, in __eq__
    raise ConanException(bad_value_msg(self._name, other, self.values_range))
conans.errors.ConanException: Invalid setting 'intel-cc' is not a valid 'settings.compiler' value.
Possible values are ['Visual Studio', 'apple-clang', 'clang', 'gcc', 'msvc']
Read "http://docs.conan.io/en/latest/faq/troubleshooting.html#error-invalid-setting"
```

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
