### PR TITLE
open-dis-cpp: Add version 1.2.0

### DIFF
--- a/recipes/open-dis-cpp/all/conandata.yml
+++ b/recipes/open-dis-cpp/all/conandata.yml
@@ -5,3 +5,6 @@ sources:
   "1.1.0":
     url: "https://github.com/open-dis/open-dis-cpp/archive/refs/tags/v1.1.0.tar.gz"
     sha256: "1c33220152ff6c303b8f84da4f80b28cde86f2df4303651183d3fa6dfcb74fc9"
+  "1.2.0":
+    url: "https://github.com/open-dis/open-dis-cpp/archive/refs/tags/v1.2.0.tar.gz"
+    sha256: "05a219fb60e3c2698e2888e23a061eb45c31234ea1caafba32e05b59b71a9ca1"

--- a/recipes/open-dis-cpp/all/conandata.yml
+++ b/recipes/open-dis-cpp/all/conandata.yml
@@ -7,4 +7,4 @@ sources:
     sha256: "1c33220152ff6c303b8f84da4f80b28cde86f2df4303651183d3fa6dfcb74fc9"
   "1.2.0":
     url: "https://github.com/open-dis/open-dis-cpp/archive/refs/tags/v1.2.0.tar.gz"
-    sha256: "05a219fb60e3c2698e2888e23a061eb45c31234ea1caafba32e05b59b71a9ca1"
+    sha256: "aa1b9b5e5f00e5b8819c111f0a5a0e56266c7ccc0ec9b9f5b9d33f7721438216"

--- a/recipes/open-dis-cpp/all/conanfile.py
+++ b/recipes/open-dis-cpp/all/conanfile.py
@@ -1,7 +1,6 @@
 import os
 
 from conan import ConanFile
-from conan.errors import ConanException
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir
 from conan.tools.build import check_min_cppstd
@@ -32,9 +31,8 @@ class OpenDisConan(ConanFile):
         tc = CMakeToolchain(self)
         tc.cache_variables["BUILD_EXAMPLES"] = "FALSE"
         tc.cache_variables["BUILD_TESTS"] = "FALSE"
-        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
-        if Version(self.version) > "1.1.0": # pylint: disable=conan-unreachable-upper-version
-            raise ConanException("CMAKE_POLICY_VERSION_MINIMUM hardcoded to 3.5, check if new version supports CMake 4")
+        if Version(self.version) < "1.2.0":
+            tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5"  # CMake 4 support
         tc.generate()
 
     def layout(self):

--- a/recipes/open-dis-cpp/config.yml
+++ b/recipes/open-dis-cpp/config.yml
@@ -3,3 +3,5 @@ versions:
     folder: all
   "1.1.0":
     folder: all
+  "1.2.0":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **open-dis-cpp/1.2.0**

#### Motivation
Update recipe to include the latest [1.2.0 library release](https://github.com/open-dis/open-dis-cpp/releases/tag/v1.2.0).

Supercedes https://github.com/conan-io/conan-center-index/pull/26839

#### Details
Added 1.2.0 release version

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
