### PR TITLE
feat: add libodb 2.5.0 recipe

### DIFF
--- a/recipes/libodb/all/conandata.yml
+++ b/recipes/libodb/all/conandata.yml
@@ -1,0 +1,8 @@
+sources:
+  "2.5.0":
+    libodb:
+      url: "https://www.codesynthesis.com/download/odb/2.5.0/libodb-2.5.0.tar.gz"
+      sha256: "700038a73c6cbead011129b15030b7cdd3f73510b687f2c4504808df4230441b"
+    build2_toolchain:
+      url: "https://download.build2.org/0.18.1/build2-toolchain-0.18.1.tar.gz"
+      sha256: "23b1719f1d8d1ef1957c2b28bc12177aa70d23d73de79889c2f5041d293692bc"

--- a/recipes/libodb/all/conanfile.py
+++ b/recipes/libodb/all/conanfile.py
@@ -1,0 +1,234 @@
+import os
+import shutil
+import stat
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import build_jobs, check_min_cppstd
+from conan.tools.files import copy, get, rm
+from conan.tools.layout import basic_layout
+
+required_conan_version = ">=2.0.9"
+
+
+class LibOdbConan(ConanFile):
+    name = "libodb"
+    description = (
+        "ODB is an open-source, cross-platform, and cross-database "
+        "object-relational mapping (ORM) system for C++."
+    )
+    license = "GPL-2.0-only"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://www.codesynthesis.com/products/odb/"
+    topics = ("odb", "orm", "database", "c++")
+    package_type = "library"
+
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    implements = ["auto_shared_fpic"]
+
+    _b2_src = "build2-toolchain-src"
+    _odb_src = "libodb-src"
+    _b_bin = "b-bin"
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def validate(self):
+        if str(self.settings.os) not in ("Windows", "Linux", "Macos"):
+            raise ConanInvalidConfiguration(
+                f"{self.ref} supports only Windows, Linux and macOS"
+            )
+        if str(self.settings.arch) not in ("x86_64", "armv8"):
+            raise ConanInvalidConfiguration(
+                f"{self.ref} supports only x86_64 and armv8"
+            )
+        if self.settings.get_safe("compiler.cppstd"):
+            check_min_cppstd(self, 11)
+
+    def source(self):
+        src_data = self.conan_data["sources"][self.version]
+        get(
+            self,
+            **src_data["libodb"],
+            strip_root=True,
+            destination=self._odb_source_dir,
+        )
+        get(
+            self,
+            **src_data["build2_toolchain"],
+            strip_root=True,
+            destination=self._build2_source_dir,
+        )
+
+    @property
+    def _build2_source_dir(self):
+        return os.path.join(self.source_folder, self._b2_src)
+
+    @property
+    def _odb_source_dir(self):
+        return os.path.join(self.source_folder, self._odb_src)
+
+    def _exe_suffix(self):
+        return ".exe" if str(self.settings.os) == "Windows" else ""
+
+    def _b_exe(self):
+        return os.path.join(self.source_folder, self._b_bin, "bin", f"b{self._exe_suffix()}")
+
+    def _cxx_exe(self):
+        compiler = str(self.settings.compiler)
+        version = str(self.settings.compiler.version)
+        os_ = str(self.settings.os)
+
+        if compiler == "msvc":
+            return "cl"
+        if compiler == "gcc":
+            return "g++" if os_ == "Windows" else f"g++-{version}"
+        if compiler == "clang":
+            return f"clang++-{version}"
+        if compiler == "apple-clang":
+            return "clang++"
+        return "c++"
+
+    def _is_msvc(self):
+        return str(self.settings.compiler) == "msvc"
+
+    @staticmethod
+    def _find_first_existing(candidates):
+        for path in candidates:
+            if os.path.isfile(path):
+                return path
+        return None
+
+    def _make_executable(self, path):
+        if str(self.settings.os) != "Windows":
+            os.chmod(path, os.stat(path).st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+    def _bootstrap_build2(self):
+        b2_pkg = os.path.join(self._build2_source_dir, "build2")
+        exe_sfx = self._exe_suffix()
+        cxx = self._cxx_exe()
+
+        if self._is_msvc():
+            self.run(f"bootstrap-msvc.bat {cxx} /w", cwd=b2_pkg)
+        else:
+            bootstrap = os.path.join(b2_pkg, "bootstrap.sh")
+            self._make_executable(bootstrap)
+            self.run(f"./bootstrap.sh {cxx} -w", cwd=b2_pkg)
+
+        old_boot = os.path.join(b2_pkg, "build2", f"b-boot{exe_sfx}")
+        new_boot = os.path.join(b2_pkg, "b", f"b-boot{exe_sfx}")
+        b_boot = self._find_first_existing([old_boot, new_boot])
+
+        if not b_boot:
+            raise ConanInvalidConfiguration(
+                f"Could not find build2 bootstrap executable after phase 1 in {b2_pkg}"
+            )
+
+        if b_boot == new_boot:
+            b_target = "b/exe{b}"
+            b_full_candidates = [os.path.join(b2_pkg, "b", f"b{exe_sfx}")]
+        else:
+            b_target = "build2/exe{b}"
+            b_full_candidates = [os.path.join(b2_pkg, "build2", f"b{exe_sfx}")]
+
+        self.output.info(f"Using build2 bootstrap executable: {b_boot}")
+        self.output.info(f"Using build2 rebuild target: {b_target}")
+
+        self.run(
+            f'"{b_boot}" config.cxx={cxx} config.bin.lib=static {b_target}',
+            cwd=b2_pkg,
+        )
+
+        b_full = self._find_first_existing(b_full_candidates)
+        if not b_full:
+            raise ConanInvalidConfiguration(
+                f"Could not find final build2 executable after phase 2 in {b2_pkg}"
+            )
+
+        self.output.info(f"Using final build2 executable: {b_full}")
+
+        b_bin_dir = os.path.join(self.source_folder, self._b_bin, "bin")
+        os.makedirs(b_bin_dir, exist_ok=True)
+
+        b_final = os.path.join(b_bin_dir, f"b{exe_sfx}")
+        shutil.copy2(b_full, b_final)
+        self._make_executable(b_final)
+
+    def _build_args(self):
+        args = []
+        debug = str(self.settings.build_type) in ("Debug", "RelWithDebInfo")
+        jobs = build_jobs(self)
+
+        if jobs > 1:
+            args.append(f"-j {jobs}")
+
+        args.extend([
+            f"config.cxx={self._cxx_exe()}",
+            "config.cxx.std=c++11",
+            f"config.bin.debug={'true' if debug else 'false'}",
+            f"config.bin.lib={'shared' if self.options.shared else 'static'}",
+        ])
+
+        if not self.options.shared and self.options.get_safe("fPIC") and not self._is_msvc():
+            args.append("config.cc.coptions+=-fPIC")
+
+        return args
+
+    def build(self):
+        self._bootstrap_build2()
+        args = " ".join(self._build_args())
+        self.run(f'"{self._b_exe()}" {args} ./odb/', cwd=self._odb_source_dir)
+
+    def _copy_headers(self):
+        src = os.path.join(self._odb_source_dir, "odb")
+        dst = os.path.join(self.package_folder, "include", "odb")
+        for pattern in ("*.hxx", "*.ixx", "*.txx", "*.h"):
+            copy(self, pattern, src, dst)
+
+    def _copy_libraries(self):
+        lib_dir = os.path.join(self.package_folder, "lib")
+        bin_dir = os.path.join(self.package_folder, "bin")
+
+        if self.options.shared:
+            copy(self, "*.dll", self._odb_source_dir, bin_dir, keep_path=False)
+            copy(self, "*.so*", self._odb_source_dir, lib_dir, keep_path=False)
+            copy(self, "*.dylib", self._odb_source_dir, lib_dir, keep_path=False)
+            copy(self, "*.lib", self._odb_source_dir, lib_dir, keep_path=False)
+        else:
+            copy(self, "*.a", self._odb_source_dir, lib_dir, keep_path=False)
+            copy(self, "*.lib", self._odb_source_dir, lib_dir, keep_path=False)
+
+    def package(self):
+        self._copy_headers()
+        self._copy_libraries()
+        copy(
+            self,
+            "LICENSE",
+            self._odb_source_dir,
+            os.path.join(self.package_folder, "licenses"),
+            keep_path=False,
+        )
+        rm(self, "*.pdb", self.package_folder, recursive=True)
+
+    def package_info(self):
+        self.cpp_info.libs = ["odb"]
+        self.cpp_info.set_property("cmake_file_name", "libodb")
+        self.cpp_info.set_property("cmake_target_name", "libodb::libodb")
+        self.cpp_info.set_property("pkg_config_name", "libodb")
+
+        if not self.options.shared:
+            self.cpp_info.defines.append("LIBODB_STATIC")
+
+        if str(self.settings.os) == "Linux":
+            self.cpp_info.system_libs.append("pthread")
+        elif str(self.settings.os) == "Windows":
+            self.cpp_info.system_libs.append("ws2_32")

--- a/recipes/libodb/all/test_package/CMakeLists.txt
+++ b/recipes/libodb/all/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(libodb REQUIRED CONFIG)
+
+add_executable(test_package test_package.cpp)
+target_link_libraries(test_package PRIVATE libodb::libodb)

--- a/recipes/libodb/all/test_package/conanfile.py
+++ b/recipes/libodb/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            import os
+            cmd = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(cmd, env="conanrun")

--- a/recipes/libodb/all/test_package/test_package.cpp
+++ b/recipes/libodb/all/test_package/test_package.cpp
@@ -1,0 +1,18 @@
+#include <odb/version.hxx>
+#include <odb/exception.hxx>
+#include <odb/database.hxx>
+
+#include <cassert>
+#include <iostream>
+
+int main()
+{
+    unsigned int maj = ODB_VERSION / 100000;
+    unsigned int min = (ODB_VERSION / 1000) % 100;
+
+    std::cout << "libodb version: " << maj << "." << min << std::endl;
+
+    assert(maj == 2);
+
+    return 0;
+}

--- a/recipes/libodb/config.yml
+++ b/recipes/libodb/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.5.0":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe: **libodb/2.5.0**

#### Motivation
Add a new ConanCenter recipe for ODB, an open-source C++ ORM library.

#### Details
- Added a new recipe for `libodb/2.5.0`.
- Implemented build and packaging using the upstream build2-based build flow.
- Added options for `shared` and `fPIC`.
- Added package metadata for CMake and pkg-config generators.
- Added a `test_package` to validate the package.

Local and CI testing:
- Tested locally with Conan 2.
- Tested in GitHub Actions using a build matrix across Linux, Windows, and macOS.
- The GitHub Actions matrix covered `x86_64` and `arm64` targets, with both `shared=True` and `shared=False` configurations.
- The workflow used separate runners for Linux, Windows, and macOS builds and executed `conan create` for the recipe in each job.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan
---