### PR TITLE
eigen: make 3.4.1 actually header only

### DIFF
--- a/recipes/eigen/all/conanfile.py
+++ b/recipes/eigen/all/conanfile.py
@@ -55,7 +55,7 @@ class EigenConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.cache_variables["BUILD_TESTING"] = not self.conf.get("tools.build:skip_test", default=True, check_type=bool)
-        if Version(self.version) >= "5.0.0":
+        if Version(self.version) >= "3.4.1":
             # TODO consider making EIGEN_BUILD_{BLAS,LAPACK} tunable
             tc.cache_variables["EIGEN_BUILD_BLAS"] = False
             tc.cache_variables["EIGEN_BUILD_LAPACK"] = False


### PR DESCRIPTION
### Summary
Changes to recipe:  **eigen/3.4.1**

#### Motivation
The recipe as it was was not header only, as can be seen on the last CI : https://c3i.jfrog.io/artifactory/cci-build-logs/cci/prod/PR-28725/3/package_build_logs/build_log_eigen_3_4_1_596b5f9599915bc0de4e7dd7fca20380_da39a3ee5e6b4b0d3255bfef95601890afd80709.success.txt
The build knobs introduced in eigen 5.0.0 have actually been backported to eigen 3.4.1 : https://gitlab.com/libeigen/eigen/-/commit/f1922b6dac4a9c18b07c26658cea08db80489278?file_path=CMakeLists.txt#line_9a2aa4db3_A58

