### PR TITLE
[Qt6] Fix windows builds for 6.11 (latest) version

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -840,6 +840,10 @@ class QtConan(ConanFile):
     def _cmake_platform_target_setup_file(self):
         return os.path.join("lib", "cmake", "Qt6", "conan_qt_platform_target_setup.cmake")
 
+    @property
+    def _cmake_config_file(self):
+        return os.path.join("lib", "cmake", "Qt6", "conan_qt_config.cmake")
+
     def _cmake_qt6_private_file(self, module):
         return os.path.join("lib", "cmake", f"Qt6{module}", f"conan_qt_qt6_{module.lower()}private.cmake")
 
@@ -1032,6 +1036,28 @@ class QtConan(ConanFile):
                         INTERFACE "$<${no_unicode_condition}:UNICODE$<SEMICOLON>_UNICODE>")
                 endif()""")
             save(self, os.path.join(self.package_folder, self._cmake_platform_target_setup_file), contents)
+
+        # additional config options
+        # taken from https://github.com/qt/qtbase/blob/6.11.1/cmake/QtConfig.cmake.in#L66-L84
+        # fixes https://github.com/conan-io/conan-center-index/issues/30474
+        contents = textwrap.dedent("""\
+            get_filename_component(_qt_import_prefix "${CMAKE_CURRENT_LIST_FILE}" PATH)
+            get_filename_component(_qt_import_prefix "${_qt_import_prefix}" REALPATH)
+
+            if(APPLE)
+                if(NOT CMAKE_SYSTEM_NAME OR CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+                    set(__qt_internal_cmake_apple_support_files_path "${_qt_import_prefix}/macos")
+                elseif(CMAKE_SYSTEM_NAME STREQUAL "iOS")
+                    set(__qt_internal_cmake_apple_support_files_path "${_qt_import_prefix}/ios")
+                elseif(CMAKE_SYSTEM_NAME STREQUAL "visionOS")
+                    set(__qt_internal_cmake_apple_support_files_path "${_qt_import_prefix}/visionos")
+                endif()
+            endif()
+
+            if(WIN32)
+                set(__qt_internal_cmake_windows_support_files_path "${_qt_import_prefix}/windows")
+            endif()""")
+        save(self, os.path.join(self.package_folder, self._cmake_config_file), contents)
 
     def package_info(self):
         disabled_features = str(self.options.disabled_features).split()
@@ -1675,6 +1701,7 @@ class QtConan(ConanFile):
 
         build_modules_list = [
             os.path.join(self.package_folder, "lib", "cmake", "Qt6", "QtInstallPaths.cmake"),
+            self._cmake_config_file
         ]
 
         if self.options.qtdeclarative:

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -1673,7 +1673,9 @@ class QtConan(ConanFile):
                     self.cpp_info.components[component].exelinkflags.extend(obj_files)
                     self.cpp_info.components[component].sharedlinkflags.extend(obj_files)
 
-        build_modules_list = []
+        build_modules_list = [
+            os.path.join(self.package_folder, "lib", "cmake", "Qt6", "QtInstallPaths.cmake"),
+        ]
 
         if self.options.qtdeclarative:
             build_modules_list.append(os.path.join(self.package_folder, "lib", "cmake", "Qt6Qml", "conan_qt_qt6_policies.cmake"))

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -840,10 +840,6 @@ class QtConan(ConanFile):
     def _cmake_platform_target_setup_file(self):
         return os.path.join("lib", "cmake", "Qt6", "conan_qt_platform_target_setup.cmake")
 
-    @property
-    def _cmake_config_file(self):
-        return os.path.join("lib", "cmake", "Qt6", "conan_qt_config.cmake")
-
     def _cmake_qt6_private_file(self, module):
         return os.path.join("lib", "cmake", f"Qt6{module}", f"conan_qt_qt6_{module.lower()}private.cmake")
 
@@ -890,6 +886,8 @@ class QtConan(ConanFile):
         filecontents += f"set(QT_VERSION_PATCH {ver.patch})\n"
         if self.settings.os == "Macos":
             filecontents += 'set(__qt_internal_cmake_apple_support_files_path "${CMAKE_CURRENT_LIST_DIR}/../../../lib/cmake/Qt6/macos")\n'
+        if self.settings.os == "Windows":
+            filecontents += 'set(__qt_internal_cmake_windows_support_files_path "${CMAKE_CURRENT_LIST_DIR}/../../../lib/cmake/Qt6/windows")\n'
         targets = ["moc", "qlalr", "rcc", "tracegen", "cmake_automoc_parser", "qmake", "qtpaths", "syncqt", "tracepointgen"]
         disabled_features = str(self.options.disabled_features).split()
         if self.options.with_dbus:
@@ -1036,28 +1034,6 @@ class QtConan(ConanFile):
                         INTERFACE "$<${no_unicode_condition}:UNICODE$<SEMICOLON>_UNICODE>")
                 endif()""")
             save(self, os.path.join(self.package_folder, self._cmake_platform_target_setup_file), contents)
