### PR TITLE
resiprocate: add 1.14.0

### DIFF
--- a/recipes/resiprocate/cmake/conandata.yml
+++ b/recipes/resiprocate/cmake/conandata.yml
@@ -18,3 +18,6 @@ patches:
       patch_type: "portability"
       patch_description: "Properly set close-on-exec for BSDs"
       patch_source: "https://github.com/resiprocate/resiprocate/commit/067fe453da0845e2179f408ebc6b8d288e03951d"
+    - patch_file: "patches/1.14.0-rutil-downgrade-c-ares-deprecation-errors-to-warning.patch"
+      patch_type: "portability"
+      patch_description: "Do not error out on recent c-ares deprecation notices"

--- a/recipes/resiprocate/cmake/conandata.yml
+++ b/recipes/resiprocate/cmake/conandata.yml
@@ -1,7 +1,20 @@
 sources:
+  "1.14.0":
+    url: "https://github.com/resiprocate/resiprocate/archive/refs/tags/resiprocate-1.14.0.tar.gz"
+    sha256: "f132e4d0fcae0c155f91e5dad608a9985e199e4e3c09b6029a70b1b3b6d0b156"
   "1.13.2":
     url: "https://github.com/resiprocate/resiprocate/archive/refs/tags/resiprocate-1.13.2.tar.gz"
     sha256: "059fda8f63c456fd61130d468a67655cfeafb5ba8ff5c1d0a55dc383f83e4fba"
   "1.13.1":
     url: "https://github.com/resiprocate/resiprocate/archive/refs/tags/resiprocate-1.13.1.tar.gz"
     sha256: "df8d0cbf17793077d59c2863b23a6da8e9c77aba88327d1a494accaded1ef605"
+patches:
+  "1.14.0":
+    - patch_file: "patches/1.14.0-Fix-POSIX-build-error.patch"
+      patch_type: "portability"
+      patch_description: "Fix POSIX build error"
+      patch_source: "https://github.com/resiprocate/resiprocate/commit/fe7d6307100ba251691ccf6bc98b5d6351420522"
+    - patch_file: "patches/1.14.0-Properly-set-close-on-exec-for-BSDs.patch"
+      patch_type: "portability"
+      patch_description: "Properly set close-on-exec for BSDs"
+      patch_source: "https://github.com/resiprocate/resiprocate/pull/474"

--- a/recipes/resiprocate/cmake/conandata.yml
+++ b/recipes/resiprocate/cmake/conandata.yml
@@ -17,4 +17,4 @@ patches:
     - patch_file: "patches/1.14.0-Properly-set-close-on-exec-for-BSDs.patch"
       patch_type: "portability"
       patch_description: "Properly set close-on-exec for BSDs"
-      patch_source: "https://github.com/resiprocate/resiprocate/pull/474"
+      patch_source: "https://github.com/resiprocate/resiprocate/commit/067fe453da0845e2179f408ebc6b8d288e03951d"

--- a/recipes/resiprocate/cmake/conanfile.py
+++ b/recipes/resiprocate/cmake/conanfile.py
@@ -56,7 +56,7 @@ class ResiprocateConan(ConanFile):
             raise ConanInvalidConfiguration(f"{self.ref} can not be built as shared on msvc, it does not export required symbols.")
 
     def build_requirements(self):
-        self.tool_requires("cmake/[>=3.21 <4]")
+        self.tool_requires("cmake/[>=3.21]")
         if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
             self.tool_requires("pkgconf/[>=2.2 <3]")
 

--- a/recipes/resiprocate/cmake/conanfile.py
+++ b/recipes/resiprocate/cmake/conanfile.py
@@ -5,7 +5,7 @@ from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import is_apple_os
 from conan.tools.build import check_min_cppstd, cross_building
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, get, rm, rmdir
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rm, rmdir
 from conan.tools.gnu import PkgConfigDeps
 from conan.tools.microsoft import is_msvc
 
@@ -38,6 +38,9 @@ class ResiprocateConan(ConanFile):
     }
     implements = ["auto_shared_fpic"]
 
+    def export_sources(self):
+        export_conandata_patches(self)
+
     def layout(self):
         cmake_layout(self, src_folder="src")
 
