### PR TITLE
Update conandata.yml to include CRoaring version 4.7.2

### DIFF
--- a/recipes/roaring/all/conandata.yml
+++ b/recipes/roaring/all/conandata.yml
@@ -1,8 +1,8 @@
 sources:
-"4.7.2":
+  "4.7.2":
     url: "https://github.com/RoaringBitmap/CRoaring/archive/refs/tags/v4.7.2.tar.gz"
     sha256: "3695a0aac3e8b6f2fd3ec45151a5fb7c28b432538777b7b7473de3b83f088960"
-  "4.5.2":
+  "4.5.0":
     url: "https://github.com/RoaringBitmap/CRoaring/archive/refs/tags/v4.5.0.tar.gz"
     sha256: "8f945ad82ce1be195c899c57e0734a5c0ea2685c3127bf9033d4391d054f94ab"
   "4.2.1":

--- a/recipes/roaring/all/conandata.yml
+++ b/recipes/roaring/all/conandata.yml
@@ -1,5 +1,8 @@
 sources:
-  "4.5.0":
+"4.7.2":
+    url: "https://github.com/RoaringBitmap/CRoaring/archive/refs/tags/v4.7.2.tar.gz"
+    sha256: "3695a0aac3e8b6f2fd3ec45151a5fb7c28b432538777b7b7473de3b83f088960"
+  "4.5.2":
     url: "https://github.com/RoaringBitmap/CRoaring/archive/refs/tags/v4.5.0.tar.gz"
     sha256: "8f945ad82ce1be195c899c57e0734a5c0ea2685c3127bf9033d4391d054f94ab"
   "4.2.1":


### PR DESCRIPTION
Added new CRoaring version 4.7.2 with its URL and SHA256 hash.


### Summary
Changes to recipe:  **roaring**

#### Motivation
Adding the new upstream release `4.7.2` which includes a critical upstream fix for an AVX-512 bug (UBSan crash on null pointer offset).

#### Details
Added version `4.7.2` and its corresponding sha256 checksum to `recipes/roaring/all/conandata.yml`.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
