### PR TITLE
hictk 2.22.0

### DIFF
--- a/recipes/hictk/all/conandata.yml
+++ b/recipes/hictk/all/conandata.yml
@@ -2,12 +2,3 @@ sources:
   "2.2.0":
     url: "https://github.com/paulsengroup/hictk/archive/refs/tags/v2.2.0.tar.gz"
     sha256: "989b6e84b967309d9822ee3274abf98daba66d3d6e6ae8c9abffcede07b24761"
-  "2.1.5":
-    url: "https://github.com/paulsengroup/hictk/archive/refs/tags/v2.1.5.tar.gz"
-    sha256: "842e0193d3c8d9286de89cd8a02a50ef11bdfd55e63fc757c64ce363d0958980"
-  "2.0.2":
-    url: "https://github.com/paulsengroup/hictk/archive/refs/tags/v2.0.2.tar.gz"
-    sha256: "349d7635186f91707ab4f55e9427fd966bebd2337542e394ae93f08c0759411d"
-  "1.0.0":
-    url: "https://github.com/paulsengroup/hictk/archive/refs/tags/v1.0.0.tar.gz"
-    sha256: "e337f52658a257eb6265e211dd3cef6b73db40bdc5b5a6433b47ce4faa6006fb"

--- a/recipes/hictk/all/conandata.yml
+++ b/recipes/hictk/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.2.0":
+    url: "https://github.com/paulsengroup/hictk/archive/refs/tags/v2.2.0.tar.gz"
+    sha256: "989b6e84b967309d9822ee3274abf98daba66d3d6e6ae8c9abffcede07b24761"
   "2.1.5":
     url: "https://github.com/paulsengroup/hictk/archive/refs/tags/v2.1.5.tar.gz"
     sha256: "842e0193d3c8d9286de89cd8a02a50ef11bdfd55e63fc757c64ce363d0958980"

--- a/recipes/hictk/all/conanfile.py
+++ b/recipes/hictk/all/conanfile.py
@@ -5,7 +5,6 @@ from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir, unzip
-from conan.tools.scm import Version
 
 required_conan_version = ">=2.0"
 
@@ -33,24 +32,15 @@ class HictkConan(ConanFile):
 
     def requirements(self):
         if self.options.with_arrow:
-            if Version(self.version) < "2.2.0":
-                self.requires("arrow/[>=16.1.0 <21]")
-            else:
-                self.requires("arrow/[>=16.1.0 <25]")
-        if Version(self.version) < "2.0.0":
-            self.requires("bshoshany-thread-pool/4.1.0")
-        else:
-            self.requires("bshoshany-thread-pool/5.0.0")
+            self.requires("arrow/[>=16.1.0 <25]")
+        self.requires("bshoshany-thread-pool/5.0.0")
         self.requires("concurrentqueue/1.0.4")
         self.requires("fast_float/6.1.1")
         if self.options.with_eigen:
             self.requires("eigen/[>=3.4.0 <4]")
         self.requires("fmt/10.2.1")
         self.requires("hdf5/1.14.3")
-        if Version(self.version) < "2.1.5":
-            self.requires("highfive/[>=2.9.0 <3]")
-        else:
-            self.requires("highfive/[>=2.9.0 <4]")
+        self.requires("highfive/[>=2.9.0 <4]")
         self.requires("libdeflate/1.22")
         self.requires("parallel-hashmap/1.3.12") # Note: v1.3.12 is more recent than v1.37
         self.requires("readerwriterqueue/1.0.6")
@@ -73,15 +63,12 @@ class HictkConan(ConanFile):
         self.tool_requires("cmake/[>=3.25]")
 
     @property
