### PR TITLE
add expat/2.8.2 

### DIFF
--- a/recipes/expat/all/conandata.yml
+++ b/recipes/expat/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.8.2":
+    url: "https://github.com/libexpat/libexpat/releases/download/R_2_8_2/expat-2.8.2.tar.xz"
+    sha256: "3ad89b8588e6644bd4e49981480d48b21289eebbcd4f0a1a4afb1c29f99b6ab4"
   "2.8.1":
     url: "https://github.com/libexpat/libexpat/releases/download/R_2_8_1/expat-2.8.1.tar.xz"
     sha256: "10b195ee78160a908388180a8fe3603d4e9a12f4755fbf5f3816b23a9d750da0"

--- a/recipes/expat/config.yml
+++ b/recipes/expat/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.8.2":
+    folder: all
   "2.8.1":
     folder: all
   "2.8.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **expat/2.8.2**, closes #30489

#### Motivation

Expat 2.8.1 suffers from several high severity vulnerabilities . See block post of the release: https://blog.hartwork.org/posts/expat-2-8-2-released/

#### Details
I added 2.8.1 to `conandata.yml` and `config.yml`. I was hesitant to remove 2.8.0 and 2.8.1 as they all suffer from those CVEs but since the update to 2.8.1 kept 2.8.0, I did the same.

I grepped other recipes, they all detpend on `[>=2.6.2 <3]` so removing them should be fine, if it's decided to remove them.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
