### PR TITLE
typecast-c: add version 1.2.6

### DIFF
--- a/recipes/typecast-c/all/conandata.yml
+++ b/recipes/typecast-c/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.2.6":
+    url: "https://github.com/neosapience/typecast-sdk/archive/refs/tags/typecast-c/v1.2.6.tar.gz"
+    sha256: "d79ac2ea6119b21330f271667a8199b291256ad4ed3869dd1cd9bf38c014ca9f"
   "1.1.0":
     url: "https://github.com/neosapience/typecast-sdk/archive/refs/tags/v1.1.0.tar.gz"
     sha256: "0254a9c7931b92c809db3bf77b2d1eb08ea7f3ec7a9091ad9aaaac0d5834044e"

--- a/recipes/typecast-c/config.yml
+++ b/recipes/typecast-c/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.2.6":
+    folder: all
   "1.1.0":
     folder: all


### PR DESCRIPTION
This adds typecast-c/1.2.6 using the upstream typecast-c/v1.2.6 tag.

Validation:
- conan create recipes/typecast-c/all --version=1.2.6 --build=missing
- test_package completed: Typecast SDK version: 1.2.6