#### Details
current windows build fails with
```
[218/222] Linking CXX static library blas\eigen_blas_static.lib
[219/222] Linking CXX static library lapack\eigen_lapack_static.lib
[220/222] Building CXX object lapack\CMakeFiles\eigen_lapack.dir\complex_double.cpp.obj
[221/222] Building CXX object lapack\CMakeFiles\eigen_lapack.dir\complex_single.cpp.obj
[222/222] Linking CXX shared library lapack\eigen_lapack.dll
FAILED: [code=4294967295] lapack/eigen_lapack.dll lapack/eigen_lapack.lib 
C:\Windows\system32\cmd.exe /C "cd . && "C:\Program Files\CMake\bin\cmake.exe" -E vs_link_dll --msvc-ver=1951 --intdir=lapack\CMakeFiles\eigen_lapack.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100261~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100261~1.0\x64\mt.exe --manifests  -- C:\PROGRA~1\MICROS~2\18\ENTERP~1\VC\Tools\MSVC\1451~1.362\bin\Hostx64\x64\link.exe /nologo lapack\CMakeFiles\eigen_lapack.dir\single.cpp.obj lapack\CMakeFiles\eigen_lapack.dir\double.cpp.obj lapack\CMakeFiles\eigen_lapack.dir\complex_single.cpp.obj lapack\CMakeFiles\eigen_lapack.dir\complex_double.cpp.obj lapack\CMakeFiles\eigen_lapack.dir\__\blas\xerbla.cpp.obj lapack\CMakeFiles\eigen_lapack.dir\slarft.f.obj lapack\CMakeFiles\eigen_lapack.dir\dlarft.f.obj lapack\CMakeFiles\eigen_lapack.dir\clarft.f.obj lapack\CMakeFiles\eigen_lapack.dir\zlarft.f.obj lapack\CMakeFiles\eigen_lapack.dir\slarfb.f.obj lapack\CMakeFiles\eigen_lapack.dir\dlarfb.f.obj lapack\CMakeFiles\eigen_lapack.dir\clarfb.f.obj lapack\CMakeFiles\eigen_lapack.dir\zlarfb.f.obj lapack\CMakeFiles\eigen_lapack.dir\slarfg.f.obj lapack\CMakeFiles\eigen_lapack.dir\dlarfg.f.obj lapack\CMakeFiles\eigen_lapack.dir\clarfg.f.obj lapack\CMakeFiles\eigen_lapack.dir\zlarfg.f.obj lapack\CMakeFiles\eigen_lapack.dir\slarf.f.obj lapack\CMakeFiles\eigen_lapack.dir\dlarf.f.obj lapack\CMakeFiles\eigen_lapack.dir\clarf.f.obj lapack\CMakeFiles\eigen_lapack.dir\zlarf.f.obj lapack\CMakeFiles\eigen_lapack.dir\sladiv.f.obj lapack\CMakeFiles\eigen_lapack.dir\dladiv.f.obj lapack\CMakeFiles\eigen_lapack.dir\cladiv.f.obj lapack\CMakeFiles\eigen_lapack.dir\zladiv.f.obj lapack\CMakeFiles\eigen_lapack.dir\ilaslr.f.obj lapack\CMakeFiles\eigen_lapack.dir\iladlr.f.obj lapack\CMakeFiles\eigen_lapack.dir\ilaclr.f.obj lapack\CMakeFiles\eigen_lapack.dir\ilazlr.f.obj lapack\CMakeFiles\eigen_lapack.dir\ilaslc.f.obj lapack\CMakeFiles\eigen_lapack.dir\iladlc.f.obj lapack\CMakeFiles\eigen_lapack.dir\ilaclc.f.obj lapack\CMakeFiles\eigen_lapack.dir\ilazlc.f.obj lapack\CMakeFiles\eigen_lapack.dir\dlapy2.f.obj lapack\CMakeFiles\eigen_lapack.dir\dlapy3.f.obj lapack\CMakeFiles\eigen_lapack.dir\slapy2.f.obj lapack\CMakeFiles\eigen_lapack.dir\slapy3.f.obj lapack\CMakeFiles\eigen_lapack.dir\clacgv.f.obj lapack\CMakeFiles\eigen_lapack.dir\zlacgv.f.obj lapack\CMakeFiles\eigen_lapack.dir\slamch.f.obj lapack\CMakeFiles\eigen_lapack.dir\dlamch.f.obj lapack\CMakeFiles\eigen_lapack.dir\second_NONE.f.obj lapack\CMakeFiles\eigen_lapack.dir\dsecnd_NONE.f.obj  /out:lapack\eigen_lapack.dll /implib:lapack\eigen_lapack.lib /pdb:lapack\eigen_lapack.pdb /dll /version:0.0 /machine:x64 /INCREMENTAL:NO -LIBPATH:C:\PROGRA~1\MICROS~2\18\ENTERP~1\VC\Tools\Llvm\x64\lib\clang\22\lib\windows   -LIBPATH:C:\PROGRA~1\MICROS~2\18\ENTERP~1\VC\Tools\Llvm\x64\lib   -LIBPATH:C:\PROGRA~1\MICROS~2\18\ENTERP~1\VC\Tools\Llvm\x64\lib\clang\22\lib\X86_64~1 blas\eigen_blas.lib  kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib && cd ."
LINK: command "C:\PROGRA~1\MICROS~2\18\ENTERP~1\VC\Tools\MSVC\1451~1.362\bin\Hostx64\x64\link.exe /nologo lapack\CMakeFiles\eigen_lapack.dir\single.cpp.obj lapack\CMakeFiles\eigen_lapack.dir\double.cpp.obj lapack\CMakeFiles\eigen_lapack.dir\complex_single.cpp.obj lapack\CMakeFiles\eigen_lapack.dir\complex_double.cpp.obj lapack\CMakeFiles\eigen_lapack.dir\__\blas\xerbla.cpp.obj lapack\CMakeFiles\eigen_lapack.dir\slarft.f.obj lapack\CMakeFiles\eigen_lapack.dir\dlarft.f.obj lapack\CMakeFiles\eigen_lapack.dir\clarft.f.obj lapack\CMakeFiles\eigen_lapack.dir\zlarft.f.obj lapack\CMakeFiles\eigen_lapack.dir\slarfb.f.obj lapack\CMakeFiles\eigen_lapack.dir\dlarfb.f.obj lapack\CMakeFiles\eigen_lapack.dir\clarfb.f.obj lapack\CMakeFiles\eigen_lapack.dir\zlarfb.f.obj lapack\CMakeFiles\eigen_lapack.dir\slarfg.f.obj lapack\CMakeFiles\eigen_lapack.dir\dlarfg.f.obj lapack\CMakeFiles\eigen_lapack.dir\clarfg.f.obj lapack\CMakeFiles\eigen_lapack.dir\zlarfg.f.obj lapack\CMakeFiles\eigen_lapack.dir\slarf.f.obj lapack\CMakeFiles\eigen_lapack.dir\dlarf.f.obj lapack\CMakeFiles\eigen_lapack.dir\clarf.f.obj lapack\CMakeFiles\eigen_lapack.dir\zlarf.f.obj lapack\CMakeFiles\eigen_lapack.dir\sladiv.f.obj lapack\CMakeFiles\eigen_lapack.dir\dladiv.f.obj lapack\CMakeFiles\eigen_lapack.dir\cladiv.f.obj lapack\CMakeFiles\eigen_lapack.dir\zladiv.f.obj lapack\CMakeFiles\eigen_lapack.dir\ilaslr.f.obj lapack\CMakeFiles\eigen_lapack.dir\iladlr.f.obj lapack\CMakeFiles\eigen_lapack.dir\ilaclr.f.obj lapack\CMakeFiles\eigen_lapack.dir\ilazlr.f.obj lapack\CMakeFiles\eigen_lapack.dir\ilaslc.f.obj lapack\CMakeFiles\eigen_lapack.dir\iladlc.f.obj lapack\CMakeFiles\eigen_lapack.dir\ilaclc.f.obj lapack\CMakeFiles\eigen_lapack.dir\ilazlc.f.obj lapack\CMakeFiles\eigen_lapack.dir\dlapy2.f.obj lapack\CMakeFiles\eigen_lapack.dir\dlapy3.f.obj lapack\CMakeFiles\eigen_lapack.dir\slapy2.f.obj lapack\CMakeFiles\eigen_lapack.dir\slapy3.f.obj lapack\CMakeFiles\eigen_lapack.dir\clacgv.f.obj lapack\CMakeFiles\eigen_lapack.dir\zlacgv.f.obj lapack\CMakeFiles\eigen_lapack.dir\slamch.f.obj lapack\CMakeFiles\eigen_lapack.dir\dlamch.f.obj lapack\CMakeFiles\eigen_lapack.dir\second_NONE.f.obj lapack\CMakeFiles\eigen_lapack.dir\dsecnd_NONE.f.obj /out:lapack\eigen_lapack.dll /implib:lapack\eigen_lapack.lib /pdb:lapack\eigen_lapack.pdb /dll /version:0.0 /machine:x64 /INCREMENTAL:NO -LIBPATH:C:\PROGRA~1\MICROS~2\18\ENTERP~1\VC\Tools\Llvm\x64\lib\clang\22\lib\windows -LIBPATH:C:\PROGRA~1\MICROS~2\18\ENTERP~1\VC\Tools\Llvm\x64\lib -LIBPATH:C:\PROGRA~1\MICROS~2\18\ENTERP~1\VC\Tools\Llvm\x64\lib\clang\22\lib\X86_64~1 blas\eigen_blas.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib /MANIFEST:EMBED,ID=2" failed (exit code 1181) with the following output:
LINK : fatal error LNK1181: cannot open input file 'blas\eigen_blas.lib'

ninja: build stopped: subcommand failed.

eigen/3.4.1: ERROR: 
Package 'da39a3ee5e6b4b0d3255bfef95601890afd80709' build failed
eigen/3.4.1: WARN: Build folder C:\Users\runner***\.conan2\p\b\eigena9888114e7add\b\build\Release
ERROR: eigen/3.4.1: Error in build() method, line 73
	cmake.build()
	ConanException: Error 4294967295 while executing
```
With this change, all configurations pass CI : https://github.com/ericLemanissier/cocorepo/actions/runs/28454662377

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
