### PR TITLE
enkits: CMake 4 support

### DIFF
--- a/recipes/enkits/all/conandata.yml
+++ b/recipes/enkits/all/conandata.yml
@@ -2,9 +2,7 @@ sources:
   "1.11":
     url: "https://github.com/dougbinks/enkiTS/archive/v1.11.tar.gz"
     sha256: "b57a782a6a68146169d29d180d3553bfecb9f1a0e87a5159082331920e7d297e"
-  "1.10":
-    url: "https://github.com/dougbinks/enkiTS/archive/v1.10.tar.gz"
-    sha256: "578f285fc7c2744bf831548f35b855c6ab06c0d541d08c9cc50b6b72a250811a"
-  "1.8":
-    url: "https://github.com/dougbinks/enkiTS/archive/v1.8.zip"
-    sha256: "b96d8d439502d52f9dc419539b12b588df10750f4631ad5518586f7048cdfaef"
+
+patches:
+  "1.11":
+    - patch_file: "patches/1.11-fix-missing-include-initializer-list.patch"

--- a/recipes/enkits/all/conanfile.py
+++ b/recipes/enkits/all/conanfile.py
@@ -2,7 +2,7 @@ import os
 
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, get, replace_in_file
+from conan.tools.files import copy, get, replace_in_file, apply_conandata_patches, export_conandata_patches
 
 required_conan_version = ">=2.1"
 
@@ -26,6 +26,9 @@ class EnkiTSConan(ConanFile):
         "fPIC": True,
     }
 
+    def export_sources(self):
+        export_conandata_patches(self)
+
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -39,6 +42,7 @@ class EnkiTSConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/recipes/enkits/all/conanfile.py
+++ b/recipes/enkits/all/conanfile.py
@@ -2,9 +2,9 @@ import os
 
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, export_conandata_patches, get, replace_in_file
+from conan.tools.files import copy, get, replace_in_file
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2.1"
 
 
 class EnkiTSConan(ConanFile):
@@ -26,9 +26,6 @@ class EnkiTSConan(ConanFile):
         "fPIC": True,
     }
 
-    def export_sources(self):
-        export_conandata_patches(self)
-
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -45,9 +42,10 @@ class EnkiTSConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["ENKITS_INSTALL"] = True
-        tc.variables["ENKITS_BUILD_EXAMPLES"] = False
-        tc.variables["ENKITS_BUILD_SHARED"] = self.options.shared
+        tc.cache_variables["ENKITS_INSTALL"] = True
+        tc.cache_variables["ENKITS_BUILD_EXAMPLES"] = False
+        tc.cache_variables["ENKITS_BUILD_SHARED"] = self.options.shared
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
 
     def _patch_sources(self):

--- a/recipes/enkits/all/patches/1.11-fix-missing-include-initializer-list.patch
+++ b/recipes/enkits/all/patches/1.11-fix-missing-include-initializer-list.patch
@@ -1,0 +1,14 @@
+Backport from https://github.com/dougbinks/enkiTS/commit/2405c77dfe7be6d5b95ee7fda5b0ee7eff4cd7ed
+
+diff --git a/src/TaskScheduler.h b/src/TaskScheduler.h
+index 7cfee7a..8cb447a 100644
+--- a/src/TaskScheduler.h
++++ b/src/TaskScheduler.h
+@@ -23,6 +23,7 @@
+ #include <condition_variable>
+ #include <stdint.h>
+ #include <functional>
++#include <initializer_list>
+ 
+ // ENKITS_TASK_PRIORITIES_NUM can be set from 1 to 5.
+ // 1 corresponds to effectively no priorities.

--- a/recipes/enkits/all/test_package/conanfile.py
+++ b/recipes/enkits/all/test_package/conanfile.py
@@ -7,7 +7,6 @@ import os
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
 
     def requirements(self):
         self.requires(self.tested_reference_str)

--- a/recipes/enkits/config.yml
+++ b/recipes/enkits/config.yml
@@ -1,7 +1,3 @@
 versions:
   "1.11":
     folder: all
-  "1.10":
-    folder: all
-  "1.8":
-    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **enkits**

#### Motivation
Reported in https://github.com/conan-io/conan-center-index/issues/26878#issuecomment-4848131351
Add `CMAKE_POLICY_VERSION_MINIMUM` in order to support CMake 4.


#### Details

Currently `1.11` is the latest release available (even though master branch is actively maintained)
- Fix linter issues
- Removed Conan v1 legacy code

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
