### PR TITLE
Add support for C++26 to boost's b2

### DIFF
--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -180,7 +180,7 @@ class BoostConan(ConanFile):
             cppstd_flags.setdefault("17", "17" if gcc_version >= "5.2" else "1z" if gcc_version >= "5" else None)
             cppstd_flags.setdefault("20", "2a" if gcc_version >= "8" else "20" if gcc_version >= "12" else None)
             cppstd_flags.setdefault("23", "2b" if gcc_version >= "11" else None)
-            cppstd_flags.setdefault("26", "26" if gcc_version >= "14" else "2c" if gcc_version >= "13" else None)
+            cppstd_flags.setdefault("26", "26" if gcc_version >= "14" else None)
             return cppstd_flags.get(cppstd.lstrip("gnu"))
 
         def _cppstd_clang(clang_version, cppstd):
@@ -192,7 +192,7 @@ class BoostConan(ConanFile):
             cppstd_flags.setdefault("17", "17" if clang_version >= "5" else "1z" if clang_version >= "3.5" else None)
             cppstd_flags.setdefault("20", "2a" if clang_version >= "6" else "20" if clang_version >= "12" else None)
             cppstd_flags.setdefault("23", "2b" if clang_version >= "13"  else "23" if clang_version >= "17" else None)
-            cppstd_flags.setdefault("26", "26" if clang_version >= "20" else "2c" if clang_version >= "17" else None)
+            cppstd_flags.setdefault("26", "26" if clang_version >= "17" None)
             return cppstd_flags.get(cppstd.lstrip("gnu"))
 
 
@@ -205,7 +205,7 @@ class BoostConan(ConanFile):
             cppstd_flags.setdefault("17", "17" if clang_version >= "9.1" else "1z" if clang_version >= "6.1" else None)
             cppstd_flags.setdefault("20", "20" if clang_version >= "13.0" else "2a" if clang_version >= "10.0" else None)
             cppstd_flags.setdefault("23", "2b" if clang_version >= "13.0" else None)
-            cppstd_flags.setdefault("26", "26" if clang_version >= "17.0" else "2c" if clang_version >= "13.0" else None)
+            cppstd_flags.setdefault("26", "26" if clang_version >= "17.0" else else None)
             return cppstd_flags.get(cppstd.lstrip("gnu"))
 
         def _cppstd_msvc(visual_version, cppstd):
@@ -217,6 +217,7 @@ class BoostConan(ConanFile):
             cppstd_flags.setdefault("17", "17" if visual_version >= "191" else "latest" if visual_version >= "190" else None)
             cppstd_flags.setdefault("20", "20" if visual_version >= "192" else "latest" if visual_version >= "191" else None)
             cppstd_flags.setdefault("23", "latest" if visual_version >= "193" else None)
+            cppstd_flags.setdefault("26", "latest" if visual_version >= "195" else None)
             return cppstd_flags.get(cppstd)
 
         func = {"gcc": _cppstd_gcc, "clang": _cppstd_clang, "apple-clang": _cppstd_apple_clang, "msvc": _cppstd_msvc}.get(compiler)

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -180,6 +180,7 @@ class BoostConan(ConanFile):
             cppstd_flags.setdefault("17", "17" if gcc_version >= "5.2" else "1z" if gcc_version >= "5" else None)
             cppstd_flags.setdefault("20", "2a" if gcc_version >= "8" else "20" if gcc_version >= "12" else None)
             cppstd_flags.setdefault("23", "2b" if gcc_version >= "11" else None)
+            cppstd_flags.setdefault("26", "26" if gcc_version >= "14" else "2c" if gcc_version >= "13" else None)
             return cppstd_flags.get(cppstd.lstrip("gnu"))
 
         def _cppstd_clang(clang_version, cppstd):
@@ -191,6 +192,7 @@ class BoostConan(ConanFile):
             cppstd_flags.setdefault("17", "17" if clang_version >= "5" else "1z" if clang_version >= "3.5" else None)
             cppstd_flags.setdefault("20", "2a" if clang_version >= "6" else "20" if clang_version >= "12" else None)
             cppstd_flags.setdefault("23", "2b" if clang_version >= "13"  else "23" if clang_version >= "17" else None)
+            cppstd_flags.setdefault("26", "26" if clang_version >= "20" else "2c" if clang_version >= "17" else None)
             return cppstd_flags.get(cppstd.lstrip("gnu"))
 
 
