### PR TITLE
[expat] Update expat recipe to support version 2.8.2

### DIFF
--- a/recipes/expat/all/conandata.yml
+++ b/recipes/expat/all/conandata.yml
@@ -1,10 +1,7 @@
 sources:
-  "2.8.1":
-    url: "https://github.com/libexpat/libexpat/releases/download/R_2_8_1/expat-2.8.1.tar.xz"
-    sha256: "10b195ee78160a908388180a8fe3603d4e9a12f4755fbf5f3816b23a9d750da0"
-  "2.8.0":
-    url: "https://github.com/libexpat/libexpat/releases/download/R_2_8_0/expat-2.8.0.tar.xz"
-    sha256: "a37bfae0aa9775bd8521ebd85dc456d486f0ff31138f6c91fd902ea732624542"
+  "2.8.2":
+    url: "https://github.com/libexpat/libexpat/releases/download/R_2_8_2/expat-2.8.2.tar.xz"
+    sha256: "3ad89b8588e6644bd4e49981480d48b21289eebbcd4f0a1a4afb1c29f99b6ab4"
   "2.7.5":
     url: "https://github.com/libexpat/libexpat/releases/download/R_2_7_5/expat-2.7.5.tar.xz"
     sha256: "1032dfef4ff17f70464827daa28369b20f6584d108bc36f17ab1676e1edd2f91"

--- a/recipes/expat/config.yml
+++ b/recipes/expat/config.yml
@@ -1,7 +1,5 @@
 versions:
-  "2.8.1":
-    folder: all
-  "2.8.0":
+  "2.8.2":
     folder: all
   "2.7.5":
     folder: all


### PR DESCRIPTION
Remove the other 2.8.x versions
expat 2.8.2 fixes 13 CVEs and a few other bugs.

[original changelog](https://github.com/libexpat/libexpat/blob/R_2_8_2/expat/Changes)

### Summary
Changes to recipe:  **expat/2.8.2**

#### Motivation

vulnerability mitigation

#### Details

tested on MacOS with various configurations

Close https://github.com/conan-io/conan-center-index/pull/30491

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
