### PR TITLE
openjph: Add version 0.30.1

### DIFF
--- a/recipes/openjph/all/conandata.yml
+++ b/recipes/openjph/all/conandata.yml
@@ -1,9 +1,9 @@
 sources:
-  "0.27.0":
-    url: "https://github.com/aous72/OpenJPH/archive/0.27.0.tar.gz"
-    sha256: "f6768e927d8e4e4884a2efcf500a88d1b6714a48d69516332a9256803a3c8343"
+  "0.30.1":
+    url: "https://github.com/aous72/OpenJPH/archive/refs/tags/0.30.1.tar.gz"
+    sha256: "fb3ccf71af838ed2a42c6ea669308a2adaba115ae9d5862dfb1e2865b43eb5b8"
 patches:
-  "0.27.0":
-    - patch_file: "patches/0.27.0-cmake-cxx-standard-pic.patch"
+  "0.30.1":
+    - patch_file: "patches/0.30.1-cmake-cxx-standard-pic.patch"
       patch_description: "Remove setting of CXX standard to a fixed value overriding the toolchain provided by Conan and PIC hardcoded option"
       patch_type: "conan"

--- a/recipes/openjph/all/patches/0.30.1-cmake-cxx-standard-pic.patch
+++ b/recipes/openjph/all/patches/0.30.1-cmake-cxx-standard-pic.patch
@@ -1,13 +1,13 @@
 diff --git src/core/CMakeLists.txt src/core/CMakeLists.txt
-index ea19aea..132a619 100644
+index 298ca17..6c87ea0 100644
 --- src/core/CMakeLists.txt
 +++ src/core/CMakeLists.txt
-@@ -135,7 +135,7 @@ if (BUILD_SHARED_LIBS AND WIN32)
+@@ -156,7 +156,7 @@ if (BUILD_SHARED_LIBS AND WIN32)
  endif()
  
  ## include library version/name
 -set_target_properties(openjph PROPERTIES POSITION_INDEPENDENT_CODE ON)
 +#set_target_properties(openjph PROPERTIES POSITION_INDEPENDENT_CODE ON)
  target_compile_definitions(openjph PUBLIC _FILE_OFFSET_BITS=64)
- target_include_directories(openjph PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/openjph> $<INSTALL_INTERFACE:include>)
- 
+ target_include_directories(openjph PUBLIC
+   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/openjph>

--- a/recipes/openjph/config.yml
+++ b/recipes/openjph/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.27.0":
+  "0.30.1":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **openjph/0.30.1**

#### Motivation
Number of fixes & improvements since the last version we supply. (Including security fixes, UB, new architecture support. Speed improvements.)

#### Details
* https://github.com/aous72/OpenJPH/releases/tag/0.30.1
* https://github.com/aous72/OpenJPH/compare/0.27.0...0.30.1

Point from the changelog that I'm curious about but not sure if problematic:
If OJPH_DISABLE_SIMD is not set, on PowerPC 64 LE it will force `-mcpu=power9` which I guess could 

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
