### PR TITLE
lightpcapng: Add version cci.20260618

### DIFF
--- a/recipes/lightpcapng/all/conandata.yml
+++ b/recipes/lightpcapng/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "cci.20211005":
-    url: "https://github.com/Technica-Engineering/LightPcapNg/archive/58b8dd687bd462aba9d6e6d8a46209f0d1236213.zip"
-    sha256: 3634a2840f7bf43ebb293a9fbdfe0619ab7f233f9f774aac54b058dd5ab1320b
+  "cci.20260618":
+    url: "https://github.com/Technica-Engineering/LightPcapNg/archive/b36c701a2b4f48714e9c23a993c2758717c84123.zip"
+    sha256: 9b686145a4fed61e99afcda0d553c464243b75aa4964b60c4b8124c1fd683751

--- a/recipes/lightpcapng/all/conanfile.py
+++ b/recipes/lightpcapng/all/conanfile.py
@@ -51,7 +51,7 @@ class LightPcapNgConan(ConanFile):
         if self.options.with_zstd:
             self.requires("zstd/1.5.5")
         if self.options.with_zlib:
-            self.requires("zlib/1.3.2")
+            self.requires("zlib/[>=1.2.11 <2]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/lightpcapng/all/conanfile.py
+++ b/recipes/lightpcapng/all/conanfile.py
@@ -21,11 +21,13 @@ class LightPcapNgConan(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "with_zstd": [True, False],
+        "with_zlib": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "with_zstd": True,
+        "with_zlib": False,
     }
 
     def config_options(self):
@@ -35,6 +37,8 @@ class LightPcapNgConan(ConanFile):
     def configure(self):
         if self.options.with_zstd:
             self.options["zstd"].shared = self.options.shared
+        if self.options.with_zlib:
+            self.options["zlib"].shared = self.options.shared
         self.settings.rm_safe("compiler.libcxx")
         self.settings.rm_safe("compiler.cppstd")
         if self.options.shared:
@@ -46,6 +50,8 @@ class LightPcapNgConan(ConanFile):
     def requirements(self):
         if self.options.with_zstd:
             self.requires("zstd/1.5.5")
+        if self.options.with_zlib:
+            self.requires("zlib/1.3.2")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -53,6 +59,7 @@ class LightPcapNgConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.variables["LIGHT_USE_ZSTD"] = self.options.with_zstd
+        tc.variables["LIGHT_USE_ZLIB"] = self.options.with_zlib
         tc.variables["BUILD_TESTING"] = False
         tc.generate()
         tc = CMakeDeps(self)
@@ -75,10 +82,6 @@ class LightPcapNgConan(ConanFile):
         self.cpp_info.set_property("cmake_target_name", "light_pcapng::light_pcapng")
         self.cpp_info.components["liblight_pcapng"].libs = ["light_pcapng"]
         if self.options.with_zstd:
-            self.cpp_info.components["liblight_pcapng"].requires = ["zstd::zstd"]
-
-        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
-        self.cpp_info.names["cmake_find_package"] = "light_pcapng"
-        self.cpp_info.names["cmake_find_package_multi"] = "light_pcapng"
-        self.cpp_info.components["liblight_pcapng"].names["cmake_find_package"] = "light_pcapng"
-        self.cpp_info.components["liblight_pcapng"].names["cmake_find_package_multi"] = "light_pcapng"
+            self.cpp_info.components["liblight_pcapng"].requires.append("zstd::zstd")
+        if self.options.with_zlib:
+            self.cpp_info.components["liblight_pcapng"].requires.append("zlib::zlib")

--- a/recipes/lightpcapng/config.yml
+++ b/recipes/lightpcapng/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "cci.20211005":
+  "cci.20260618":
     folder: "all"


### PR DESCRIPTION
### Summary
Changes to recipe:  **lightpcapng/cci.20260618**
* update upstream version to cci.20260618

#### Motivation
* contains fix for C1017 error which enables use with latest MSVC setups 

#### Details
* based on upstream commit b36c701a2b4f48714e9c23a993c2758717c84123
* add use_zlib option for new LIGHT_USE_ZLIB option
* remove Conan 1.x todo from conanfile
* stop publishing old cci.20211005 version 
* diff of build related changes: https://github.com/Technica-Engineering/LightPcapNg/compare/58b8dd687bd462aba9d6e6d8a46209f0d1236213..b36c701a2b4f48714e9c23a993c2758717c84123#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a 

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