@@ -59,6 +62,7 @@ class ResiprocateConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/recipes/resiprocate/cmake/patches/1.14.0-Fix-POSIX-build-error.patch
+++ b/recipes/resiprocate/cmake/patches/1.14.0-Fix-POSIX-build-error.patch
@@ -1,0 +1,49 @@
+From fe7d6307100ba251691ccf6bc98b5d6351420522 Mon Sep 17 00:00:00 2001
+From: Scott Godin <sgodin@sipspectrum.com>
+Date: Fri, 19 Jun 2026 13:20:19 -0400
+Subject: [PATCH] Fix POSIX build error:
+
+strerror_r has two incompatible signatures depending on feature-test macros and the platform's libc. The GNU variant returns char* (the message, which may not be 'buf'); the XSI/POSIX variant returns int (0 on success) and writes the message into 'buf'. Let overload resolution pick the right one.
+---
+ rutil/compat.hxx | 18 ++++++++++++++++--
+ 1 file changed, 16 insertions(+), 2 deletions(-)
+
+diff --git a/rutil/compat.hxx b/rutil/compat.hxx
+index e16ab692b..deba4327f 100644
+--- a/rutil/compat.hxx
++++ b/rutil/compat.hxx
+@@ -237,6 +237,21 @@ hton64(const uint64_t input)
+ 
+ #endif
+ 
++#ifndef _MSC_VER
++// strerror_r has two incompatible signatures depending on feature-test macros
++// and the platform's libc. The GNU variant returns char* (the message, which
++// may not be 'buf'); the XSI/POSIX variant returns int (0 on success) and
++// writes the message into 'buf'. Let overload resolution pick the right one.
++inline const char* strErrorResult(char* result, char* /*buf*/)
++{
++   return result;                                   // GNU variant
++}
++inline const char* strErrorResult(int result, char* buf)
++{
++   return (result == 0) ? buf : "Unknown error";    // XSI/POSIX variant
++}
++#endif
++
+ inline std::string strError(int err)
+ {
+    char buf[256];
+@@ -244,8 +259,7 @@ inline std::string strError(int err)
+    strerror_s(buf, sizeof(buf), err);
+    return buf;
+ #else
+-   char* res = strerror_r(err, buf, sizeof(buf));
+-   return std::string(res);
++   return strErrorResult(strerror_r(err, buf, sizeof(buf)), buf);
+ #endif
+ }
+ 
+-- 
+2.54.0
+

--- a/recipes/resiprocate/cmake/patches/1.14.0-Properly-set-close-on-exec-for-BSDs.patch
+++ b/recipes/resiprocate/cmake/patches/1.14.0-Properly-set-close-on-exec-for-BSDs.patch
@@ -1,0 +1,50 @@
+From b23900cda7af5d0ba84cd5775b421beefacb68a3 Mon Sep 17 00:00:00 2001
+From: Gregor Jasny <gjasny@googlemail.com>
+Date: Mon, 29 Jun 2026 17:30:51 +0200
+Subject: [PATCH] Properly set close on exec for BSDs
+
+---
+ resip/stack/InternalTransport.cxx | 16 +++++++++++++++-
+ 1 file changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/resip/stack/InternalTransport.cxx b/resip/stack/InternalTransport.cxx
+index 5a19deff0..b5485d430 100644
+--- a/resip/stack/InternalTransport.cxx
++++ b/resip/stack/InternalTransport.cxx
+@@ -4,11 +4,13 @@
+ 
+ #include <iostream>
+ 
++#include <fcntl.h>
++
+ #if defined(HAVE_SYS_SOCKIO_H)
+ #include <sys/sockio.h>
+ #endif
+ 
+-#if defined(WIN32)
++#ifndef SOCK_CLOEXEC
+ #define SOCK_CLOEXEC 0
+ #endif
+ 
+@@ -112,6 +114,18 @@ InternalTransport::socket(TransportType type, IpVersion ipVer)
+       ErrLog(<< "Failed to set handle information: " << strError(e));
+       throw Transport::Exception("Failed SetHandleInformation", __FILE__, __LINE__);
+    }
++#else
++   int flags = fcntl(fd, F_GETFD);
++   if (flags == -1) {
++      int e = getErrno();
++      ErrLog (<< "Failed to get socket flags: " << strError(e));
++      throw Transport::Exception("Can't get socket flags", __FILE__,__LINE__);
++   }
++   if (fcntl(fd, F_SETFD, flags | FD_CLOEXEC) == -1) {
++      int e = getErrno();
++      ErrLog (<< "Failed to set socket flags: " << strError(e));
++      throw Transport::Exception("Can't set socket flags", __FILE__,__LINE__);
++   }
+ #endif
+ 
+ #ifdef USE_IPV6
+-- 
+2.54.0
+