-    def project_options_version(self):
-        if Version(self.version) < "2.0.0":
-            return "0.33.0"
-        else:
-            return "0.36.6"
+    def _project_options_version(self):
+        return "0.36.6"
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
-        unzip(self, os.path.join(self.source_folder, "external", f"project_options-v{self.project_options_version}.tar.xz"), os.path.join(self.source_folder, "external"))
+        unzip(self, os.path.join(self.source_folder, "external", f"project_options-v{self._project_options_version}.tar.xz"), os.path.join(self.source_folder, "external"))
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -93,7 +80,10 @@ class HictkConan(ConanFile):
         tc.cache_variables["HICTK_ENABLE_FUZZY_TESTING"] = "OFF"
         tc.cache_variables["HICTK_WITH_ARROW"] = self.options.get_safe("with_arrow", False)
         tc.cache_variables["HICTK_WITH_EIGEN"] = self.options.with_eigen
-        tc.cache_variables["FETCHCONTENT_SOURCE_DIR__HICTK_PROJECT_OPTIONS"] = os.path.join(self.source_folder, "external", f"project_options-{self.project_options_version}")
+
+        project_options_dir = os.path.join(self.source_folder, "external", f"project_options-{self._project_options_version}")
+        # prevent a download during the build for FetchContent_Declare(_hictk_project_options ...)
+        tc.cache_variables["FETCHCONTENT_SOURCE_DIR__HICTK_PROJECT_OPTIONS"] = project_options_dir
         tc.generate()
 
         cmakedeps = CMakeDeps(self)

--- a/recipes/hictk/all/conanfile.py
+++ b/recipes/hictk/all/conanfile.py
@@ -36,7 +36,7 @@ class HictkConan(ConanFile):
             if Version(self.version) < "2.2.0":
                 self.requires("arrow/[>=16.1.0 <21]")
             else:
-                self.requires("arrow/[>=16.1.0]")
+                self.requires("arrow/[>=16.1.0 <25]")
         if Version(self.version) < "2.0.0":
             self.requires("bshoshany-thread-pool/4.1.0")
         else:

--- a/recipes/hictk/all/conanfile.py
+++ b/recipes/hictk/all/conanfile.py
@@ -46,7 +46,7 @@ class HictkConan(ConanFile):
         if self.options.with_eigen:
             self.requires("eigen/[>=3.4.0 <4]")
         self.requires("fmt/10.2.1")
-        self.requires("hdf5/1.14.6")
+        self.requires("hdf5/1.14.3")
         if Version(self.version) < "2.1.5":
             self.requires("highfive/[>=2.9.0 <3]")
         else:

--- a/recipes/hictk/all/conanfile.py
+++ b/recipes/hictk/all/conanfile.py
@@ -46,7 +46,7 @@ class HictkConan(ConanFile):
         if self.options.with_eigen:
             self.requires("eigen/[>=3.4.0 <4]")
         self.requires("fmt/10.2.1")
-        self.requires("hdf5/1.14.3")
+        self.requires("hdf5/1.14.6")
         if Version(self.version) < "2.1.5":
             self.requires("highfive/[>=2.9.0 <3]")
         else:

--- a/recipes/hictk/all/conanfile.py
+++ b/recipes/hictk/all/conanfile.py
@@ -33,7 +33,10 @@ class HictkConan(ConanFile):
 
     def requirements(self):
         if self.options.with_arrow:
-            self.requires("arrow/[>=16.1.0 <21]")
+            if Version(self.version) < "2.2.0":
+                self.requires("arrow/[>=16.1.0 <21]")
+            else:
+                self.requires("arrow/[>=16.1.0]")
         if Version(self.version) < "2.0.0":
             self.requires("bshoshany-thread-pool/4.1.0")
         else:

--- a/recipes/hictk/all/conanfile.py
+++ b/recipes/hictk/all/conanfile.py
@@ -72,9 +72,16 @@ class HictkConan(ConanFile):
     def build_requirements(self):
         self.tool_requires("cmake/[>=3.25]")
 
