### PR TITLE
intrusive_shared_ptr: publish version 1.13

### DIFF
--- a/recipes/intrusive_shared_ptr/all/conandata.yml
+++ b/recipes/intrusive_shared_ptr/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "1.12":
-    url: "https://github.com/gershnik/intrusive_shared_ptr/archive/refs/tags/v1.12.tar.gz"
-    sha256: "be687c721c223a98632d6b0d0faa6cd232a8fbc19058c24d41f72c8c1d43a24b"
+  "1.13":
+    url: "https://github.com/gershnik/intrusive_shared_ptr/archive/refs/tags/v1.13.tar.gz"
+    sha256: "8fdad3b3e3ca1477421e0035e3aaa08986abca34e737fb30125e2c78f4ecd363"

--- a/recipes/intrusive_shared_ptr/all/conanfile.py
+++ b/recipes/intrusive_shared_ptr/all/conanfile.py
@@ -2,10 +2,9 @@ from pathlib import Path
 
 from conan import ConanFile
 from conan.tools.layout import basic_layout
-from conan.tools.files import get, copy, replace_in_file, rm, rmdir
+from conan.tools.files import get, copy, rm, rmdir
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake
-import os
 
 required_conan_version = ">=2.1"
 
@@ -38,21 +37,18 @@ class IsptrRecipe(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
-        replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
-                        "add_subdirectory(test)",
-                        "# add_subdirectory(test)")
 
     def build(self):
         cmake = CMake(self)
-        cmake.configure()
+        cmake.configure(variables={"BUILD_TESTING": "OFF"})
         cmake.build()
 
     def package(self):
         copy(self, pattern="LICENSE.txt", src=self.source_folder, dst=Path(self.package_folder) / "licenses")
         cmake = CMake(self)
         cmake.install()
-        rmdir(self, Path(self.package_folder) / "share")
-        rm(self, "*.cmake", Path(self.package_folder) / "lib" / "isptr")
+        rm(self, "*.cmake", Path(self.package_folder) / "share" / "isptr")
+        rmdir(self, Path(self.package_folder) / "share" / "pkgconfig")
 
     def package_info(self):
         self.cpp_info.bindirs = []

--- a/recipes/intrusive_shared_ptr/all/conanfile.py
+++ b/recipes/intrusive_shared_ptr/all/conanfile.py
@@ -4,7 +4,7 @@ from conan import ConanFile
 from conan.tools.layout import basic_layout
 from conan.tools.files import get, copy, rm, rmdir
 from conan.tools.build import check_min_cppstd
-from conan.tools.cmake import CMake
+from conan.tools.cmake import CMake, CMakeToolchain
 
 required_conan_version = ">=2.1"
 
@@ -18,7 +18,6 @@ class IsptrRecipe(ConanFile):
     homepage = "https://github.com/gershnik/intrusive_shared_ptr"
     topics = ("smart-pointer", "intrusive", "header-only", "header-library")
 
-    generators = "CMakeToolchain"
     settings = "os", "arch", "build_type", "compiler"
     package_type = "header-library"
     no_copy_source = True
@@ -37,10 +36,15 @@ class IsptrRecipe(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+    
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.cache_variables["BUILD_TESTING"] = False
+        tc.generate()
 
     def build(self):
         cmake = CMake(self)
-        cmake.configure(variables={"BUILD_TESTING": "OFF"})
+        cmake.configure()
         cmake.build()
 
     def package(self):

--- a/recipes/intrusive_shared_ptr/config.yml
+++ b/recipes/intrusive_shared_ptr/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.12":
+  "1.13":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **intrusive_shared_ptr/1.13**

#### Motivation
Updating to the latest upstream

#### Details
* Upstream now supports `BUILD_TESTING` - conanfile is adjusted to make use of it and not remove the test folders
* Upstream now installs CMake and pkgconfig files in \<prefix\>/share rather than \<prefix\>/lib - conanfile is adjusted accordingly.

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