--- a/recipes/resiprocate/cmake/patches/1.14.0-Properly-set-close-on-exec-for-BSDs.patch
+++ b/recipes/resiprocate/cmake/patches/1.14.0-Properly-set-close-on-exec-for-BSDs.patch
@@ -1,17 +1,45 @@
-From b23900cda7af5d0ba84cd5775b421beefacb68a3 Mon Sep 17 00:00:00 2001
+From 067fe453da0845e2179f408ebc6b8d288e03951d Mon Sep 17 00:00:00 2001
 From: Gregor Jasny <gjasny@googlemail.com>
 Date: Mon, 29 Jun 2026 17:30:51 +0200
 Subject: [PATCH] Properly set close on exec for BSDs
 
 ---
- resip/stack/InternalTransport.cxx | 16 +++++++++++++++-
- 1 file changed, 15 insertions(+), 1 deletion(-)
+ CMakeLists.txt                    |  3 +++
+ config.h.cmake                    |  1 +
+ resip/stack/InternalTransport.cxx | 34 +++++++++++++++++++++++++------
+ 3 files changed, 32 insertions(+), 6 deletions(-)
 
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index cddf7ff4a..43f993cf9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -899,6 +899,9 @@ endif()
+ include(CheckIncludeFiles)
+ check_include_files(sys/epoll.h HAVE_EPOLL)
+ 
++include(CheckSymbolExists)
++check_symbol_exists(SOCK_CLOEXEC "sys/socket.h" HAVE_SOCK_CLOEXEC)
++
+ # HAVE_LIBDL from autotools obsolete,
+ # now we use CMAKE_DL_LIBS to include the library
+ # when necessary
+diff --git a/config.h.cmake b/config.h.cmake
+index 701010190..431703597 100644
+--- a/config.h.cmake
++++ b/config.h.cmake
+@@ -9,6 +9,7 @@
+ #cmakedefine USE_POSTGRESQL
+ #cmakedefine USE_MAXMIND_GEOIP
+ #cmakedefine01 HAVE_CLOCK_GETTIME_MONOTONIC
++#cmakedefine HAVE_SOCK_CLOEXEC
+ #define DEFAULT_BRIDGE_MAX_IN_OUTPUTS @DEFAULT_BRIDGE_MAX_IN_OUTPUTS@
+ #cmakedefine SIPX_NO_RECORD
+ 
 diff --git a/resip/stack/InternalTransport.cxx b/resip/stack/InternalTransport.cxx
-index 5a19deff0..b5485d430 100644
+index 5a19deff0..932839110 100644
 --- a/resip/stack/InternalTransport.cxx
 +++ b/resip/stack/InternalTransport.cxx
-@@ -4,11 +4,13 @@
+@@ -4,12 +4,14 @@
  
  #include <iostream>
  
@@ -22,22 +50,59 @@ index 5a19deff0..b5485d430 100644
  #endif
  
 -#if defined(WIN32)
-+#ifndef SOCK_CLOEXEC
- #define SOCK_CLOEXEC 0
+-#define SOCK_CLOEXEC 0
++#if defined(HAVE_SOCK_CLOEXEC)
++#include <sys/socket.h>
  #endif
  
