### PR TITLE
pugixml: Add version 1.16

### DIFF
--- a/recipes/pugixml/all/conandata.yml
+++ b/recipes/pugixml/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.16":
+    url: "https://github.com/zeux/pugixml/releases/download/v1.16/pugixml-1.16.tar.gz"
+    sha256: "4cee1ca4aad395170f4c7a07824f3bdd41f28316c6e1e1090a1425b278ec0b4b"
   "1.15":
     url: "https://github.com/zeux/pugixml/releases/download/v1.15/pugixml-1.15.tar.gz"
     sha256: "655ade57fa703fb421c2eb9a0113b5064bddb145d415dd1f88c79353d90d511a"

--- a/recipes/pugixml/all/conandata.yml
+++ b/recipes/pugixml/all/conandata.yml
@@ -11,12 +11,3 @@ sources:
   "1.13":
     url: "https://github.com/zeux/pugixml/releases/download/v1.13/pugixml-1.13.tar.gz"
     sha256: "40c0b3914ec131485640fa57e55bf1136446026b41db91c1bef678186a12abbe"
-  "1.12.1":
-    url: "https://github.com/zeux/pugixml/releases/download/v1.12.1/pugixml-1.12.1.tar.gz"
-    sha256: "dcf671a919cc4051210f08ffd3edf9e4247f79ad583c61577a13ee93af33afc7"
-  "1.11":
-    url: "https://github.com/zeux/pugixml/releases/download/v1.11/pugixml-1.11.tar.gz"
-    sha256: "26913d3e63b9c07431401cf826df17ed832a20d19333d043991e611d23beaa2c"
-  "1.10":
-    url: "https://github.com/zeux/pugixml/releases/download/v1.10/pugixml-1.10.tar.gz"
-    sha256: "55f399fbb470942410d348584dc953bcaec926415d3462f471ef350f29b5870a"

--- a/recipes/pugixml/all/conanfile.py
+++ b/recipes/pugixml/all/conanfile.py
@@ -7,7 +7,7 @@ from conan.tools.layout import basic_layout
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.54.0"
+required_conan_version = ">=2"
 
 
 class PugiXmlConan(ConanFile):
@@ -40,6 +40,8 @@ class PugiXmlConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+        if Version(self.version) < "1.16":
+            del self.options.charconv_float
 
     def configure(self):
         if self.options.shared or self.options.header_only:
@@ -61,12 +63,9 @@ class PugiXmlConan(ConanFile):
         if self.options.get_safe("shared") and self.options.wchar_mode:
             # The app crashes with error "The procedure entry point ... could not be located in the dynamic link library"
             raise ConanInvalidConfiguration("Combination of 'shared' and 'wchar_mode' options is not supported")
-        if self.options.get_safe("charconv_float", False):
+        if self.options.get_safe("charconv_float"):
             # PUGIXML_CHARCONV_FLOAT requires at least C++17
             check_min_cppstd(self, "17")
-            # and is only available since pugixml version 1.16
-            if Version(self.version) < "1.16":
-                raise ConanInvalidConfiguration("charconv_float option requires pugixml version 1.16 or higher")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -87,7 +86,7 @@ class PugiXmlConan(ConanFile):
                 replace_in_file(self, header_file, "// #define PUGIXML_WCHAR_MODE", "#define PUGIXML_WCHAR_MODE")
             if self.options.no_exceptions:
                 replace_in_file(self, header_file, "// #define PUGIXML_NO_EXCEPTIONS", "#define PUGIXML_NO_EXCEPTIONS")
-            if self.options.charconv_float:
+            if self.options.get_safe("charconv_float"):
                 replace_in_file(self, header_file, "// #define PUGIXML_CHARCONV_FLOAT", "#define PUGIXML_CHARCONV_FLOAT")
             cmake = CMake(self)
             cmake.configure()
@@ -119,7 +118,7 @@ class PugiXmlConan(ConanFile):
                 self.cpp_info.defines.append("PUGIXML_WCHAR_MODE")
             if self.options.no_exceptions:
                 self.cpp_info.defines.append("PUGIXML_NO_EXCEPTIONS")
-            if self.options.charconv_float:
+            if self.options.get_safe("charconv_float"):
                 self.cpp_info.defines.append("PUGIXML_CHARCONV_FLOAT")
             self.cpp_info.bindirs = []
             self.cpp_info.libdirs = []

--- a/recipes/pugixml/all/conanfile.py
+++ b/recipes/pugixml/all/conanfile.py
@@ -63,6 +63,8 @@ class PugiXmlConan(ConanFile):
         if self.options.get_safe("shared") and self.options.wchar_mode:
             # The app crashes with error "The procedure entry point ... could not be located in the dynamic link library"
             raise ConanInvalidConfiguration("Combination of 'shared' and 'wchar_mode' options is not supported")