-
-        # additional config options
-        # taken from https://github.com/qt/qtbase/blob/6.11.1/cmake/QtConfig.cmake.in#L66-L84
-        # fixes https://github.com/conan-io/conan-center-index/issues/30474
-        contents = textwrap.dedent("""\
-            get_filename_component(_qt_import_prefix "${CMAKE_CURRENT_LIST_FILE}" PATH)
-            get_filename_component(_qt_import_prefix "${_qt_import_prefix}" REALPATH)
-
-            if(APPLE)
-                if(NOT CMAKE_SYSTEM_NAME OR CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-                    set(__qt_internal_cmake_apple_support_files_path "${_qt_import_prefix}/macos")
-                elseif(CMAKE_SYSTEM_NAME STREQUAL "iOS")
-                    set(__qt_internal_cmake_apple_support_files_path "${_qt_import_prefix}/ios")
-                elseif(CMAKE_SYSTEM_NAME STREQUAL "visionOS")
-                    set(__qt_internal_cmake_apple_support_files_path "${_qt_import_prefix}/visionos")
-                endif()
-            endif()
-
-            if(WIN32)
-                set(__qt_internal_cmake_windows_support_files_path "${_qt_import_prefix}/windows")
-            endif()""")
-        save(self, os.path.join(self.package_folder, self._cmake_config_file), contents)
 
     def package_info(self):
         disabled_features = str(self.options.disabled_features).split()
@@ -1701,7 +1677,6 @@ class QtConan(ConanFile):
 
         build_modules_list = [
             os.path.join(self.package_folder, "lib", "cmake", "Qt6", "QtInstallPaths.cmake"),
-            self._cmake_config_file
         ]
 
         if self.options.qtdeclarative:

--- a/recipes/qt/6.x.x/test_package/CMakeLists.txt
+++ b/recipes/qt/6.x.x/test_package/CMakeLists.txt
@@ -3,16 +3,8 @@ project(test_package LANGUAGES CXX)
 
 find_package(Qt6 COMPONENTS Core Network Sql Concurrent Xml REQUIRED CONFIG)
 
-add_executable(${PROJECT_NAME} test_package.cpp greeter.h example.qrc)
+qt_standard_project_setup()
+
+qt_add_executable(${PROJECT_NAME} WIN32 MACOSX_BUNDLE test_package.cpp greeter.h example.qrc)
 target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::Core Qt6::Network Qt6::Sql Qt6::Concurrent Qt6::Xml Qt6::Widgets)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
-set_target_properties(${PROJECT_NAME} PROPERTIES AUTOMOC ON AUTORCC ON)
-
-# Only running this Qt macros in macOS
-if (APPLE)
-    # Related to https://github.com/conan-io/conan-center-index/issues/20574
-    qt_standard_project_setup()
-    qt_add_executable(test_macos_bundle MACOSX_BUNDLE test_macos_bundle.cpp)
-    target_link_libraries(test_macos_bundle PRIVATE Qt6::Core)
-    target_compile_features(test_macos_bundle PRIVATE cxx_std_17)
-endif()

--- a/recipes/qt/6.x.x/test_package/CMakeLists.txt
+++ b/recipes/qt/6.x.x/test_package/CMakeLists.txt
@@ -5,6 +5,8 @@ find_package(Qt6 COMPONENTS Core Network Sql Concurrent Xml REQUIRED CONFIG)
 
 qt_standard_project_setup()
 
-qt_add_executable(${PROJECT_NAME} WIN32 MACOSX_BUNDLE test_package.cpp greeter.h example.qrc)
+qt_add_executable(${PROJECT_NAME} WIN32 MACOSX_BUNDLE test_package.cpp greeter.h)
 target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::Core Qt6::Network Qt6::Sql Qt6::Concurrent Qt6::Xml Qt6::Widgets)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+
+qt_add_resources(${PROJECT_NAME} "files" PREFIX "/" FILES "resource.txt")

--- a/recipes/qt/6.x.x/test_package/conanfile.py
+++ b/recipes/qt/6.x.x/test_package/conanfile.py
@@ -47,12 +47,13 @@ Prefix = {path}""")
     def test(self):
         if can_run(self):
             copy(self, "qt.conf", src=self.generators_folder, dst=os.path.join(self.cpp.build.bindirs[0]))
-            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
-            self.run(bin_path, env="conanrun")
-            # Related to https://github.com/conan-io/conan-center-index/issues/20574
-            if self.settings.os == "Macos":
-                bin_macos_path = os.path.join(self.cpp.build.bindirs[0], "test_package.app", "Contents", "MacOS", "test_package")
-                self.run(bin_macos_path, env="conanrun")
+
+            if self.settings.os != "Macos":
+                bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+                self.run(bin_path, env="conanrun")
+            else: # Related to https://github.com/conan-io/conan-center-index/issues/20574
+                bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package.app", "Contents", "MacOS", "test_package")
+                self.run(bin_path, env="conanrun")
 
         # Check that the directory exposed in the configuration exists and includes moc
         qt_tools_dir = self.dependencies.host["qt"].conf_info.get("user.qt:tools_directory")

--- a/recipes/qt/6.x.x/test_package/conanfile.py
+++ b/recipes/qt/6.x.x/test_package/conanfile.py
@@ -51,7 +51,7 @@ Prefix = {path}""")
             self.run(bin_path, env="conanrun")
             # Related to https://github.com/conan-io/conan-center-index/issues/20574
             if self.settings.os == "Macos":