+    @property
+    def project_options_version(self):
+        if Version(self.version) < "2.0.0":
+            return "0.33.0"
+        else:
+            return "0.36.6"
+
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
-        unzip(self, os.path.join(self.source_folder, "external", "project_options-v0.36.6.tar.xz"), os.path.join(self.source_folder, "external"))
+        unzip(self, os.path.join(self.source_folder, "external", f"project_options-v{self.project_options_version}.tar.xz"), os.path.join(self.source_folder, "external"))
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -86,7 +93,7 @@ class HictkConan(ConanFile):
         tc.cache_variables["HICTK_ENABLE_FUZZY_TESTING"] = "OFF"
         tc.cache_variables["HICTK_WITH_ARROW"] = self.options.get_safe("with_arrow", False)
         tc.cache_variables["HICTK_WITH_EIGEN"] = self.options.with_eigen
-        tc.cache_variables["FETCHCONTENT_SOURCE_DIR__HICTK_PROJECT_OPTIONS"] = os.path.join(self.source_folder, "external", "project_options-0.36.6")
+        tc.cache_variables["FETCHCONTENT_SOURCE_DIR__HICTK_PROJECT_OPTIONS"] = os.path.join(self.source_folder, "external", f"project_options-{self.project_options_version}")
         tc.generate()
 
         cmakedeps = CMakeDeps(self)

--- a/recipes/hictk/all/conanfile.py
+++ b/recipes/hictk/all/conanfile.py
@@ -4,7 +4,7 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, get, rmdir
+from conan.tools.files import copy, get, rmdir, unzip
 from conan.tools.scm import Version
 
 required_conan_version = ">=2.0"
@@ -74,6 +74,7 @@ class HictkConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        unzip(self, os.path.join(self.source_folder, "external", "project_options-v0.36.6.tar.xz"), os.path.join(self.source_folder, "external"))
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -85,6 +86,7 @@ class HictkConan(ConanFile):
         tc.cache_variables["HICTK_ENABLE_FUZZY_TESTING"] = "OFF"
         tc.cache_variables["HICTK_WITH_ARROW"] = self.options.get_safe("with_arrow", False)
         tc.cache_variables["HICTK_WITH_EIGEN"] = self.options.with_eigen
+        tc.cache_variables["FETCHCONTENT_SOURCE_DIR__HICTK_PROJECT_OPTIONS"] = os.path.join(self.source_folder, "external", "project_options-0.36.6")
         tc.generate()
 
         cmakedeps = CMakeDeps(self)

--- a/recipes/hictk/all/test_package/test_package.cpp
+++ b/recipes/hictk/all/test_package/test_package.cpp
@@ -1,28 +1,12 @@
-#include <stdexcept>
-
-#include "hictk/balancing/ice.hpp"  // test bshoshany-thread-pool
 #include "hictk/chromosome.hpp"
-#include "hictk/file.hpp"
 #include "hictk/fmt.hpp"  // test formatting of user-defined types with fmt
+#include "spdlog/spdlog.h"
 #include "hictk/genomic_interval.hpp"
-
-#if __has_include("hictk/transformers/to_dataframe.hpp")
-#include "hictk/transformers/to_dataframe.hpp"  // test hictk/*:with_arrow
-#endif
-
-#if __has_include("hictk/transformers/to_dense_matrix.hpp")
-#include "hictk/transformers/to_dense_matrix.hpp"  // test hictk/*:with_eigen
-#endif
 
 int main(int argc, char **argv) {
   const hictk::Chromosome chrom(0, "chr1", 123);
   const hictk::GenomicInterval gi(chrom, 10, 20);
   SPDLOG_INFO(FMT_STRING("interval: {}"), gi);
-
-  try {
-    const hictk::File f(argv[0], 10);  // This is expected to throw
-    return 1;
-  } catch (const std::exception &e) {}
 
   return 0;
 }

--- a/recipes/hictk/config.yml
+++ b/recipes/hictk/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.2.0":
+    folder: all
   "2.1.5":
     folder: all
   "2.0.2":

--- a/recipes/hictk/config.yml
+++ b/recipes/hictk/config.yml
@@ -1,9 +1,3 @@
 versions:
   "2.2.0":
     folder: all
