### PR TITLE
libcurl: detect openssl/libressl via pkg-config instead of a prefix path

### DIFF
--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -356,12 +356,8 @@ class LibcurlConan(ConanFile):
         if not self.options.with_ssl:
             tc.configure_args.append("--without-ssl")
 
-        if self.options.with_ssl == "openssl":
-            path = unix_path(self, self.dependencies["openssl"].package_folder)
-            tc.configure_args.append(f"--with-openssl={path}")
-        elif self.options.with_ssl == "libressl":
-            path = unix_path(self, self.dependencies["libressl"].package_folder)
-            tc.configure_args.append(f"--with-openssl={path}")
+        if self.options.with_ssl in ("openssl", "libressl"):
+            tc.configure_args.append("--with-openssl")
         else:
             tc.configure_args.append("--without-openssl")
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **libcurl/8.20.0**

#### Motivation
In the autotools build, the recipe passed `--with-openssl=<package_folder>`.
curl's `m4/curl-openssl.m4` treats `--with-openssl=<prefix>` as "look only here", disabling the pkg-config probe and hard-codes `-I<prefix>/include` / `-L<prefix>/lib`.
That assumes the resolved openssl/libressl package ships a real include/lib tree.

That holds for the conan-center recipes but not for a **system-wrapper** package (canonical Conan 2 system-package pattern), whose `package_folder` has no headers or libs. In these cases configure fails with `bad --with-openssl prefix!`.

Closes #30515

#### Details
Passing `--with-openssl` **without a path** makes configure resolve the backend through pkg-config, which this recipe already wires up (`PkgConfigDeps` emits `openssl.pc`, `pkgconf` is a `tool_requires`, and `AutotoolsToolchain` puts the generators folder on `PKG_CONFIG_PATH`).

This works for **both** stock packages and system wrappers.
libressl is handled identically: it sets `provides = "openssl"` and `pkg_config_name = "openssl"`, so it exposes `openssl.pc` and stays mutually exclusive with openssl in the graph.

The CMake build path is unaffected (it drives detection via `CURL_USE_OPENSSL` + `CMakeDeps`/`find_package`, not a prefix).

Tested locally (autotools, `aarch64-linux-gnu`):
- **System-wrapper openssl** - configure now resolves via pkg-config (`checking for openssl options with pkg-config... found`, `SSL_LIBS: -lssl -lcrypto`) instead of erroring on the empty prefix.
- **Stock conan-center openssl/3.x** - full end-to-end build passes, confirming no regression for normal packages.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!