### PR TITLE
ecbuild: add version 3.14.2

### DIFF
--- a/recipes/ecbuild/all/conandata.yml
+++ b/recipes/ecbuild/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "3.14.2":
+    url: "https://github.com/ecmwf/ecbuild/archive/refs/tags/3.14.2.tar.gz"
+    sha256: "319522426e0114dfe2050830c2fd9303d87101bbb2c65eb2356108664e7639f5"

--- a/recipes/ecbuild/all/conanfile.py
+++ b/recipes/ecbuild/all/conanfile.py
@@ -1,0 +1,56 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, rmdir
+from conan.tools.scm import Version
+import os
+
+required_conan_version = ">=1.53.0"
+
+class EcbuildConan(ConanFile):
+    name = "ecbuild"
+    description = "A build system built on top of CMake by ECMWF"
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/ecmwf/ecbuild"
+    topics = ("cmake", "build-system", "ecmwf", "build-tool")
+    
+    package_type = "application"
+    settings = "os", "arch", "compiler", "build_type"
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["ENABLE_TESTS"] = False
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        # Remove empty share/man/man1 directory if exists, etc. Or maybe clean up unwanted files
+        rmdir(self, os.path.join(self.package_folder, "share", "doc"))
+        rmdir(self, os.path.join(self.package_folder, "share", "man"))
+
+    def package_info(self):
+        self.cpp_info.libs = []
+        
+        # It's a tool, but we might want to expose it to CMakeToolchain.
+        # Find path to ecbuildConfig.cmake
+        self.cpp_info.builddirs.append(os.path.join("share", "ecbuild", "cmake"))
+        
+        # In Conan 2, packages that want to be found via CMakeDeps usually set:
+        self.cpp_info.set_property("cmake_file_name", "ecbuild")
+        self.cpp_info.set_property("cmake_target_name", "ecbuild::ecbuild")
+        
+        # Make the scripts in bin available on the path
+        self.cpp_info.bindirs = ["bin"]

--- a/recipes/ecbuild/all/test_package/CMakeLists.txt
+++ b/recipes/ecbuild/all/test_package/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.18)
+project(test_package CXX)
+
+find_package(ecbuild REQUIRED)
+
+# ecBuild is primarily a set of CMake macros, let's just make sure we can include one
+if(TARGET ecbuild::ecbuild)
+    message(STATUS "ecbuild target exists (though typically we just use its macros)")
+endif()
+
+# We can also try including a macro
+include(ecbuild_system)
+message(STATUS "ecbuild_system included successfully")
+
+add_executable(test_package test_package.cpp)

--- a/recipes/ecbuild/all/test_package/conanfile.py
+++ b/recipes/ecbuild/all/test_package/conanfile.py
@@ -1,0 +1,30 @@
+import os
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.env import VirtualBuildEnv
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "VirtualBuildEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.tool_requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            # Run the basic test to see if finding the package works
+            self.run("ecbuild --version", env="conanbuild")

--- a/recipes/ecbuild/all/test_package/test_package.cpp
+++ b/recipes/ecbuild/all/test_package/test_package.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+    std::cout << "test_package: ecbuild consumed successfully!\n";
+    return 0;
+}

--- a/recipes/ecbuild/config.yml
+++ b/recipes/ecbuild/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "3.14.2":
+    folder: all

--- a/recipes/eccodes/all/conandata.yml
+++ b/recipes/eccodes/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2.47.0":
+    url: "https://github.com/ecmwf/eccodes/archive/refs/tags/2.47.0.tar.gz"
+    sha256: "6318a6a1e296d6698bcd83719212cf630b9bb45c054723c22bbc449090ae0c0e"