-  "2.1.5":
-    folder: all
-  "2.0.2":
-    folder: all
-  "1.0.0":
-    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **hitctk/2.22.0**
Also, workaround cmake FetchContent:
```
hictk/2.2.0: Calling build()
hictk/2.2.0: Running CMake.configure()
hictk/2.2.0: RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/Users/runner/.conan2/p/b/hictk8ed06f1fa0da6/p" -DHICTK_BUILD_BENCHMARKS="OFF" -DHICTK_BUILD_EXAMPLES="OFF" -DHICTK_BUILD_TOOLS="OFF" -DHICTK_ENABLE_GIT_VERSION_TRACKING="OFF" -DHICTK_ENABLE_TESTING="OFF" -DHICTK_ENABLE_FUZZY_TESTING="OFF" -DHICTK_WITH_ARROW="OFF" -DHICTK_WITH_EIGEN="ON" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/Users/runner/.conan2/p/b/hictk8ed06f1fa0da6/b/src"
-- Using Conan toolchain: /Users/runner/.conan2/p/b/hictk8ed06f1fa0da6/b/build/Release/generators/conan_toolchain.cmake
-- Conan toolchain: Defining libcxx as C++ flags: -stdlib=libc++
-- Conan toolchain: C++ Standard 17 with extensions ON
-- The C compiler identification is AppleClang 15.0.0.15000309
-- The CXX compiler identification is AppleClang 15.0.0.15000309
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
CMake Error at /Users/runner/.conan2/p/cmake7509dbf5dd5a9/p/CMake.app/Contents/share/cmake-4.3/Modules/FetchContent.cmake:2119 (message):
  FETCHCONTENT_FULLY_DISCONNECTED is set to true, which requires the source
  directory for dependency _hictk_project_options to already be populated.
  This generally means it must not be set to true the first time CMake is run
  in a build directory.  The following source directory should already be
  populated, but it doesn't exist:

    /Users/runner/.conan2/p/b/hictk8ed06f1fa0da6/b/build/Release/_deps/_hictk_project_options-src

  Policy CMP0170 controls enforcement of this requirement.
Call Stack (most recent call first):
  /Users/runner/.conan2/p/cmake7509dbf5dd5a9/p/CMake.app/Contents/share/cmake-4.3/Modules/FetchContent.cmake:2399 (__FetchContent_Populate)
  CMakeLists.txt:48 (FetchContent_MakeAvailable)


-- Configuring incomplete, errors occurred!

hictk/2.2.0: ERROR: 
```
Which is now fixed:
```
hictk/2.2.0: Calling source() in /home/codespace/.conan2/p/hictk83ae6b6af2775/s/src
hictk/2.2.0: Uncompressing v2.2.0.tar.gz to .
hictk/2.2.0: Uncompressing /home/codespace/.conan2/p/hictk83ae6b6af2775/s/src/external/project_options-v0.36.6.tar.xz to /home/codespace/.conan2/p/hictk83ae6b6af2775/s/src/external

-------- Installing package hictk/2.2.0 (20 of 20) --------
hictk/2.2.0: Building from source
hictk/2.2.0: Package hictk/2.2.0:da39a3ee5e6b4b0d3255bfef95601890afd80709
hictk/2.2.0: Copying sources to build folder
hictk/2.2.0: Building your package in /home/codespace/.conan2/p/b/hictk9870ed088ce3a/b
hictk/2.2.0: Calling generate()
hictk/2.2.0: Generators folder: /home/codespace/.conan2/p/b/hictk9870ed088ce3a/b/build/Release/generators
hictk/2.2.0: CMakeToolchain generated: conan_toolchain.cmake
hictk/2.2.0: CMakeToolchain generated: /home/codespace/.conan2/p/b/hictk9870ed088ce3a/b/build/Release/generators/CMakePresets.json
hictk/2.2.0: CMakeToolchain generated: /home/codespace/.conan2/p/b/hictk9870ed088ce3a/b/src/CMakeUserPresets.json
hictk/2.2.0: CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(bshoshany-thread-pool)
    find_package(concurrentqueue)
    find_package(FastFloat)
    find_package(HighFive)
    find_package(HDF5)
    find_package(Eigen3)
    find_package(libdeflate)
    find_package(phmap)
    find_package(readerwriterqueue)
    find_package(span-lite)
    find_package(spdlog)
    find_package(fmt)
    find_package(zstd)
    target_link_libraries(... bshoshany-thread-pool::bshoshany-thread-pool concurrentqueue::concurrentqueue FastFloat::fast_float HighFive::HighFive HDF5::HDF5 Eigen3::Eigen libdeflate::libdeflate_static phmap readerwriterqueue::readerwriterqueue nonstd::span-lite spdlog::spdlog fmt::fmt zstd::libzstd_static)
hictk/2.2.0: Generating aggregated env files
hictk/2.2.0: Generated aggregated env files: ['conanbuild.sh', 'conanrun.sh']
hictk/2.2.0: Calling build()
hictk/2.2.0: Running CMake.configure()
hictk/2.2.0: RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/home/codespace/.conan2/p/b/hictk9870ed088ce3a/p" -DHICTK_BUILD_BENCHMARKS="OFF" -DHICTK_BUILD_EXAMPLES="OFF" -DHICTK_BUILD_TOOLS="OFF" -DHICTK_ENABLE_GIT_VERSION_TRACKING="OFF" -DHICTK_ENABLE_TESTING="OFF" -DHICTK_ENABLE_FUZZY_TESTING="OFF" -DHICTK_WITH_ARROW="OFF" -DHICTK_WITH_EIGEN="ON" -DFETCHCONTENT_SOURCE_DIR__HICTK_PROJECT_OPTIONS="/home/codespace/.conan2/p/b/hictk9870ed088ce3a/b/src/external/project_options-0.36.6" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/home/codespace/.conan2/p/b/hictk9870ed088ce3a/b/src"
-- Using Conan toolchain: /home/codespace/.conan2/p/b/hictk9870ed088ce3a/b/build/Release/generators/conan_toolchain.cmake
-- Conan toolchain: Defining architecture flag: -m64
-- Conan toolchain: C++ Standard 17 with extensions ON
-- The C compiler identification is GNU 13.3.0
-- The CXX compiler identification is GNU 13.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- project_options: skipping msvc_toolchain as CMAKE_TOOLCHAIN_FILE is set
-- Developer mode is OFF. For developement, use `-DENABLE_DEVELOPER_MODE:BOOL=ON`. Building the project for the end-user...
-- The default CMAKE_C_STANDARD used by external targets and tools is not set yet. Using the latest supported C standard that is 17
-- Interprocedural optimization is enabled. In other projects, linking with the compiled libraries of this project might require `set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)`
CMake Warning at external/project_options-0.36.6/src/Cache.cmake:23 (message):
  ccache is enabled but was not found.  Not using it
Call Stack (most recent call first):
  external/project_options-0.36.6/src/Index.cmake:247 (enable_cache)
  external/project_options-0.36.6/src/DynamicProjectOptions.cmake:250 (project_options)
  CMakeLists.txt:77 (dynamic_project_options)


-- Detected LITTLE_ENDIAN architecture
-- Configuring done (3.1s)
-- Generating done (0.0s)
-- Build files have been written to: /home/codespace/.conan2/p/b/hictk9870ed088ce3a/b/build/Release

hictk/2.2.0: Running CMake.build()
hictk/2.2.0: RUN: cmake --build "/home/codespace/.conan2/p/b/hictk9870ed088ce3a/b/build/Release" -- -j2

hictk/2.2.0: Package 'da39a3ee5e6b4b0d3255bfef95601890afd80709' built
hictk/2.2.0: Build folder /home/codespace/.conan2/p/b/hictk9870ed088ce3a/b/build/Release
hictk/2.2.0: Generating the package
hictk/2.2.0: Packaging in folder /home/codespace/.conan2/p/b/hictk9870ed088ce3a/p
```

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

#### Details
don't limit arrow cf https://github.com/paulsengroup/hictk/commit/8446aeadc314f67cef4bf5c0cc5e9a7987f3063a

CI results on https://github.com/ericLemanissier/cocorepo/actions/runs/28459221183

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
