### PR TITLE
resiprocate: add option to disable non-POSIX random_r on Alpine Linux

### DIFF
--- a/recipes/resiprocate/cmake/conanfile.py
+++ b/recipes/resiprocate/cmake/conanfile.py
@@ -29,12 +29,14 @@ class ResiprocateConan(ConanFile):
         "fPIC": [True, False],
         "with_cares": [True, False],
         "with_ssl": [True, False],
+        "with_random": [True, False]
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "with_cares": True,
         "with_ssl": True,
+        "with_random": True
     }
     implements = ["auto_shared_fpic"]
 
@@ -83,7 +85,7 @@ class ResiprocateConan(ConanFile):
         tc.variables["VERSIONED_SONAME"] = False
         tc.variables["WITH_C_ARES"] = self.options.with_cares
         tc.variables["WITH_SSL"] = self.options.with_ssl
-        if self.settings.os in ["Linux"]:
+        if self.settings.os in ["Linux"] and self.options.with_random:
             tc.preprocessor_definitions["RESIP_RANDOM_THREAD_LOCAL"] = True
         if cross_building(self):
             tc.cache_variables["HAVE_CLOCK_GETTIME_MONOTONIC"] = not self.settings.os in ["Windows"]


### PR DESCRIPTION
### Summary
Changes to recipe:  **resiprocate/1.13.2**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
The current implementation of `resiprocate` uses `random_r()` and `initstate_r()` for random number generation on non-Windows platforms. These functions are GNU glibc extensions and are not part of the POSIX standard. 

When trying to compile the package using the Clang compiler on Alpine Linux (which uses `musl libc` instead of `glibc`), the build fails because these functions are completely missing in the standard library. This PR introduces a option to drop the non-POSIX glibc-specific random generator, enabling cross-platform compatibility and successful builds on Alpine Linux.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
Add an option **with_random** to disable the non-POSIX random number generator (random_r) to fix compilation errors with Clang on Alpine Linux (musl libc).

This fixes the following error when building on Alpine Linux when `RESIP_RANDOM_THREAD_LOCAL` was set to `True`.

```sh
/root/.conan2/p/b/resip26e9085e022b7/b/src/rutil/Random.cxx: In static member function 'static int resip::Random::getRandom()':
/root/.conan2/p/b/resip26e9085e022b7/b/src/rutil/Random.cxx:287:19: error: invalid application of 'sizeof' to incomplete type 'random_data'
  287 |       size_t sz = sizeof(*buf)+RANDOM_STATE_SIZE;
      |                   ^~~~~~~~~~~~
/root/.conan2/p/b/resip26e9085e022b7/b/src/rutil/Random.cxx:291:38: error: invalid application of 'sizeof' to incomplete type 'random_data'
  291 |       initstate_r(seed, ((char*)buf)+sizeof(*buf), RANDOM_STATE_SIZE, buf);
      |                                      ^~~~~~~~~~~~
/root/.conan2/p/b/resip26e9085e022b7/b/src/rutil/Random.cxx:291:7: error: 'initstate_r' was not declared in this scope; did you mean 'initstate'?
  291 |       initstate_r(seed, ((char*)buf)+sizeof(*buf), RANDOM_STATE_SIZE, buf);
      |       ^~~~~~~~~~~
      |       initstate
/root/.conan2/p/b/resip26e9085e022b7/b/src/rutil/Random.cxx:295:4: error: 'random_r' was not declared in this scope; did you mean 'random'?
  295 |    random_r(buf, &ret);
      |    ^~~~~~~~
      |    random
gmake[2]: *** [rutil/CMakeFiles/rutil.dir/build.make:457: rutil/CMakeFiles/rutil.dir/Random.cxx.o] Error 1
gmake[2]: *** Waiting for unfinished jobs....
gmake[1]: *** [CMakeFiles/Makefile2:249: rutil/CMakeFiles/rutil.dir/all] Error 2
gmake: *** [Makefile:156: all] Error 2
resiprocate/1.13.2: ERROR: 
Package 'cdc852dc65648cbf9fc56176b655a7dd359844d5' build failed
resiprocate/1.13.2: WARN: Build folder /root/.conan2/p/b/resip26e9085e022b7/b/build/Release
ERROR: resiprocate/1.13.2: Error in build() method, line 101
        cmake.build()
        ConanException: Error 2 while executing
```

---
- [*] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [*] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [*] If this is a bug fix, please link related issue or provide bug details
- [*] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