-                bin_macos_path = os.path.join(self.cpp.build.bindirs[0], "test_macos_bundle.app", "Contents", "MacOS", "test_macos_bundle")
+                bin_macos_path = os.path.join(self.cpp.build.bindirs[0], "test_package.app", "Contents", "MacOS", "test_package")
                 self.run(bin_macos_path, env="conanrun")
 
         # Check that the directory exposed in the configuration exists and includes moc

--- a/recipes/qt/6.x.x/test_package/example.qrc
+++ b/recipes/qt/6.x.x/test_package/example.qrc
@@ -1,5 +1,0 @@
-<RCC>
-    <qresource>
-        <file>resource.txt</file>
-    </qresource>
-</RCC>

--- a/recipes/qt/6.x.x/test_package/test_macos_bundle.cpp
+++ b/recipes/qt/6.x.x/test_package/test_macos_bundle.cpp
@@ -1,7 +1,0 @@
-#include <QCoreApplication>
-
-int main(int argc, char *argv[])
-{
-    QCoreApplication app(argc, argv);
-    return 0;
- }

--- a/recipes/qt/6.x.x/test_package/test_package.cpp
+++ b/recipes/qt/6.x.x/test_package/test_package.cpp
@@ -16,7 +16,7 @@ int main(int argc, char *argv[]){
     QCoreApplication::setApplicationName("Application Example");
     QCoreApplication::setApplicationVersion("1.0.0");
 
-    QString name = argc > 0 ? argv[1] : "";
+    QString name = argc > 1 ? argv[1] : "";
     if (name.isEmpty()) {
         name = "World";
     }


### PR DESCRIPTION
### Summary
Changes to recipe:  **qt/6.11**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Latest Qt version/recipe doesn't work at all on Windows, see https://github.com/conan-io/conan-center-index/issues/30474.

This also fixes https://github.com/conan-io/conan-center-index/issues/30450.

Upstream: https://github.com/qt/qtbase/commit/4b0e7438ec89f1a6c6d7ed4688ebbb9c58c55ec3

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
1. Ported a recently introduced feature of [`QtConfig.cmake`](https://github.com/qt/qtbase/commit/00816f1ea26ddb95062bfdd41c90502817f55549#diff-3803651242a2a89e7d05534570044370fb82d363c691e9fef599f7322b5bf3eb) to the `CMakeDeps` generator.
2. Change `test_package/` to use Qt's CMake macros (e.g. `qt_add_executable`) to better verify functioning integration.

This is somewhat related to https://github.com/conan-io/conan-center-index/issues/20574 but for Windows.

#### Notes
~~Running `conan test` (or `conan create`) locally, fails for me with the following error. But it also does this already with `6.10.3` and `6.8.3`. The error code `3221226505`  (`NT: 0xc0000409 STATUS_STACK_BUFFER_OVERRUN`) is a bit interesting. However, running the program manually works just fine.~~

**UPDATE:** This (see notes above) has been fixed now. But as said, this seemed to be broken in prior versions as well. 🤔

<details>
<summary>conan test output</summary>

```
======== Testing the package: Executing test ========
qt/6.11.1 (test package): Running test()
qt/6.11.1 (test package): copy(pattern=qt.conf) copied 1 files
  from C:\Projects\conan-center-index\recipes\qt\6.x.x\test_package\build\msvc-194-x86_64-17-release\generators\
  to Release
  Files:
    qt.conf
qt/6.11.1 (test package): RUN: Release\test_package
qt/6.11.1 (test package): Full command: "C:\Projects\conan-center-index\recipes\qt\6.x.x\test_package\build\msvc-194-x86_64-17-release\generators\conanrun.bat" && Release\test_package

ERROR: Traceback (most recent call last):
  File "C:\Users\jdoubleu\AppData\Local\Programs\Python\Python312\Lib\site-packages\conan\internal\errors.py", line 35, in conanfile_exception_formatter
    yield
  File "C:\Users\jdoubleu\AppData\Local\Programs\Python\Python312\Lib\site-packages\conan\api\subapi\local.py", line 180, in test
    conanfile.test()
  File "C:\Projects\conan-center-index\recipes\qt\6.x.x\test_package\conanfile.py", line 51, in test
    self.run(bin_path, env="conanrun")
  File "C:\Users\jdoubleu\AppData\Local\Programs\Python\Python312\Lib\site-packages\conan\internal\model\conan_file.py", line 411, in run
    raise ConanException("Error %d while executing" % retcode)
conan.errors.ConanException: Error 3221226505 while executing

qt/6.11.1 (test package): Error in test() method, line 51
        self.run(bin_path, env="conanrun")
        ConanException: Error 3221226505 while executing
```

</details>

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