--- a/recipes/eccodes/all/conanfile.py
+++ b/recipes/eccodes/all/conanfile.py
@@ -1,0 +1,176 @@
+import os
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, rmdir, replace_in_file
+
+required_conan_version = ">=1.53.0"
+
+
+class EccodesConan(ConanFile):
+    name = "eccodes"
+    description = "ECMWF ecCodes is a package developed by ECMWF which provides an API and a set of tools for decoding and encoding GRIB, BUFR and GTS formats."
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/ecmwf/eccodes"
+    topics = ("grib", "bufr", "gts", "ecmwf", "meteorology")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "with_png": [True, False],
+        "with_jasper": [True, False],
+        "with_openjpeg": [True, False],
+        "with_netcdf": [True, False],
+        "fortran": [True, False],
+        "with_threads": [True, False],
+        "build_tools": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "with_png": False,
+        "with_jasper": True,
+        "with_openjpeg": True,
+        "with_netcdf": True,
+        "fortran": False,
+        "with_threads": True,
+        "build_tools": True,
+    }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        if not self.options.fortran:
+            self.settings.rm_safe("compiler.libcxx")
+            self.settings.rm_safe("compiler.cppstd")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("libaec/1.1.4")
+        self.requires("eckit/2.1.0")
+        if self.options.with_png:
+            self.requires("libpng/[>=1.6 <2]")
+        if self.options.with_jasper:
+            self.requires("jasper/4.2.4")
+        if self.options.with_openjpeg:
+            self.requires("openjpeg/2.5.2")
+        if self.options.with_netcdf:
+            self.requires("netcdf/4.8.1")
+
+    def build_requirements(self):
+        self.tool_requires("ecbuild/3.14.2")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["ENABLE_AEC"] = True
+        tc.variables["ENABLE_ECKIT_GEO"] = True
+        tc.variables["ENABLE_JPG"] = self.options.with_jasper or self.options.with_openjpeg
+        tc.variables["ENABLE_JPG_LIBJASPER"] = self.options.with_jasper
+        tc.variables["ENABLE_JPG_LIBOPENJPEG"] = self.options.with_openjpeg
+        tc.variables["ENABLE_PNG"] = self.options.with_png
+        tc.variables["ENABLE_NETCDF"] = self.options.with_netcdf
+        tc.variables["ENABLE_FORTRAN"] = self.options.fortran
+        tc.variables["ENABLE_MEMFS"] = False
+        tc.variables["ENABLE_PYTHON"] = False
+        tc.variables["ENABLE_BUILD_TOOLS"] = self.options.build_tools
+        tc.variables["ENABLE_EXAMPLES"] = False
+        tc.variables["ENABLE_TESTS"] = False
+        tc.variables["ENABLE_EXTRA_TESTS"] = False
+        tc.variables["ENABLE_ECCODES_THREADS"] = self.options.with_threads
+        tc.variables["ENABLE_PKGCONFIG"] = False
+        tc.variables["INSTALL_ECCODES_DEFINITIONS"] = True
+        tc.variables["INSTALL_ECCODES_SAMPLES"] = True
+        tc.variables["BUILD_SHARED_LIBS"] = self.options.shared
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def _patch_sources(self):
+        # We need to define eckit_geo target if it doesn't exist so ecbuild finds it
+        cmakelists = os.path.join(self.source_folder, "CMakeLists.txt")
+        
+        replacement = (
+            "if( eccodes_HAVE_ECKIT_GEO AND NOT TARGET eckit_geo )\n"
+            "    ecbuild_find_package(NAME eckit REQUIRED)\n"
+            "    if( NOT TARGET eckit_geo )\n"
+            "        if( TARGET eckit::eckit )\n"
+            "            add_library(eckit_geo INTERFACE IMPORTED)\n"
+            "            target_link_libraries(eckit_geo INTERFACE eckit::eckit eckit::eckit)\n"
+            "        elseif( TARGET eckit )\n"
+            "            add_library(eckit_geo INTERFACE IMPORTED)\n"
+            "            target_link_libraries(eckit_geo INTERFACE eckit eckit)\n"
+            "        else()\n"
+            "            ecbuild_critical(\"eckit has not been built with ECKIT_GEO enabled\")\n"
+            "        endif()\n"
+            "    endif()\n"
+            "endif()"
+        )
+        
+        with open(cmakelists, "r", encoding="utf-8") as f:
+            content = f.read()
+        
+        target_str = (
+            "if( eccodes_HAVE_ECKIT_GEO AND NOT TARGET eckit_geo )\n"
+            "    ecbuild_find_package(NAME eckit VERSION 1.27 REQUIRED)\n"
+            "    if( NOT TARGET eckit_geo )\n"
+            "        ecbuild_critical(\"eckit has not been built with ECKIT_GEO enabled\")\n"
+            "    endif()\n"
+            "endif()"
+        )
+        
+        if target_str in content:
+            content = content.replace(target_str, replacement)
+        else:
+            self.output.warn("Could not find expected eckit_geo check in CMakeLists.txt to patch")
+            
+        if self.options.with_netcdf:
+            netcdf_patch = (
+                "find_package( netCDF REQUIRED )\n"
+                "set( NetCDF_C_EXTRA_LIBRARIES netCDF::netcdf )\n"
+                "ecbuild_add_option( FEATURE NETCDF"
+            )
+            content = content.replace("ecbuild_add_option( FEATURE NETCDF", netcdf_patch)
+
+        content = content.replace("add_subdirectory( tests )", "if(ENABLE_TESTS)\nadd_subdirectory( tests )\nendif()")
+        content = content.replace("add_subdirectory( examples )", "if(ENABLE_EXAMPLES)\nadd_subdirectory( examples )\nendif()")
+
+        with open(cmakelists, "w", encoding="utf-8") as f:
+            f.write(content)
+
+    def build(self):
+        self._patch_sources()
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        # Clean up unwanted cmake files and pkgconfig
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "eccodes")
+        self.cpp_info.set_property("cmake_target_name", "eccodes::eccodes")
+        
+        # Libraries built by eccodes
+        self.cpp_info.libs = ["eccodes"]
+        if self.options.fortran:
+            self.cpp_info.libs.append("eccodes_f90")
+            
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.extend(["m", "pthread", "dl"])

