### PR TITLE
opus: fix windows arm

### DIFF
--- a/recipes/opus/all/conandata.yml
+++ b/recipes/opus/all/conandata.yml
@@ -6,5 +6,7 @@ sources:
     url: "https://github.com/xiph/opus/releases/download/v1.5.2/opus-1.5.2.tar.gz"
     sha256: "65c1d2f78b9f2fb20082c38cbe47c951ad5839345876e46941612ee87f9a7ce1"
 patches:
+  "1.6.1":
+    - patch_file: "patches/1.6.1-windows-arm.patch"
   "1.5.2":
     - patch_file: "patches/1.5.2-add-sse4.1-flag-when-using-clang-cl.patch"

--- a/recipes/opus/all/patches/1.6.1-windows-arm.patch
+++ b/recipes/opus/all/patches/1.6.1-windows-arm.patch
@@ -1,11 +1,6 @@
-From e19605be6ac07992b0870413f02c705df97ef8ae Mon Sep 17 00:00:00 2001
-From: Terry Chen <terry@example.com>
-Date: Mon, 27 Apr 2026 22:46:05 -0400
-Subject: [PATCH] Gate ARM DNN RTCD source on DNN builds
-
----
- CMakeLists.txt | 4 +++-
- 1 file changed, 3 insertions(+), 1 deletion(-)
+Upstream PR: https://github.com/xiph/opus/pull/471
+- Only add the ARM DNN runtime-dispatch source when DNN sources are enabled.
+- Match the x86 CMake path and Autotools gating so non-DNN ARM builds do not compile arm_dnn_map.c.
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 index aa7b1ae17..913768856 100644

--- a/recipes/opus/all/patches/1.6.1-windows-arm.patch
+++ b/recipes/opus/all/patches/1.6.1-windows-arm.patch
@@ -1,0 +1,24 @@
+From e19605be6ac07992b0870413f02c705df97ef8ae Mon Sep 17 00:00:00 2001
+From: Terry Chen <terry@example.com>
+Date: Mon, 27 Apr 2026 22:46:05 -0400
+Subject: [PATCH] Gate ARM DNN RTCD source on DNN builds
+
+---
+ CMakeLists.txt | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index aa7b1ae17..913768856 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -563,7 +563,9 @@ if(NOT OPUS_DISABLE_INTRINSICS)
+         target_compile_definitions(opus PRIVATE OPUS_HAVE_RTCD)
+         add_sources_group(opus celt ${celt_sources_arm_rtcd})
+         add_sources_group(opus silk ${silk_sources_arm_rtcd})
+-        add_sources_group(opus lpcnet ${dnn_sources_arm_rtcd})
++        if (OPUS_DNN)
++          add_sources_group(opus lpcnet ${dnn_sources_arm_rtcd})
++        endif()
+       else()
+         message(ERROR "Runtime cpu capability detection needed for MAY_HAVE_NEON")
+       endif()


### PR DESCRIPTION
### Summary
Changes to recipe:  **opus/1.6.2**