@@ -203,6 +205,7 @@ class BoostConan(ConanFile):
             cppstd_flags.setdefault("17", "17" if clang_version >= "9.1" else "1z" if clang_version >= "6.1" else None)
             cppstd_flags.setdefault("20", "20" if clang_version >= "13.0" else "2a" if clang_version >= "10.0" else None)
             cppstd_flags.setdefault("23", "2b" if clang_version >= "13.0" else None)
+            cppstd_flags.setdefault("26", "26" if clang_version >= "17.0" else "2c" if clang_version >= "13.0" else None)
             return cppstd_flags.get(cppstd.lstrip("gnu"))
 
         def _cppstd_msvc(visual_version, cppstd):

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -192,7 +192,7 @@ class BoostConan(ConanFile):
             cppstd_flags.setdefault("17", "17" if clang_version >= "5" else "1z" if clang_version >= "3.5" else None)
             cppstd_flags.setdefault("20", "2a" if clang_version >= "6" else "20" if clang_version >= "12" else None)
             cppstd_flags.setdefault("23", "2b" if clang_version >= "13"  else "23" if clang_version >= "17" else None)
-            cppstd_flags.setdefault("26", "26" if clang_version >= "17" None)
+            cppstd_flags.setdefault("26", "26" if clang_version >= "17" else None)
             return cppstd_flags.get(cppstd.lstrip("gnu"))
 
 
@@ -205,7 +205,7 @@ class BoostConan(ConanFile):
             cppstd_flags.setdefault("17", "17" if clang_version >= "9.1" else "1z" if clang_version >= "6.1" else None)
             cppstd_flags.setdefault("20", "20" if clang_version >= "13.0" else "2a" if clang_version >= "10.0" else None)
             cppstd_flags.setdefault("23", "2b" if clang_version >= "13.0" else None)
-            cppstd_flags.setdefault("26", "26" if clang_version >= "17.0" else else None)
+            cppstd_flags.setdefault("26", "26" if clang_version >= "17.0" else None)
             return cppstd_flags.get(cppstd.lstrip("gnu"))
 
         def _cppstd_msvc(visual_version, cppstd):


### PR DESCRIPTION
### Summary
Changes to recipe:  **boost**

#### Motivation

Trying to evaluate and hopefully use C++26 in a project but can't due to this error:

```
/Users/runner/.conan2/p/b2035f5ae7e2dd7/p/bin/.b2/build/feature.jam:491: in feature.validate-value-string from module feature
error: "None" is not a known value of feature <cxxstd>
error: legal values: "98" "03" "0x" "11" "1y" "14" "1z" "17" "2a" "20" "2b" "23" "2c" "26" "latest"
/Users/runner/.conan2/p/b2035f5ae7e2dd7/p/bin/.b2/build/property.jam:349: in validate1 from module property
/Users/runner/.conan2/p/b2035f5ae7e2dd7/p/bin/.b2/build/property.jam:375: in property.validate from module property
/Users/runner/.conan2/p/b2035f5ae7e2dd7/p/bin/.b2/build/build-request.jam:286: in convert-command-line-element from module build-request
/Users/runner/.conan2/p/b2035f5ae7e2dd7/p/bin/.b2/build/build-request.jam:222: in build-request.convert-command-line-elements from module build-request
/Users/runner/.conan2/p/b2035f5ae7e2dd7/p/bin/.b2/build-system.jam:804: in module scope from module build-system

boost/1.90.0: ERROR: 
Package '405f433f866a6d376eb0433e5089876c2559c530' build failed
boost/1.90.0: WARN: Build folder /Users/runner/.conan2/p/b/boost8edd9c90bdddd/b/build-release
ERROR: boost/1.90.0: Error in build() method, line 1175
	self.run(full_command)
	ConanException: Error 1 while executing
```

#### Details
This adds a mapping for C++26 for the boost build system, there is this [PR](https://github.com/conan-io/conan-center-index/pull/26030) that reworks this entirely but it's gone stale. I'm fine with this PR being closed but it would be nice to have support added for C++26 either way.

I'm not sure if I got the compiler versions right and I don't know what to put for 

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] If this is a bug fix, [please link related issue or provide bug details](https://github.com/conan-io/conan-center-index/issues/26390)
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