--- a/recipes/eccodes/all/test_package/CMakeLists.txt
+++ b/recipes/eccodes/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package C)
+
+find_package(eccodes CONFIG REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} eccodes::eccodes)

--- a/recipes/eccodes/all/test_package/conanfile.py
+++ b/recipes/eccodes/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+import os
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/eccodes/all/test_package/test_package.c
+++ b/recipes/eccodes/all/test_package/test_package.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+#include <grib_api.h>
+
+int main() {
+    long version = grib_get_api_version();
+    printf("ecCodes version: %ld\n", version);
+    return 0;
+}

--- a/recipes/eccodes/config.yml
+++ b/recipes/eccodes/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.47.0":
+    folder: all

--- a/recipes/eckit/all/conandata.yml
+++ b/recipes/eckit/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2.1.0":
+    url: "https://github.com/ecmwf/eckit/archive/refs/tags/2.1.0.tar.gz"
+    sha256: "bb7e888498b39925d724019f02c14b981761e7c94de899b5322cffe025d1e3d6"

--- a/recipes/eckit/all/conanfile.py
+++ b/recipes/eckit/all/conanfile.py
@@ -1,0 +1,200 @@
+import os
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, collect_libs, replace_in_file
+from conan.tools.scm import Version
+
+required_conan_version = ">=1.53.0"
+
+
+class EckitConan(ConanFile):
+    name = "eckit"
+    description = "C++ toolkit for ECMWF tools and applications"
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/ecmwf/eckit"
+    topics = ("toolkit", "ecmwf")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "with_openssl": [True, False],
+        "with_curl": [True, False],
+        "with_omp": [True, False],
+        "with_mpi": [True, False],
+        "with_bzip2": [True, False],
+        "with_lz4": [True, False],
+        "with_snappy": [True, False],
+        "with_aec": [True, False],
+        "with_zip": [True, False],
+        "with_xxhash": [True, False],
+        "with_proj": [True, False],
+        "with_lapack": [True, False],
+        "with_mkl": [True, False],
+        "with_eigen": [True, False],
+        "with_qhull": [True, False],
+        "with_shapelib": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "with_openssl": True,
+        "with_curl": True,
+        "with_omp": True,
+        "with_mpi": True,
+        "with_bzip2": True,
+        "with_lz4": True,
+        "with_snappy": True,
+        "with_aec": True,
+        "with_zip": True,
+        "with_xxhash": True,
+        "with_proj": True,
+        "with_lapack": False,
+        "with_mkl": False,
+        "with_eigen": False,
+        "with_qhull": False,
+        "with_shapelib": False,
+    }
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        if self.options.with_openssl:
+            self.requires("openssl/[>=1.1 <4]")
+        if self.options.with_curl:
+            self.requires("libcurl/[>=7.78.0 <9]")
+        if self.options.with_mpi:
+            self.requires("openmpi/[>=4.0]")
+        if self.options.with_bzip2:
+            self.requires("bzip2/1.0.8")
+        if self.options.with_lz4:
+            self.requires("lz4/1.10.0")
+        if self.options.with_snappy:
+            self.requires("snappy/1.2.1")
+        if self.options.with_aec:
+            self.requires("libaec/1.1.4")
+        if self.options.with_zip:
+            self.requires("libzip/1.11.4")
+        if self.options.with_xxhash:
+            self.requires("xxhash/0.8.3")
+        if self.options.with_proj:
+            self.requires("proj/9.7.0")
+        if self.options.with_lapack:
+            self.requires("openblas/0.3.30")
+        if self.options.with_eigen:
+            self.requires("eigen/3.4.1")
+        if self.options.with_qhull:
+            self.requires("qhull/8.0.2")
+        if self.options.with_shapelib:
+            self.requires("shapelib/1.6.1")
+
+    def build_requirements(self):
+        self.tool_requires("ecbuild/3.14.2")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["ENABLE_SSL"] = self.options.with_openssl
+        tc.variables["ENABLE_CURL"] = self.options.with_curl
+        tc.variables["ENABLE_OMP"] = self.options.with_omp
+        tc.variables["ENABLE_MPI"] = self.options.with_mpi
+        tc.variables["ENABLE_BZIP2"] = self.options.with_bzip2
+        tc.variables["ENABLE_LZ4"] = self.options.with_lz4
+        tc.variables["ENABLE_SNAPPY"] = self.options.with_snappy
+        tc.variables["ENABLE_AEC"] = self.options.with_aec
+        tc.variables["ENABLE_ZIP"] = self.options.with_zip
+        tc.variables["ENABLE_XXHASH"] = self.options.with_xxhash
+        tc.variables["ENABLE_PROJ"] = self.options.with_proj
+        tc.variables["ENABLE_LAPACK"] = self.options.with_lapack
+        tc.variables["ENABLE_MKL"] = self.options.with_mkl
+        tc.variables["ENABLE_EIGEN"] = self.options.with_eigen
+        tc.variables["ENABLE_CONVEX_HULL"] = self.options.with_qhull
+        tc.variables["ENABLE_GEO_AREA_SHAPEFILE"] = self.options.with_shapelib
+        
+        if self.options.with_mpi:
+            tc.variables["MPI_C_LIBRARIES"] = "MPI::MPI_C"
+        tc.variables["ENABLE_PKGCONFIG"] = False
+        tc.variables["BUILD_SHARED_LIBS"] = self.options.shared
+        
+        tc.variables["BUILD_TESTING"] = False
+        tc.variables["ENABLE_TESTS"] = False
+        tc.variables["ENABLE_EXTRA_TESTS"] = False
+        tc.variables["ENABLE_AIO"] = False
+        tc.variables["ENABLE_CUDA"] = False
+        tc.variables["ENABLE_HIP"] = False
+        tc.variables["ENABLE_TORCH"] = False
+        tc.variables["ENABLE_RADOS"] = False
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        apply_conandata_patches(self)
+        self.output.info(f"source_folder: {self.source_folder}")
+        self.output.info(f"build_folder: {self.build_folder}")
+        import re
+        for root, _, files in os.walk(self.source_folder):
+            for f in files:
+                if f == "CMakeLists.txt":
+                    filepath = os.path.join(root, f)
+                    with open(filepath, "r", encoding="utf-8") as file:
+                        content = file.read()
+                    new_content, count = re.subn(r"TYPE\s+SHARED", "", content)
+                    if count > 0:
+                        self.output.info(f"Replaced {count} occurrences in {filepath}")
+                    with open(filepath, "w", encoding="utf-8") as file:
+                        file.write(new_content)
+        
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "eckit")
+        self.cpp_info.set_property("cmake_target_name", "eckit")
+        
+        all_libs = [
+            "eckit_geo",
+            "eckit_sql",
+            "eckit_web",
+            "eckit_distributed",
+            "eckit_mpi",
+            "eckit_linalg",
+            "eckit_geometry",
+            "eckit_maths",
+            "eckit_option",
+            "eckit_spec",
+            "eckit_codec",
+            "eckit_cmd",
+            "eckit",
+        ]
+        collected = collect_libs(self)
+        self.cpp_info.libs = [lib for lib in all_libs if lib in collected] + [lib for lib in collected if lib not in all_libs]
+        self.cpp_info.includedirs = ["include"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.extend(["pthread", "dl", "m", "rt"])

--- a/recipes/eckit/all/test_package/CMakeLists.txt
+++ b/recipes/eckit/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(eckit REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE eckit)

--- a/recipes/eckit/all/test_package/conanfile.py
+++ b/recipes/eckit/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/eckit/all/test_package/test_package.cpp
+++ b/recipes/eckit/all/test_package/test_package.cpp
@@ -1,0 +1,8 @@
+#include "eckit/runtime/Main.h"
+#include "eckit/log/Log.h"
+
+int main(int argc, char** argv) {
+    eckit::Main::initialise(argc, argv);
+    eckit::Log::info() << "Application started!" << std::endl;
+    return 0;
+}

--- a/recipes/eckit/config.yml
+++ b/recipes/eckit/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.1.0":
+    folder: all


### PR DESCRIPTION
  ### Summary
  Changes to recipe:  **ecbuild/3.14.2**
  
  #### Motivation
  This PR adds a Conan 2 recipe for ecBuild, the CMake-based build system used by ECMWF projects such as eckit and ecCodes.

ecBuild is a build-time dependency (tool requirement) and is required to correctly configure and build ECMWF software stacks.

There is currently no Conan Center recipe for ecBuild, which blocks packaging of downstream libraries such as eckit and ecCodes.
  
  #### Details
Added Conan 2 recipe for ecBuild as a tool_require package
Packaged CMake modules and configuration files required by:
find_package(ecbuild)
ECMWF macro system (ecbuild_add_option, etc.)
Marked package as header-only / build-only (no runtime libraries)
Exported CMake integration via CMakeDeps
Ensured compatibility with downstream consumers such as eckit and ecCodes
Verified integration with at least one build (e.g. eckit or ecCodes)
  
 #### Notes for reviewers
  **This recipe is a prerequisite for packaging eckit and ecCodes in Conan Center Index.**
ecBuild does not produce runtime libraries
It is only used at configure/build time via CMake
The package is intended to be used via tool_requires()
No ABI or runtime impact

  ---
  - [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
  - [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
  - [ ] If this is a bug fix, please link related issue or provide bug details
  - [x] Tested locally with at least one configuration using a recent version of Conan
  
  ---