#### Motivation
failure without this fix:
```
opus/1.6.1: Building from source
opus/1.6.1: Package opus/1.6.1:4432a0a14d3f85a3674742d1be4261502c686dae
opus/1.6.1: settings: os=Windows arch=armv8 compiler=msvc compiler.runtime=dynamic compiler.runtime_type=Release compiler.version=194 build_type=Release
opus/1.6.1: options: fixed_point=False shared=True stack_protector=True
opus/1.6.1: Copying sources to build folder
opus/1.6.1: Building your package in C:\Users\runner***\.conan2\p\b\opus688977059c6a9\b
opus/1.6.1: Calling generate()
opus/1.6.1: Generators folder: C:\Users\runner***\.conan2\p\b\opus688977059c6a9\b\build\Release\generators
opus/1.6.1: CMakeToolchain generated: conan_toolchain.cmake
opus/1.6.1: CMakeToolchain generated: C:\Users\runner***\.conan2\p\b\opus688977059c6a9\b\build\Release\generators\CMakePresets.json
opus/1.6.1: CMakeToolchain generated: C:\Users\runner***\.conan2\p\b\opus688977059c6a9\b\src\CMakeUserPresets.json
opus/1.6.1: Generating aggregated env files
opus/1.6.1: Generated aggregated env files: ['conanbuild.bat', 'conanrun.bat']
opus/1.6.1: Calling build()
opus/1.6.1: apply_conandata_patches(): No patches defined in conandata
opus/1.6.1: Running CMake.configure()
opus/1.6.1: RUN: cmake -G "Ninja" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="C:/Users/runner***/.conan2/p/b/opus688977059c6a9/p" -DOPUS_BUILD_SHARED_LIBRARY="ON" -DOPUS_FIXED_POINT="OFF" -DOPUS_STACK_PROTECTOR="ON" -DOPUS_STATIC_RUNTIME="OFF" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" -DCMAKE_C_COMPILER="cl" -DCMAKE_CXX_COMPILER="cl" "C:/Users/runner***/.conan2/p/b/opus688977059c6a9/b/src"
conanvcvars.bat: Activating environment Visual Studio 17 - arm64 - winsdk_version=None - vcvars_ver=14.4
[vcvarsall.bat] Environment initialized for: 'arm64'
-- Found Git: C:/Program Files/Git/bin/git.exe (found version "2.54.0.windows.1")
-- Opus package version from package_version file: 1.6.1
-- Opus project version: 1.6.1
-- Using Conan toolchain: C:/Users/runner***/.conan2/p/b/opus688977059c6a9/b/build/Release/generators/conan_toolchain.cmake
-- Conan toolchain: Setting CMAKE_MSVC_RUNTIME_LIBRARY=$<$<CONFIG:Release>:MultiThreadedDLL>
-- Conan toolchain: Setting BUILD_SHARED_LIBS = ON
-- The C compiler identification is MSVC 19.44.35228.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.44.35207/bin/Hostarm64/arm64/cl.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Performing Test VLA_SUPPORTED
-- Performing Test VLA_SUPPORTED -- failed to compile
-- Looking for alloca.h
-- Looking for alloca.h - not found
-- Looking for alloca
-- Looking for alloca - found
-- Looking for floor in m
-- Looking for floor in m - not found
-- Looking for lrintf
-- Looking for lrintf - found
-- Looking for lrint
-- Looking for lrint - found
-- Looking for elf_aux_info
-- Looking for elf_aux_info - not found
-- Check NEON support by compiler
-- Looking for arm_neon.h
-- Looking for arm_neon.h - found
-- Performing Test FAST_MATH_SUPPORTED
-- Performing Test FAST_MATH_SUPPORTED - Success
-- Performing Test STACK_PROTECTOR_SUPPORTED
-- Performing Test STACK_PROTECTOR_SUPPORTED - Success
-- Performing Test STACK_PROTECTOR_DISABLED_SUPPORTED
-- Performing Test STACK_PROTECTOR_DISABLED_SUPPORTED - Success
-- The following features have been enabled:

 * OPUS_BUILD_SHARED_LIBRARY, build shared library.
 * OPUS_ENABLE_FLOAT_API, compile with the floating point API (for machines with float library).
 * OPUS_HARDENING, run-time checks that are cheap and safe for use in production.
 * OPUS_INSTALL_PKG_CONFIG_MODULE, install pkg-config module.
 * OPUS_INSTALL_CMAKE_CONFIG_MODULE, install CMake package config module.
 * OPUS_USE_ALLOCA, use alloca for stack arrays (on non-C99 compilers).
 * OPUS_STACK_PROTECTOR, use stack protection.

-- The following OPTIONAL packages have been found:

 * Git

-- The following features have been disabled:

 * OPUS_BUILD_TESTING, build tests.
 * OPUS_CUSTOM_MODES, enable non-Opus modes, e.g. 44.1 kHz & 2^n frames.
 * OPUS_BUILD_PROGRAMS, build programs.
 * OPUS_DISABLE_INTRINSICS, disable all intrinsics optimizations.
 * OPUS_FIXED_POINT, compile as fixed-point (for machines without a fast enough FPU).
 * OPUS_FLOAT_APPROX, enable floating point approximations (Ensure your platform supports IEEE 754 before enabling).
 * OPUS_ASSERTIONS, additional software error checking.
 * OPUS_FUZZING, causes the encoder to make random decisions (do not use in production).
 * OPUS_CHECK_ASM, enable bit-exactness checks between optimized and c implementations.
 * OPUS_DNN_FLOAT_DEBUG, Run DNN computations as float for debugging purposes.
 * OPUS_DRED, enable DRED.
 * OPUS_OSCE, enable OSCE.
 * OPUS_STATIC_RUNTIME, build with static runtime library.
 * OPUS_FIXED_POINT_DEBUG, debug fixed-point implementation.
 * OPUS_VAR_ARRAYS, use variable length arrays for stack arrays.
 * OPUS_NONTHREADSAFE_PSEUDOSTACK, use a non threadsafe pseudostack when neither variable length arrays or alloca is supported.
 * OPUS_FAST_MATH, enable fast math (unsupported and discouraged use, as code is not well tested with this build option).

-- OPUS_MAY_HAVE_NEON enabling runtime detection
-- Configuring done (6.0s)
-- Generating done (0.1s)
-- Build files have been written to: C:/Users/runner***/.conan2/p/b/opus688977059c6a9/b/build/Release

opus/1.6.1: Running CMake.build()
opus/1.6.1: RUN: cmake --build "C:\Users\runner***\.conan2\p\b\opus688977059c6a9\b\build\Release" -- -j4
conanvcvars.bat: Activating environment Visual Studio 17 - arm64 - winsdk_version=None - vcvars_ver=14.4
[vcvarsall.bat] Environment initialized for: 'arm64'
[1/148] Building C object CMakeFiles\opus.dir\src\opus.c.obj
...
[147/148] Building C object CMakeFiles\opus.dir\silk\arm\NSQ_del_dec_neon_intr.c.obj
[148/148] Linking C shared library opus.dll
FAILED: [code=4294967295] opus.dll opus.lib 
C:\Windows\system32\cmd.exe /C "cd . && C:\Users\runner***\.conan2\p\cmaked362ef56d9303\p\bin\cmake.exe -E vs_link_dll --msvc-ver=1944 --intdir=CMakeFiles\opus.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100261~1.0\arm64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100261~1.0\arm64\mt.exe --manifests  -- C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1444~1.352\bin\HOSTAR~1\arm64\link.exe /nologo @CMakeFiles\opus.rsp  /out:opus.dll /implib:opus.lib /pdb:opus.pdb /dll /version:0.11 /machine:ARM64 /INCREMENTAL:NO && cd ."
LINK: command "C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1444~1.352\bin\HOSTAR~1\arm64\link.exe /nologo @CMakeFiles\opus.rsp /out:opus.dll /implib:opus.lib /pdb:opus.pdb /dll /version:0.11 /machine:ARM64 /INCREMENTAL:NO /MANIFEST:EMBED,ID=2" failed (exit code 1120) with the following output:
   Creating library opus.lib and object opus.exp

arm_dnn_map.c.obj : error LNK2001: unresolved external symbol compute_activation_c

arm_dnn_map.c.obj : error LNK2001: unresolved external symbol compute_conv2d_c

arm_dnn_map.c.obj : error LNK2001: unresolved external symbol compute_activation_neon

arm_dnn_map.c.obj : error LNK2001: unresolved external symbol compute_conv2d_neon

opus.dll : fatal error LNK1120: 4 unresolved externals

ninja: build stopped: subcommand failed.

opus/1.6.1: ERROR: 
Package '4432a0a14d3f85a3674742d1be4261502c686dae' build failed
opus/1.6.1: WARN: Build folder C:\Users\runner***\.conan2\p\b\opus688977059c6a9\b\build\Release
ERROR: opus/1.6.1: Error in build() method, line 67
	cmake.build()
	ConanException: Error 4294967295 while executing
Error: Process completed with exit code 1.
```

success with this change : https://github.com/ericLemanissier/cocorepo/actions/runs/28425887691/job/84228978497

#### Details
the fix comes from https://github.com/xiph/opus/pull/471

it reproduces the x86 logic https://github.com/xiph/opus/blob/v1.6.1/CMakeLists.txt#L447


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
