### PR TITLE
opencolorio: require sse2neon on arm

### DIFF
--- a/recipes/opencolorio/all/conanfile.py
+++ b/recipes/opencolorio/all/conanfile.py
@@ -53,6 +53,8 @@ class OpenColorIOConan(ConanFile):
         self.requires("pystring/1.1.4")
         self.requires("yaml-cpp/0.8.0")
         self.requires("minizip-ng/[>=4.0.3 <5]")
+        if self.settings.arch == "armv8" and str(self.settings.os) in ["Windows", "Macos"]:
+            self.requires("sse2neon/1.9.1")
 
         # for tools only
         self.requires("lcms/[>=2.16 <3]")


### PR DESCRIPTION
### Summary
Changes to recipe:  **opencolorio/***
add dependency on sse2neon

#### Motivation
https://github.com/AcademySoftwareFoundation/OpenColorIO/blob/f660cee6127011fdb03e0d227572901631435d3c/CMakeLists.txt#L328

#### Details
without this dependency, it falls back on fetchcontent

CI successful with this change: https://github.com/ericLemanissier/cocorepo/actions/runs/28432086218
CI error without this change: https://github.com/ericLemanissier/cocorepo/actions/runs/28433084437/job/84252477444
```
opencolorio/2.5.2: RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/Users/runner/.conan2/p/b/openc04f6fa2b2fb54/p" -DCMAKE_POLICY_DEFAULT_CMP0077="NEW" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/Users/runner/.conan2/p/b/openc04f6fa2b2fb54/b/src"
-- Using Conan toolchain: /Users/runner/.conan2/p/b/openc04f6fa2b2fb54/b/build/Release/generators/conan_toolchain.cmake
-- Conan toolchain: Setting CMAKE_POSITION_INDEPENDENT_CODE=ON (options.fPIC)
-- Conan toolchain: Defining libcxx as C++ flags: -stdlib=libc++
-- Conan toolchain: C++ Standard 17 with extensions ON
-- Conan toolchain: Setting BUILD_SHARED_LIBS = OFF
-- The CXX compiler identification is AppleClang 15.0.0.15000309
-- The C compiler identification is AppleClang 15.0.0.15000309
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Performing Test COMPILER_SUPPORTS_CXX17
-- Performing Test COMPILER_SUPPORTS_CXX17 - Success
-- 
-- Checking for GPU configuration...
-- Found OpenGL (no version information)
-- Found GLUT (no version information)
-- GLVND not supported; legacy OpenGL libraries used
-- Performing Test COMPILER_SUPPORTS_ARM_NEON
-- Performing Test COMPILER_SUPPORTS_ARM_NEON - Success
CMake Error at /Users/runner/.conan2/p/cmake7509dbf5dd5a9/p/CMake.app/Contents/share/cmake-4.3/Modules/FetchContent.cmake:2119 (message):
  FETCHCONTENT_FULLY_DISCONNECTED is set to true, which requires the source
  directory for dependency sse2neon to already be populated.  This generally
  means it must not be set to true the first time CMake is run in a build
  directory.  The following source directory should already be populated, but
  it doesn't exist:

    /Users/runner/.conan2/p/b/openc04f6fa2b2fb54/b/build/Release/ext/build/sse2neon/sse2neon-src

  Policy CMP0170 controls enforcement of this requirement.
Call Stack (most recent call first):
  /Users/runner/.conan2/p/cmake7509dbf5dd5a9/p/CMake.app/Contents/share/cmake-4.3/Modules/FetchContent.cmake:2399 (__FetchContent_Populate)
  share/cmake/modules/install/Installsse2neon.cmake:27 (FetchContent_MakeAvailable)
  CMakeLists.txt:332 (include)


-- Configuring incomplete, errors occurred!

opencolorio/2.5.2: ERROR: 
Package '201fab48be8a035bc7c344d473c4dee4c2c0ceba' build failed
opencolorio/2.5.2: WARN: Build folder /Users/runner/.conan2/p/b/openc04f6fa2b2fb54/b/build/Release
ERROR: opencolorio/2.5.2: Error in build() method, line 127
	cm.configure()
	ConanException: Error 1 while executing
```

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
