### PR TITLE
Qt6 missing pcre - possible fix for MR #30524 build issue

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -854,6 +854,18 @@ class QtConan(ConanFile):
         for module in self._get_module_tree:
             if not getattr(self.options, module):
                 rmdir(self, os.path.join(self.package_folder, "licenses", module))
+        if self.options.with_pcre2:
+            # moc and libQt6Core have RUNPATH=$ORIGIN/../lib (resp. $ORIGIN), so
+            # they look for shared libraries inside Qt's own lib/. pcre2 lives in
+            # a separate Conan package and is not copied there by cmake --install.
+            # Copy libpcre2-16.so* into Qt's lib/ to satisfy the existing RUNPATH
+            # without requiring consumers to manipulate LD_LIBRARY_PATH. No-op if
+            # pcre2 was built as a static library (no .so files to copy).
+            pcre2_libdir = os.path.join(self.dependencies["pcre2"].package_folder, "lib")
+            copy(self, "libpcre2-16.so*",
+                 src=pcre2_libdir,
+                 dst=os.path.join(self.package_folder, "lib"))
+
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         for mask in ["Find*.cmake", "*Config.cmake", "*-config.cmake"]:
             rm(self, mask, self.package_folder, recursive=True, excludes="Qt6HostInfoConfig.cmake")


### PR DESCRIPTION
### Summary
Changes to recipe:  **qt**

#### Motivation
My quazip MR https://github.com/conan-io/conan-center-index/pull/30524 is failing to build.

Job example:
https://c3i.jfrog.io/artifactory/cci-build-logs/cci/prod/PR-30524/1/package_build_logs/build_log_quazip_1_7_2_7ffd186ecb505ba3fdd37c91b60c7756_b26e4bce224c484cf8a6b3860393e6948115a23f.txt

`/tmp/workspace/cci_prod_PR-30524/conan-home/p/qt1c37d8e3a92a9/p/lib/cmake/Qt6Core/../../../libexec/moc: error while loading shared libraries: libpcre2-16.so.0: cannot open shared object file: No such file or directory`

It is some kind of an issue with pcre dependency when using moc.

#### Details
Unfortunately I am not an expert in Qt6, this solution is something I managed to get done with help of AI and looks like a pure hack to me. So while this patch resolves the quazip build, I think I need a Qt expert to actually have a look what exactly is going on here.

I also managed to get a quazip recipe local fix but it feels like it should be fixed in Qt package.

---
- [ ✅] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [✅ ] If this is a bug fix, please link related issue or provide bug details
- [ ✅] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
