### PR TITLE
[Arrow] Fix Windows static dataset/acero build

### DIFF
--- a/recipes/arrow/all/conanfile.py
+++ b/recipes/arrow/all/conanfile.py
@@ -470,6 +470,9 @@ class ArrowConan(ConanFile):
             if Version(self.version) >= "21.0.0" and self.options.compute:
                 # libacero depends on compute
                 self.cpp_info.components["libacero"].requires.append("libarrow_compute")
+            if not self.options.shared:
+                # arrow/acero/visibility.h checks ARROW_ACERO_STATIC
+                self.cpp_info.components["libacero"].defines = ["ARROW_ACERO_STATIC"]
 
         if Version(self.version) >= "21.0.0" and self.options.compute:
             self.cpp_info.components["libarrow_compute"].set_property("pkg_config_name", "arrow_compute")
@@ -501,11 +504,20 @@ class ArrowConan(ConanFile):
             self.cpp_info.components["libarrow_flight_sql"].requires = ["libarrow", "libarrow_flight"]
 
         if self.options.dataset_modules:
-            self.cpp_info.components["dataset"].libs = ["arrow_dataset"]
+            self.cpp_info.components["dataset"].set_property(
+                "cmake_target_name", f"ArrowDataset::arrow_dataset_{cmake_suffix}"
+            )
+            self.cpp_info.components["dataset"].libs = [f"arrow_dataset{suffix}"]
+            _dataset_requires = []
             if self.options.parquet:
-                self.cpp_info.components["dataset"].requires = ["libparquet"]
+                _dataset_requires.append("libparquet")
             if self.options.acero:
-                self.cpp_info.components["dataset"].requires = ["libacero"]
+                _dataset_requires.append("libacero")
+            if _dataset_requires:
+                self.cpp_info.components["dataset"].requires = _dataset_requires
+            if not self.options.shared:
+                # arrow/dataset/visibility.h checks ARROW_DS_STATIC
+                self.cpp_info.components["dataset"].defines = ["ARROW_DS_STATIC"]
 
         if self.options.with_boost:
             if self.options.gandiva:

--- a/recipes/arrow/all/conanfile.py
+++ b/recipes/arrow/all/conanfile.py
@@ -452,7 +452,7 @@ class ArrowConan(ConanFile):
 
         if self.options.get_safe("substrait"):
             self.cpp_info.components["libarrow_substrait"].set_property("pkg_config_name", "arrow_substrait")
-            self.cpp_info.components["libarrow_substrait"].set_property("cmake_target_name", f"Arrow::arrow_substrait_{cmake_suffix}")
+            self.cpp_info.components["libarrow_substrait"].set_property("cmake_target_name", f"ArrowSubstrait::arrow_substrait_{cmake_suffix}")
             self.cpp_info.components["libarrow_substrait"].libs = [f"arrow_substrait{suffix}"]
             self.cpp_info.components["libarrow_substrait"].requires = ["libparquet"]
             if self.options.dataset_modules:
@@ -479,6 +479,9 @@ class ArrowConan(ConanFile):
             self.cpp_info.components["libarrow_compute"].set_property("cmake_target_name", f"ArrowCompute::arrow_compute_{cmake_suffix}")
             self.cpp_info.components["libarrow_compute"].libs = [f"arrow_compute{suffix}"]
             self.cpp_info.components["libarrow_compute"].requires = ["libarrow"]
+            if not self.options.shared:
+                # arrow/compute/visibility.h checks ARROW_COMPUTE_STATIC
+                self.cpp_info.components["libarrow_compute"].defines = ["ARROW_COMPUTE_STATIC"]
 
         if self.options.gandiva:
             self.cpp_info.components["libgandiva"].set_property("pkg_config_name", "gandiva")


### PR DESCRIPTION
### Summary
Fix five bugs in package_info():
1. dataset libs missing _static suffix (arrow_dataset -> arrow_dataset_static)
2. dataset cmake_target_name not set
3. dataset requires list drops parquet when acero is also enabled
4. dataset static define wrong (ARROW_DATASET_STATIC -> ARROW_DS_STATIC)
5. acero missing ARROW_ACERO_STATIC define for static builds

#### Motivation
Fixes #30483 

#### Details
The issues caused by the bugs:
1. the dataset lib would not be found when using a static build by a consumer (e.g. PyArrow)
2. same as above
3. if acero is enabled, dataset misses required parquet component
4. Windows static build still tries to dll export dataset
5. Windows static build still tried to dll export acero


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
