### PR TITLE
fixes 28851 (attempt)

### DIFF
--- a/recipes/boost/all/conandata.yml
+++ b/recipes/boost/all/conandata.yml
@@ -97,6 +97,12 @@ patches:
     - patch_file: "patches/1.82.0-locale-iconv-library-option.patch"
       patch_description: "Optional flag to specify iconv from either libc of libiconv"
       patch_type: "conan"
+    - patch_file: "patches/1.86.0-process-win-cross-compile.patch"
+      patch_description: "Declare Windows system libs unconditionally so Boost.Process can be cross-compiled to Windows from non-Windows hosts"
+      patch_type: "conan"
+    - patch_file: "patches/1.86.0-stacktrace-from-exception-mingw.patch"
+      patch_description: "Disable boost_stacktrace_from_exception for GCC targeting Windows as its source uses POSIX/ELF APIs unavailable in MinGW"
+      patch_type: "conan"
   "1.85.0":
     - patch_file: "patches/1.82.0-locale-iconv-library-option.patch"
       patch_description: "Optional flag to specify iconv from either libc of libiconv"

--- a/recipes/boost/all/conanfile.py
+++ b/recipes/boost/all/conanfile.py
@@ -639,6 +639,9 @@ class BoostConan(ConanFile):
             return True
         elif Version(self.version) >= "1.86.0":
             # https://github.com/boostorg/stacktrace/blob/boost-1.86.0/build/Jamfile.v2#L148
+            # from_exception.cpp uses POSIX/ELF APIs not available with MinGW (GCC targeting Windows)
+            if cross_building(self) and self.settings.os == "Windows" and str(self.settings.compiler) not in ("Visual Studio", "msvc"):
+                return False
             return not self.options.header_only and not self.options.without_stacktrace and self._b2_architecture == "x86"
 
     def configure(self):
@@ -1952,11 +1955,13 @@ class BoostConan(ConanFile):
             def filter_transform_module_libraries(names):
                 libs = []
                 for name in names:
-                    if name in ("boost_stacktrace_windbg", "boost_stacktrace_windbg_cached") and self.settings.os != "Windows":
+                    if name in ("boost_stacktrace_windbg", "boost_stacktrace_windbg_cached") and (self.settings.os != "Windows" or cross_building(self)):
                         continue
                     if name in ("boost_math_c99l", "boost_math_tr1l") and (str(self.settings.arch).startswith("ppc") or (Version(self.version) >= "1.87.0" and self.settings.os == "Emscripten")):
                         continue
-                    if name in ("boost_stacktrace_addr2line", "boost_stacktrace_backtrace", "boost_stacktrace_basic") and self.settings.os == "Windows":
+                    if name in ("boost_stacktrace_addr2line", "boost_stacktrace_backtrace") and self.settings.os == "Windows":
+                        continue
+                    if name == "boost_stacktrace_basic" and self.settings.os == "Windows" and not cross_building(self):
                         continue
                     if name == "boost_stacktrace_from_exception" and not self._stacktrace_from_exception_available:
                         continue
@@ -2079,7 +2084,7 @@ class BoostConan(ConanFile):
 
             if not self.options.get_safe("without_process"):
                 if self.settings.os == "Windows":
-                    self.cpp_info.components["process"].system_libs.extend(["ntdll", "shell32", "advapi32", "user32"])
+                    self.cpp_info.components["process"].system_libs.extend(["ntdll", "shell32", "advapi32", "user32", "ws2_32"])
                 if self._shared:
                     self.cpp_info.components["process"].defines.append("BOOST_PROCESS_DYN_LINK")
 

--- a/recipes/boost/all/patches/1.86.0-process-win-cross-compile.patch
+++ b/recipes/boost/all/patches/1.86.0-process-win-cross-compile.patch
@@ -1,0 +1,20 @@
+--- libs/process/build/Jamfile
++++ libs/process/build/Jamfile
+@@ -41,12 +41,9 @@
+    ;
+
+-if [ os.name ] = NT
+-{
+-  lib shell32 ;
+-  lib advapi32 ;
+-  lib ntdll ;
+-  lib user32 ;
+-  explicit shell32 advapi32 ntdll user32 ;
+-}
++lib shell32 ;
++lib advapi32 ;
++lib ntdll ;
++lib user32 ;
++explicit shell32 advapi32 ntdll user32 ;
+
+ lib boost_process

--- a/recipes/boost/all/patches/1.86.0-stacktrace-from-exception-mingw.patch
+++ b/recipes/boost/all/patches/1.86.0-stacktrace-from-exception-mingw.patch
@@ -1,0 +1,11 @@
+--- libs/stacktrace/build/Jamfile.v2
++++ libs/stacktrace/build/Jamfile.v2
+@@ -157,6 +157,8 @@ lib boost_stacktrace_from_exception
+   : # requirements
+     <warnings>all
+     <target-os>linux:<library>dl
++    # from_exception.cpp uses POSIX/ELF APIs not available with MinGW (GCC targeting Windows)
++    <toolset>gcc,<target-os>windows:<build>no
+
+     # Enable build when explicitly requested, or by default, when on x86
+     <conditional>@build-stacktrace-from-exception


### PR DESCRIPTION
### Summary
Changes to recipe:  **boost**

#### Motivation
I was affected by the issue when doing cross-compiling on Linux host to Windows so I decided to try and solve it with some help from AI. Needs expert review, most fixes seem sensible to me. https://github.com/conan-io/conan-center-index/issues/28851

#### Details

1. `patches/1.86.0-process-win-cross-compile.patch`

`libs/process/build/Jamfile` wraps lib advapi32 ; lib shell32 ; ... in `if [ os.name ] = NT { ... }`. B2's os.name reflects the build host OS, so cross-compiling from Linux means those
B2 targets are never declared. Yet <target-os>windows:<library>advapi32 still references them - linker error. The patch removes the guard so the targets are always declared (the explicit keyword keeps them from being built unless actually needed).

2. `patches/1.86.0-stacktrace-from-exception-mingw.patch`

boost_stacktrace_from_exception built from_exception.cpp for all x86 targets. That file uses #if defined(_MSC_VER) ... #else #include <dlfcn.h> - MinGW is not MSVC so it falls into
the POSIX branch and fails. Added <toolset>gcc,<target-os>windows:<build>no to the Jamfile lib requirement.

3. conanfile.py - _stacktrace_from_exception_available

The Python property must return False for cross-compile + GCC -> Windows to match what the patched Jamfile produces.

4. conanfile.py - filter_transform_module_libraries for stacktrace_windbg/_cached

These were only skipped for os != "Windows", but WinDbg is also unavailable on a Linux build host -> they're not built when cross-compiling. Added `or cross_building(self)` to the filter.

5. conanfile.py - filter_transform_module_libraries for stacktrace_basic

Normally skipped on Windows (WinDbg preferred). But when cross-compiling, WinDbg can't be checked so boost_stacktrace_basic IS built. Split the condition so it's only skipped for native Windows builds.

6. conanfile.py - process component system_libs

Added ws2_32 to the process component's Windows system libs. boost_process uses Winsock (WSAStartup/WSACleanup). MSVC auto-links it via #pragma comment, but MinGW requires explicit -lws2_32.


A dedicated Cross-compile CI task should probably be added for all new Boost versions so any breakage is caught early.

---
- [✅] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [✅] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [✅] If this is a bug fix, please link related issue or provide bug details
- [✅] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
