### PR TITLE
ktx: Change CMakeToolchain variables to cache_variables

### DIFF
--- a/recipes/ktx/all/conanfile.py
+++ b/recipes/ktx/all/conanfile.py
@@ -87,11 +87,11 @@ class KtxConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["KTX_FEATURE_TOOLS"] = self.options.tools
-        tc.variables["KTX_FEATURE_DOC"] = False
-        tc.variables["KTX_FEATURE_LOADTEST_APPS"] = False
-        tc.variables["KTX_FEATURE_TESTS"] = False
-        tc.variables["BASISU_SUPPORT_SSE"] = self.options.get_safe("sse", False)
+        tc.cache_variables["KTX_FEATURE_TOOLS"] = self.options.tools
+        tc.cache_variables["KTX_FEATURE_DOC"] = False
+        tc.cache_variables["KTX_FEATURE_LOADTEST_APPS"] = False
+        tc.cache_variables["KTX_FEATURE_TESTS"] = False
+        tc.cache_variables["BASISU_SUPPORT_SSE"] = self.options.get_safe("sse", False)
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()


### PR DESCRIPTION
### Summary
Changes to recipe: **ktx/4.4.2**

#### Motivation
Bug encountered: `fmt` was not disabled when `tools=False`.
The KTX CMake feature options are currently passed using `tc.variables`, which means they are not available during the initial CMake configure step.

#### Details
Replace `tc.variables` with `tc.cache_variables` for the KTX CMake feature options.