-@@ -112,6 +114,18 @@ InternalTransport::socket(TransportType type, IpVersion ipVer)
+ #include "resip/stack/Helper.hxx"
+@@ -75,22 +77,28 @@ InternalTransport::isFinished() const
+ Socket
+ InternalTransport::socket(TransportType type, IpVersion ipVer)
+ {
++#if defined(HAVE_SOCK_CLOEXEC)
++   const int sockCloexec = SOCK_CLOEXEC;
++#else
++   const int sockCloexec = 0;
++#endif
++
+    Socket fd;
+    switch (type)
+    {
+       case UDP:
+ #ifdef USE_IPV6
+-         fd = ::socket(ipVer == V4 ? PF_INET : PF_INET6, SOCK_DGRAM | SOCK_CLOEXEC, IPPROTO_UDP);
++         fd = ::socket(ipVer == V4 ? PF_INET : PF_INET6, SOCK_DGRAM | sockCloexec, IPPROTO_UDP);
+ #else
+-         fd = ::socket(PF_INET, SOCK_DGRAM | SOCK_CLOEXEC, IPPROTO_UDP);
++         fd = ::socket(PF_INET, SOCK_DGRAM | sockCloexec, IPPROTO_UDP);
+ #endif
+          break;
+       case TCP:
+       case TLS:
+ #ifdef USE_IPV6
+-         fd = ::socket(ipVer == V4 ? PF_INET : PF_INET6, SOCK_STREAM | SOCK_CLOEXEC, 0);
++         fd = ::socket(ipVer == V4 ? PF_INET : PF_INET6, SOCK_STREAM | sockCloexec, 0);
+ #else
+-         fd = ::socket(PF_INET, SOCK_STREAM | SOCK_CLOEXEC, 0);
++         fd = ::socket(PF_INET, SOCK_STREAM | sockCloexec, 0);
+ #endif
+          break;
+       default:
+@@ -112,6 +120,20 @@ InternalTransport::socket(TransportType type, IpVersion ipVer)
        ErrLog(<< "Failed to set handle information: " << strError(e));
        throw Transport::Exception("Failed SetHandleInformation", __FILE__, __LINE__);
     }
-+#else
++#elif !defined(HAVE_SOCK_CLOEXEC)
 +   int flags = fcntl(fd, F_GETFD);
-+   if (flags == -1) {
++   if (flags == -1)
++   {
 +      int e = getErrno();
 +      ErrLog (<< "Failed to get socket flags: " << strError(e));
 +      throw Transport::Exception("Can't get socket flags", __FILE__,__LINE__);
 +   }
-+   if (fcntl(fd, F_SETFD, flags | FD_CLOEXEC) == -1) {
++   if (fcntl(fd, F_SETFD, flags | FD_CLOEXEC) == -1)
++   {
 +      int e = getErrno();
 +      ErrLog (<< "Failed to set socket flags: " << strError(e));
 +      throw Transport::Exception("Can't set socket flags", __FILE__,__LINE__);

--- a/recipes/resiprocate/cmake/patches/1.14.0-rutil-downgrade-c-ares-deprecation-errors-to-warning.patch
+++ b/recipes/resiprocate/cmake/patches/1.14.0-rutil-downgrade-c-ares-deprecation-errors-to-warning.patch
@@ -1,0 +1,31 @@
+From 80b9a654cac1f35c13fc818b1568c3f705d8686a Mon Sep 17 00:00:00 2001
+From: Gregor Jasny <gjasny@googlemail.com>
+Date: Fri, 3 Jul 2026 13:44:13 +0200
+Subject: [PATCH] rutil: downgrade c-ares deprecation errors to warnings
+
+---
+ rutil/dns/AresDns.cxx | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/rutil/dns/AresDns.cxx b/rutil/dns/AresDns.cxx
+index 563770c28..bdbb5128b 100644
+--- a/rutil/dns/AresDns.cxx
++++ b/rutil/dns/AresDns.cxx
+@@ -27,6 +27,14 @@
+ #endif
+ #endif
+ 
++#ifndef WIN32
++#pragma GCC diagnostic push
++#pragma GCC diagnostic warning "-Wdeprecated-declarations"
++#else
++#pragma warning(push)
++#pragma warning(3 : 4996)
++#endif
++
+ using namespace resip;
+ 
+ #define RESIPROCATE_SUBSYSTEM resip::Subsystem::DNS
+-- 
+2.54.0
+

--- a/recipes/resiprocate/config.yml
+++ b/recipes/resiprocate/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.14.0":
+    folder: cmake
   "1.13.2":
     folder: cmake
   "1.13.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  **resiprocate/1.14.0**

I had to backport two patches from resiprocate mainline and add another one to get past the c-ares deprecation warnings. Filed upstream as: https://github.com/resiprocate/resiprocate/pull/475

#### Motivation
Add new upstream version.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
