### PR TITLE
cloudini: add version 1.2.3

### DIFF
--- a/recipes/cloudini/all/conandata.yml
+++ b/recipes/cloudini/all/conandata.yml
@@ -2,6 +2,3 @@ sources:
   "1.2.3":
     url: "https://github.com/facontidavide/cloudini/archive/refs/tags/1.2.3.tar.gz"
     sha256: "414e55a63eae2ffa169da16e24c69723c96d4d9d13cc020c175763f14c029209"
-  "1.2.2":
-    url: "https://github.com/facontidavide/cloudini/archive/refs/tags/1.2.2.tar.gz"
-    sha256: "fd71f0dce1bc23ff12e82f26666861df8fdc5a250f4d8440851bd45f10e5eb6a"

--- a/recipes/cloudini/all/conandata.yml
+++ b/recipes/cloudini/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.2.3":
+    url: "https://github.com/facontidavide/cloudini/archive/refs/tags/1.2.3.tar.gz"
+    sha256: "414e55a63eae2ffa169da16e24c69723c96d4d9d13cc020c175763f14c029209"
   "1.2.2":
     url: "https://github.com/facontidavide/cloudini/archive/refs/tags/1.2.2.tar.gz"
     sha256: "fd71f0dce1bc23ff12e82f26666861df8fdc5a250f4d8440851bd45f10e5eb6a"

--- a/recipes/cloudini/config.yml
+++ b/recipes/cloudini/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.2.3":
+    folder: all
   "1.2.2":
     folder: all

--- a/recipes/cloudini/config.yml
+++ b/recipes/cloudini/config.yml
@@ -1,5 +1,3 @@
 versions:
   "1.2.3":
     folder: all
-  "1.2.2":
-    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe: **cloudini/1.2.3**

#### Motivation
Publish the latest upstream release of [cloudini](https://github.com/facontidavide/cloudini) (tag `1.2.3`) to Conan Center. The recipe is unchanged; this only registers the new version.

#### Details
- Add `1.2.3` to `config.yml` and `conandata.yml` (source tarball + sha256).
- Recipe (`conanfile.py`) is version-agnostic and unchanged.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan (Conan 2.27.1, GCC 13, C++20 — static and shared, `test_package` passes)