+    
+    def validate_build(self):
         if self.options.get_safe("charconv_float"):
             # PUGIXML_CHARCONV_FLOAT requires at least C++17
             check_min_cppstd(self, "17")

--- a/recipes/pugixml/all/conanfile.py
+++ b/recipes/pugixml/all/conanfile.py
@@ -1,8 +1,10 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import collect_libs, copy, get, load, replace_in_file, rmdir, save
 from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.54.0"
@@ -24,6 +26,7 @@ class PugiXmlConan(ConanFile):
         "header_only": [True, False],
         "wchar_mode": [True, False],
         "no_exceptions": [True, False],
+        "charconv_float": [True, False],
     }
     default_options = {
         "shared": False,
@@ -31,6 +34,7 @@ class PugiXmlConan(ConanFile):
         "header_only": False,
         "wchar_mode": False,
         "no_exceptions": False,
+        "charconv_float": False,
     }
 
     def config_options(self):
@@ -57,6 +61,12 @@ class PugiXmlConan(ConanFile):
         if self.options.get_safe("shared") and self.options.wchar_mode:
             # The app crashes with error "The procedure entry point ... could not be located in the dynamic link library"
             raise ConanInvalidConfiguration("Combination of 'shared' and 'wchar_mode' options is not supported")
+        if self.options.get_safe("charconv_float", False):
+            # PUGIXML_CHARCONV_FLOAT requires at least C++17
+            check_min_cppstd(self, "17")
+            # and is only available since pugixml version 1.16
+            if Version(self.version) < "1.16":
+                raise ConanInvalidConfiguration("charconv_float option requires pugixml version 1.16 or higher")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -77,6 +87,8 @@ class PugiXmlConan(ConanFile):
                 replace_in_file(self, header_file, "// #define PUGIXML_WCHAR_MODE", "#define PUGIXML_WCHAR_MODE")
             if self.options.no_exceptions:
                 replace_in_file(self, header_file, "// #define PUGIXML_NO_EXCEPTIONS", "#define PUGIXML_NO_EXCEPTIONS")
+            if self.options.charconv_float:
+                replace_in_file(self, header_file, "// #define PUGIXML_CHARCONV_FLOAT", "#define PUGIXML_CHARCONV_FLOAT")
             cmake = CMake(self)
             cmake.configure()
             cmake.build()
@@ -107,6 +119,8 @@ class PugiXmlConan(ConanFile):
                 self.cpp_info.defines.append("PUGIXML_WCHAR_MODE")
             if self.options.no_exceptions:
                 self.cpp_info.defines.append("PUGIXML_NO_EXCEPTIONS")
+            if self.options.charconv_float:
+                self.cpp_info.defines.append("PUGIXML_CHARCONV_FLOAT")
             self.cpp_info.bindirs = []
             self.cpp_info.libdirs = []
         else:

--- a/recipes/pugixml/all/test_package/CMakeLists.txt
+++ b/recipes/pugixml/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES CXX)
 
 find_package(pugixml REQUIRED CONFIG)

--- a/recipes/pugixml/config.yml
+++ b/recipes/pugixml/config.yml
@@ -7,9 +7,3 @@ versions:
     folder: "all"
   "1.13":
     folder: "all"
-  "1.12.1":
-    folder: "all"
-  "1.11":
-    folder: "all"
-  "1.10":
-    folder: "all"

--- a/recipes/pugixml/config.yml
+++ b/recipes/pugixml/config.yml
@@ -1,4 +1,4 @@
-versions:  
+versions:
   "1.16":
     folder: "all"
   "1.15":

--- a/recipes/pugixml/config.yml
+++ b/recipes/pugixml/config.yml
@@ -1,4 +1,6 @@
-versions:
+versions:  
+  "1.16":
+    folder: "all"
   "1.15":
     folder: "all"
   "1.14":


### PR DESCRIPTION
### Summary
Changes to recipe:  **pugixml/1.16**
* add version 1.16

#### Motivation
* add cmake 4 compatibility
* get latest pugixml version (performance improvements)

#### Details
* add pugixml release 1.16
* add recipe option charconv_float for PUGIXML_CHARCONV_FLOAT
* update cmake_minimum_required in test package for CMake 4 compatibility
* build related changes: https://github.com/zeux/pugixml/compare/v1.15...v1.16#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20a (new PUGIXML_INSTALL_SOURCE option is not used by recipe)


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
