### PR TITLE
sse2neon/1.9.1

### DIFF
--- a/recipes/sse2neon/all/conandata.yml
+++ b/recipes/sse2neon/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.9.1":
+    url: "https://github.com/DLTcollab/sse2neon/archive/refs/tags/v1.9.1.tar.gz"
+    sha256: "6b70e7cb8c5ce4641002b85deaafe97efdf9ade9b49884edeaf678b35f0e132f"

--- a/recipes/sse2neon/all/conanfile.py
+++ b/recipes/sse2neon/all/conanfile.py
@@ -44,6 +44,3 @@ class PackageConan(ConanFile):
     def package_info(self):
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
-        if is_msvc(self):
-            # cf https://github.com/DLTcollab/sse2neon/blob/v1.9.1/sse2neon.h#L365
-            self.cpp_info.cxxflags.append("/Zc:preprocessor")

--- a/recipes/sse2neon/all/conanfile.py
+++ b/recipes/sse2neon/all/conanfile.py
@@ -2,7 +2,6 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.files import copy, get
 from conan.tools.layout import basic_layout
-from conan.tools.microsoft import is_msvc
 import os
 
 
@@ -21,7 +20,7 @@ class PackageConan(ConanFile):
     no_copy_source = True
 
     def layout(self):
-        basic_layout(self, src_folder=".")
+        basic_layout(self, src_folder="src")
 
     def package_id(self):
         self.info.clear()

--- a/recipes/sse2neon/all/conanfile.py
+++ b/recipes/sse2neon/all/conanfile.py
@@ -1,0 +1,49 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+from conan.tools.microsoft import is_msvc
+import os
+
+
+required_conan_version = ">=2.0"
+
+
+class PackageConan(ConanFile):
+    name = "sse2neon"
+    description = "A translator from Intel SSE intrinsics to Arm/Aarch64 NEON implementation"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/DLTcollab/sse2neon"
+    topics = ("sse2", "neon", "header-only")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    def layout(self):
+        basic_layout(self, src_folder=".")
+
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        arch = str(self.settings.arch)
+        if not arch.startswith("armv7") and not arch.startswith("armv8") and not arch.startswith("arm64"):
+            raise ConanInvalidConfiguration(f"{self.ref} can only be used for ARM NEON architectures.")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def build(self):
+        pass
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        copy(self, "sse2neon.h", self.source_folder, os.path.join(self.package_folder, "include"))
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+        if is_msvc(self):
+            # cf https://github.com/DLTcollab/sse2neon/blob/v1.9.1/sse2neon.h#L365
+            self.cpp_info.cxxflags.append("/Zc:preprocessor")

--- a/recipes/sse2neon/all/test_package/CMakeLists.txt
+++ b/recipes/sse2neon/all/test_package/CMakeLists.txt
@@ -6,6 +6,6 @@ find_package(sse2neon REQUIRED CONFIG)
 add_executable(${PROJECT_NAME} test_package.cpp)
 if (MSVC)
     # Consumers should define Zc:preprocessor
-    target_compile_options(${PROJECT_NAME} /Zc:preprocessor)
+    target_compile_options(${PROJECT_NAME} PRIVATE "/Zc:preprocessor")
 endif()
 target_link_libraries(${PROJECT_NAME} PRIVATE sse2neon::sse2neon)

--- a/recipes/sse2neon/all/test_package/CMakeLists.txt
+++ b/recipes/sse2neon/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(sse2neon REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE sse2neon::sse2neon)

--- a/recipes/sse2neon/all/test_package/CMakeLists.txt
+++ b/recipes/sse2neon/all/test_package/CMakeLists.txt
@@ -4,4 +4,8 @@ project(test_package LANGUAGES CXX)
 find_package(sse2neon REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
+if (MSVC)
+    # Consumers should define Zc:preprocessor
+    target_compile_options(${PROJECT_NAME} /Zc:preprocessor)
+endif()
 target_link_libraries(${PROJECT_NAME} PRIVATE sse2neon::sse2neon)

--- a/recipes/sse2neon/all/test_package/conanfile.py
+++ b/recipes/sse2neon/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/sse2neon/all/test_package/test_package.cpp
+++ b/recipes/sse2neon/all/test_package/test_package.cpp
@@ -1,0 +1,16 @@
+#include <stdio.h>
+#include "sse2neon.h"
+
+int main(void) {
+    __m128i a = _mm_set_epi32(4, 3, 2, 1);
+    __m128i b = _mm_set_epi32(40, 30, 20, 10);
+
+    __m128i sum = _mm_add_epi32(a, b);
+
+    int32_t result[4];
+    _mm_storeu_si128((__m128i *)result, sum);
+
+    printf("Result: %d %d %d %d\n", result[0], result[1], result[2], result[3]);
+
+    return 0;
+}

--- a/recipes/sse2neon/config.yml
+++ b/recipes/sse2neon/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.9.1":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **sse2neon/1.9.1**

#### Motivation
this recipe is a requirement of OpenColorIO https://github.com/AcademySoftwareFoundation/OpenColorIO/blob/f660cee6127011fdb03e0d227572901631435d3c/CMakeLists.txt#L328

vcpkg provides it https://github.com/microsoft/vcpkg/tree/86dc619bd8d9697405ae5c944b474117ea9457ce/ports/sse2neon and opencolorio consumes it https://github.com/microsoft/vcpkg/blob/86dc619bd8d9697405ae5c944b474117ea9457ce/ports/opencolorio/vcpkg.json#L20

#### Details
successful ARM CI:
- linux: https://github.com/ericLemanissier/cocorepo/actions/runs/28430606927/job/84244378938#step:13:129
- windows: https://github.com/ericLemanissier/cocorepo/actions/runs/28430606927/job/84244378960#step:13:141


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
