### PR TITLE
gdal: bump arrow

### DIFF
--- a/recipes/gdal/post_3.5.0/conanfile.py
+++ b/recipes/gdal/post_3.5.0/conanfile.py
@@ -183,7 +183,7 @@ class GdalConan(ConanFile):
         if self.options.with_armadillo:
             self.requires("armadillo/12.6.4")
         if self.options.with_arrow:
-            if self.options.with_arrow and Version(self.version) >= "3.13.0":
+            if Version(self.version) >= "3.13.0":
                 self.requires("arrow/[>=14.0.2 <25]")
             else:
                 self.requires("arrow/[>=14.0.2 <20]")

--- a/recipes/gdal/post_3.5.0/conanfile.py
+++ b/recipes/gdal/post_3.5.0/conanfile.py
@@ -184,7 +184,7 @@ class GdalConan(ConanFile):
             self.requires("armadillo/12.6.4")
         if self.options.with_arrow:
             if self.options.with_arrow and Version(self.version) >= "3.13.0":
-                self.requires("arrow/[>=14.0.2]")
+                self.requires("arrow/[>=14.0.2 <25]")
             else:
                 self.requires("arrow/[>=14.0.2 <20]")
         if self.options.with_basisu:

--- a/recipes/gdal/post_3.5.0/conanfile.py
+++ b/recipes/gdal/post_3.5.0/conanfile.py
@@ -183,7 +183,10 @@ class GdalConan(ConanFile):
         if self.options.with_armadillo:
             self.requires("armadillo/12.6.4")
         if self.options.with_arrow:
-            self.requires("arrow/[>=14.0.2 <20]")
+            if self.options.with_arrow and Version(self.version) >= "3.13.0":
+                self.requires("arrow/[>=14.0.2]")
+            else:
+                self.requires("arrow/[>=14.0.2 <20]")
         if self.options.with_basisu:
             self.requires("libbasisu/1.15.0")
         if self.options.with_blosc:


### PR DESCRIPTION
### Summary
Changes to recipe:  **gdal/3.13.0**

#### Motivation
compatibility with arrow > 20 has been fixed in gdal 3.13.0 cf https://github.com/OSGeo/gdal/issues/14320
bumping arrow unlocks windows arm build : https://github.com/ericLemanissier/cocorepo/actions/runs/28445132643/job/84292797974

#### Details
CI results at https://github.com/ericLemanissier/cocorepo/actions/runs/28445132643


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
