### PR TITLE
GStreamer and gst-* port to Conan v2 and update to 1.29.2

### DIFF
--- a/recipes/gst-libav/all/conandata.yml
+++ b/recipes/gst-libav/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "1.19.1":
-    url: "https://gitlab.freedesktop.org/gstreamer/gst-libav/-/archive/1.19.1/gst-libav-1.19.1.tar.bz2"
-    sha256 : "771b55f9de7f81153b12c0d2d562e82d4119fcb6e5983bcf51c872dfbe2f5edc"
+  "1.29.2":
+    url: "https://gstreamer.freedesktop.org/src/gst-libav/gst-libav-1.29.2.tar.xz"
+    sha256: "cb3b3f1274221a04b7c71eb24b9aea8cf8f74f16dff051364548872fb31ad8b4"

--- a/recipes/gst-libav/all/conanfile.py
+++ b/recipes/gst-libav/all/conanfile.py
@@ -1,9 +1,18 @@
-from conans import ConanFile, tools, Meson, VisualStudioBuildEnvironment
-from conans.errors import ConanInvalidConfiguration
-from conan.tools.microsoft import msvc_runtime_flag
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import fix_apple_shared_install_name
+from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
+from conan.tools.files import chdir, copy, get, rename, rm, rmdir, apply_conandata_patches, export_conandata_patches
+from conan.tools.gnu import PkgConfigDeps
+from conan.tools.layout import basic_layout
+from conan.tools.meson import Meson, MesonToolchain
+from conan.tools.microsoft import is_msvc, is_msvc_static_runtime, check_min_vs
+from conan.tools.scm import Version
+
 import glob
 import os
-import shutil
+
+required_conan_version = ">=1.60.0 <2 || >=2.0.5"
 
 
 class GStLibAVConan(ConanFile):
@@ -14,157 +23,157 @@ class GStLibAVConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://gstreamer.freedesktop.org/"
     license = "GPL-2.0-only"
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
         "with_introspection": [True, False],
-        }
+    }
     default_options = {
         "shared": False,
         "fPIC": True,
         "with_introspection": False,
-        }
-    _source_subfolder = "source_subfolder"
-    _build_subfolder = "build_subfolder"
-    exports_sources = ["patches/*.patch"]
-
-    generators = "pkg_config"
+    }
 
     @property
-    def _is_msvc(self):
-        return self.settings.compiler == "Visual Studio"
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
 
-    def validate(self):
-        if self.options.shared != self.options["gstreamer"].shared or \
-            self.options.shared != self.options["glib"].shared or \
-            self.options.shared != self.options["gst-plugins-base"].shared:
-                # https://gitlab.freedesktop.org/gstreamer/gst-build/-/issues/133
-                raise ConanInvalidConfiguration("GLib, GStreamer and GstPlugins must be either all shared, or all static")
-        if tools.Version(self.version) >= "1.18.2" and\
-           self.settings.compiler == "gcc" and\
-           tools.Version(self.settings.compiler.version) < "5":
-            raise ConanInvalidConfiguration(
-                "gst-plugins-good %s does not support gcc older than 5" % self.version
-            )
-        if self.options.shared and str(msvc_runtime_flag(self)).startswith("MT"):
-            raise ConanInvalidConfiguration('shared build with static runtime is not supported due to the FlsAlloc limit')
+    @property
+    def _is_legacy_one_profile(self):
+        return not hasattr(self, "settings_build")
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
-        del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
-        self.options['gstreamer'].shared = self.options.shared
-        self.options['gst-plugins-base'].shared = self.options.shared
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
+        self.options["gstreamer"].shared = self.options.shared
+        self.options["gst-plugins-base"].shared = self.options.shared
 
-    def config_options(self):
-        if self.settings.os == 'Windows':
-            del self.options.fPIC
+    def layout(self):
+        basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("glib/2.70.1")
-        self.requires("gstreamer/1.19.1")
-        self.requires("gst-plugins-base/1.19.1")
-        self.requires('ffmpeg/4.4')
-        if self.settings.os == 'Linux':
-            self.requires('libalsa/1.2.5.1') # temp - conflict with gst-plugins-base
+        self.requires("glib/2.78.3", transitive_headers=True, transitive_libs=True)
+        self.requires("gstreamer/1.29.2", transitive_headers=True, transitive_libs=True)
+        self.requires("gst-plugins-base/1.29.2", transitive_headers=True, transitive_libs=True)
+        self.requires("ffmpeg/7.1.4")
+        if self.settings.os == "Linux":
+            self.requires("libalsa/1.2.13")  # temp - conflict with gst-plugins-base
+
+    def validate(self):
+        if self.options.shared != self.dependencies.direct_host["gstreamer"].options.shared or \
+           self.options.shared != self.dependencies.direct_host["glib"].options.shared or \
+           self.options.shared != self.dependencies.direct_host["gst-plugins-base"].options.shared:
+            # https://gitlab.freedesktop.org/gstreamer/gst-build/-/issues/133
+            raise ConanInvalidConfiguration("GLib, GStreamer and GstPlugins must be either all shared, or all static")
+        if Version(self.version) >= "1.18.2" and \
+           self.settings.compiler == "gcc" and \
+           Version(self.settings.compiler.version) < "5":
+            raise ConanInvalidConfiguration(f"{self.ref} does not support gcc older than 5")
+        if self.options.shared and is_msvc_static_runtime(self):
+            raise ConanInvalidConfiguration("shared build with static runtime is not supported due to the FlsAlloc limit")
 
     def build_requirements(self):
-        self.build_requires("meson/0.54.2")
-        if not tools.which("pkg-config"):
-            self.build_requires("pkgconf/1.7.4")
-        if self.settings.os == 'Windows':
-            self.build_requires("winflexbison/2.5.24")
+        self.tool_requires("meson/[>=1.2.3 <2]")
+        if not self._is_legacy_one_profile:
+            self.tool_requires("glib/<host_version>")
+        if not self.conf.get("tools.gnu:pkg_config", check_type=str):
+            self.tool_requires("pkgconf/[>=2.2 <3]")
+        if self._settings_build.os == "Windows":
+            self.tool_requires("winflexbison/2.5.25")
         else:
-            self.build_requires("bison/3.7.6")
-            self.build_requires("flex/2.6.4")
+            self.tool_requires("bison/3.8.2")
+            self.tool_requires("flex/2.6.4")
         if self.options.with_introspection:
-            self.build_requires("gobject-introspection/1.68.0")
+            self.tool_requires("gobject-introspection/1.78.1")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
-    def _configure_meson(self):
-        defs = dict()
-
-        def add_flag(name, value):
-            if name in defs:
-                defs[name] += " " + value
-            else:
-                defs[name] = value
-
-        def add_compiler_flag(value):
-            add_flag("c_args", value)
-            add_flag("cpp_args", value)
-
-        def add_linker_flag(value):
-            add_flag("c_link_args", value)
-            add_flag("cpp_link_args", value)
-
-        meson = Meson(self)
-        if self.settings.compiler == "Visual Studio":
-            add_linker_flag("-lws2_32")
-            add_compiler_flag("-%s" % self.settings.compiler.runtime)
-            if int(str(self.settings.compiler.version)) < 14:
-                add_compiler_flag("-Dsnprintf=_snprintf")
-        if self.settings.get_safe("compiler.runtime"):
-            defs["b_vscrt"] = str(self.settings.compiler.runtime).lower()
-        defs["tools"] = "disabled"
-        defs["examples"] = "disabled"
-        defs["benchmarks"] = "disabled"
-        defs["tests"] = "disabled"
-        defs["wrap_mode"] = "nofallback"
-        defs["introspection"] = "enabled" if self.options.with_introspection else "disabled"
-        meson.configure(build_folder=self._build_subfolder,
-                        source_folder=self._source_subfolder,
-                        defs=defs)
-        return meson
+    def generate(self):
+        virtual_build_env = VirtualBuildEnv(self)
+        virtual_build_env.generate()
+        if self._is_legacy_one_profile:
+            VirtualRunEnv(self).generate(scope="build")
+        pkg_config_deps = PkgConfigDeps(self)
+        pkg_config_deps.generate()
+        tc = MesonToolchain(self)
+        if is_msvc(self) and not check_min_vs(self, "190", raise_invalid=False):
+            tc.c_args.append("-Dsnprintf=_snprintf")
+            tc.project_options["c_std"] = "c99"
+        if is_msvc(self):
+            tc.c_link_args.append("-lws2_32")
+            tc.cpp_link_args.append("-lws2_32")
+        tc.project_options["tests"] = "disabled"
+        tc.project_options["doc"] = "disabled"
+        tc.project_options["wrap_mode"] = "nofallback"
+        tc.generate()
 
     def build(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
-
-        with tools.environment_append(VisualStudioBuildEnvironment(self).vars) if self._is_msvc else tools.no_op():
-            meson = self._configure_meson()
-            meson.build()
+        apply_conandata_patches(self)
+        meson = Meson(self)
+        meson.configure()
+        meson.build()
 
     def _fix_library_names(self, path):
         # regression in 1.16
-        if self.settings.compiler == "Visual Studio":
-            with tools.chdir(path):
+        if is_msvc(self):
+            with chdir(self, path):
                 for filename_old in glob.glob("*.a"):
                     filename_new = filename_old[3:-2] + ".lib"
-                    self.output.info("rename %s into %s" % (filename_old, filename_new))
-                    shutil.move(filename_old, filename_new)
+                    self.output.info(f"rename {filename_old} into {filename_new}")
+                    rename(self, filename_old, filename_new)
 
     def package(self):
-        self.copy(pattern="COPYING", dst="licenses", src=self._source_subfolder)
-        with tools.environment_append(VisualStudioBuildEnvironment(self).vars) if self._is_msvc else tools.no_op():
-            meson = self._configure_meson()
-            meson.install()
+        copy(self, "COPYING", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        meson = Meson(self)
+        meson.install()
 
         self._fix_library_names(os.path.join(self.package_folder, "lib"))
         self._fix_library_names(os.path.join(self.package_folder, "lib", "gstreamer-1.0"))
-        tools.rmdir(os.path.join(self.package_folder, "share"))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "gstreamer-1.0", "pkgconfig"))
-        tools.remove_files_by_mask(self.package_folder, "*.pdb")
+        rmdir(self, os.path.join(self.package_folder, "share"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "gstreamer-1.0", "pkgconfig"))
+        rm(self, "*.pdb", self.package_folder, recursive=True)
+        fix_apple_shared_install_name(self)
+
+    @staticmethod
+    def _installed_plugin_libs(gst_plugin_path, plugins):
+        # The set of plugins actually built varies across gstreamer versions, so only
+        # expose the ones whose static library was installed to avoid CMakeDeps errors.
+        libs = []
+        for plugin in plugins:
+            lib = f"gst{plugin}"
+            candidates = [f"lib{lib}.a", f"{lib}.lib", f"lib{lib}.so", f"lib{lib}.dylib", f"{lib}.dll"]
+            if any(os.path.exists(os.path.join(gst_plugin_path, candidate)) for candidate in candidates):
+                libs.append(lib)
+        return libs
 
     def package_info(self):
-
         plugins = ["libav"]
 
         gst_plugin_path = os.path.join(self.package_folder, "lib", "gstreamer-1.0")
         if self.options.shared:
-            self.output.info("Appending GST_PLUGIN_PATH env var : %s" % gst_plugin_path)
-            self.cpp_info.bindirs.append(gst_plugin_path)
-            self.runenv_info.prepend_path("GST_PLUGIN_PATH", gst_plugin_path)
+            self.runenv_info.append_path("GST_PLUGIN_PATH", gst_plugin_path)
+            # TODO: remove the following when only Conan 2.0 is supported
             self.env_info.GST_PLUGIN_PATH.append(gst_plugin_path)
+            self.cpp_info.bindirs.append(gst_plugin_path)
         else:
             self.cpp_info.defines.append("GST_LIBAV_STATIC")
             self.cpp_info.libdirs.append(gst_plugin_path)
-            self.cpp_info.libs.extend(["gst%s" % plugin for plugin in plugins])
+            self.cpp_info.libs.extend(self._installed_plugin_libs(gst_plugin_path, plugins))
 
-        self.cpp_info.includedirs = ["include", os.path.join("include", "gstreamer-1.0")]
+        self.cpp_info.includedirs = [
+            includedir for includedir in ["include", os.path.join("include", "gstreamer-1.0")]
+            if os.path.isdir(os.path.join(self.package_folder, includedir))
+        ]

--- a/recipes/gst-libav/all/test_package/CMakeLists.txt
+++ b/recipes/gst-libav/all/test_package/CMakeLists.txt
@@ -1,11 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
-project(test_package)
-
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
+project(test_package LANGUAGES CXX)
 
 find_package(gst-libav CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} gst-libav::gst-libav)
+target_link_libraries(${PROJECT_NAME} PRIVATE gst-libav::gst-libav)

--- a/recipes/gst-libav/all/test_package/conanfile.py
+++ b/recipes/gst-libav/all/test_package/conanfile.py
@@ -1,10 +1,30 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.env import Environment
 import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "PkgConfigDeps", "VirtualBuildEnv", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build_requirements(self):
+        if not self.conf.get("tools.gnu:pkg_config", check_type=str):
+            self.tool_requires("pkgconf/[>=2.2 <3]")
+
+    def generate(self):
+        # Print debug information from gstreamer at runtime
+        env = Environment()
+        env.define("GST_DEBUG", "7")
+        env.vars(self, scope="run").save_script("conanrun_gstdebug")
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +32,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/gst-libav/config.yml
+++ b/recipes/gst-libav/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.19.1":
+  "1.29.2":
     folder: all

--- a/recipes/gst-plugins-bad/all/conandata.yml
+++ b/recipes/gst-plugins-bad/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "1.19.1":
-    url: "https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/-/archive/1.19.1/gst-plugins-bad-1.19.1.tar.bz2"
-    sha256 : "eef44e835a8425a79d69241853040a24769067707c1012ade5cae55175392dcf"
+  "1.29.2":
+    url: "https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-1.29.2.tar.xz"
+    sha256: "bf5811da6159e0d2ae0617fd22f354f2f3a15cbc5baea00ca5b4620a8bc3c38c"

--- a/recipes/gst-plugins-bad/all/conanfile.py
+++ b/recipes/gst-plugins-bad/all/conanfile.py
@@ -1,9 +1,18 @@
-from conans import ConanFile, tools, Meson, VisualStudioBuildEnvironment
-from conans.errors import ConanInvalidConfiguration
-from conan.tools.microsoft import msvc_runtime_flag
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import fix_apple_shared_install_name
+from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
+from conan.tools.files import chdir, copy, get, rename, rm, rmdir, apply_conandata_patches, export_conandata_patches
+from conan.tools.gnu import PkgConfigDeps
+from conan.tools.layout import basic_layout
+from conan.tools.meson import Meson, MesonToolchain
+from conan.tools.microsoft import is_msvc, is_msvc_static_runtime, check_min_vs
+from conan.tools.scm import Version
+
 import glob
 import os
-import shutil
+
+required_conan_version = ">=1.60.0 <2 || >=2.0.5"
 
 
 class GStPluginsBadConan(ConanFile):
@@ -14,219 +23,168 @@ class GStPluginsBadConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://gstreamer.freedesktop.org/"
     license = "GPL-2.0-only"
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
         "with_introspection": [True, False],
-        }
+    }
     default_options = {
         "shared": False,
         "fPIC": True,
         "with_introspection": False,
-        }
-    _source_subfolder = "source_subfolder"
-    _build_subfolder = "build_subfolder"
-    exports_sources = ["patches/*.patch"]
-
-    generators = "pkg_config"
+    }
 
     @property
-    def _is_msvc(self):
-        return self.settings.compiler == "Visual Studio"
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
 
-    def validate(self):
-        if self.options.shared != self.options["gstreamer"].shared or \
-            self.options.shared != self.options["glib"].shared or \
-            self.options.shared != self.options["gst-plugins-base"].shared:
-                # https://gitlab.freedesktop.org/gstreamer/gst-build/-/issues/133
-                raise ConanInvalidConfiguration("GLib, GStreamer and GstPlugins must be either all shared, or all static")
-        if tools.Version(self.version) >= "1.18.2" and\
-           self.settings.compiler == "gcc" and\
-           tools.Version(self.settings.compiler.version) < "5":
-            raise ConanInvalidConfiguration(
-                "gst-plugins-bad %s does not support gcc older than 5" % self.version
-            )
-        if self.options.shared and str(msvc_runtime_flag(self)).startswith("MT"):
-            raise ConanInvalidConfiguration('shared build with static runtime is not supported due to the FlsAlloc limit')
+    @property
+    def _is_legacy_one_profile(self):
+        return not hasattr(self, "settings_build")
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
-        del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
-        self.options['gstreamer'].shared = self.options.shared
-        self.options['gst-plugins-base'].shared = self.options.shared
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
+        self.options["gstreamer"].shared = self.options.shared
+        self.options["gst-plugins-base"].shared = self.options.shared
 
-    def config_options(self):
-        if self.settings.os == 'Windows':
-            del self.options.fPIC
+    def layout(self):
+        basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("glib/2.70.1")
-        self.requires("gstreamer/1.19.1")
-        self.requires("gst-plugins-base/1.19.1")
+        self.requires("glib/2.78.3", transitive_headers=True, transitive_libs=True)
+        self.requires("gstreamer/1.29.2", transitive_headers=True, transitive_libs=True)
+        self.requires("gst-plugins-base/1.29.2", transitive_headers=True, transitive_libs=True)
+
+    def validate(self):
+        if self.options.shared != self.dependencies.direct_host["gstreamer"].options.shared or \
+           self.options.shared != self.dependencies.direct_host["glib"].options.shared or \
+           self.options.shared != self.dependencies.direct_host["gst-plugins-base"].options.shared:
+            # https://gitlab.freedesktop.org/gstreamer/gst-build/-/issues/133
+            raise ConanInvalidConfiguration("GLib, GStreamer and GstPlugins must be either all shared, or all static")
+        if Version(self.version) >= "1.18.2" and \
+           self.settings.compiler == "gcc" and \
+           Version(self.settings.compiler.version) < "5":
+            raise ConanInvalidConfiguration(f"{self.ref} does not support gcc older than 5")
+        if self.options.shared and is_msvc_static_runtime(self):
+            raise ConanInvalidConfiguration("shared build with static runtime is not supported due to the FlsAlloc limit")
 
     def build_requirements(self):
-        self.build_requires("meson/0.54.2")
-        if not tools.which("pkg-config"):
-            self.build_requires("pkgconf/1.7.4")
-        if self.settings.os == 'Windows':
-            self.build_requires("winflexbison/2.5.24")
+        self.tool_requires("meson/[>=1.2.3 <2]")
+        if not self._is_legacy_one_profile:
+            self.tool_requires("glib/<host_version>")
+        if not self.conf.get("tools.gnu:pkg_config", check_type=str):
+            self.tool_requires("pkgconf/[>=2.2 <3]")
+        if self._settings_build.os == "Windows":
+            self.tool_requires("winflexbison/2.5.25")
         else:
-            self.build_requires("bison/3.7.6")
-            self.build_requires("flex/2.6.4")
+            self.tool_requires("bison/3.8.2")
+            self.tool_requires("flex/2.6.4")
         if self.options.with_introspection:
-            self.build_requires("gobject-introspection/1.68.0")
+            self.tool_requires("gobject-introspection/1.78.1")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
-    def _configure_meson(self):
-        defs = dict()
-
-        def add_flag(name, value):
-            if name in defs:
-                defs[name] += " " + value
-            else:
-                defs[name] = value
-
-        def add_compiler_flag(value):
-            add_flag("c_args", value)
-            add_flag("cpp_args", value)
-
-        def add_linker_flag(value):
-            add_flag("c_link_args", value)
-            add_flag("cpp_link_args", value)
-
-        meson = Meson(self)
-        if self.settings.compiler == "Visual Studio":
-            add_linker_flag("-lws2_32")
-            add_compiler_flag("-%s" % self.settings.compiler.runtime)
-            if int(str(self.settings.compiler.version)) < 14:
-                add_compiler_flag("-Dsnprintf=_snprintf")
-        if self.settings.get_safe("compiler.runtime"):
-            defs["b_vscrt"] = str(self.settings.compiler.runtime).lower()
-        defs["tools"] = "disabled"
-        defs["examples"] = "disabled"
-        defs["benchmarks"] = "disabled"
-        defs["tests"] = "disabled"
-        defs["wrap_mode"] = "nofallback"
-        defs["introspection"] = "enabled" if self.options.with_introspection else "disabled"
-        meson.configure(build_folder=self._build_subfolder,
-                        source_folder=self._source_subfolder,
-                        defs=defs)
-        return meson
+    def generate(self):
+        virtual_build_env = VirtualBuildEnv(self)
+        virtual_build_env.generate()
+        if self._is_legacy_one_profile:
+            VirtualRunEnv(self).generate(scope="build")
+        pkg_config_deps = PkgConfigDeps(self)
+        pkg_config_deps.generate()
+        tc = MesonToolchain(self)
+        if is_msvc(self) and not check_min_vs(self, "190", raise_invalid=False):
+            tc.c_args.append("-Dsnprintf=_snprintf")
+            tc.project_options["c_std"] = "c99"
+        if is_msvc(self):
+            tc.c_link_args.append("-lws2_32")
+            tc.cpp_link_args.append("-lws2_32")
+        tc.project_options["examples"] = "disabled"
+        tc.project_options["tests"] = "disabled"
+        tc.project_options["doc"] = "disabled"
+        tc.project_options["wrap_mode"] = "nofallback"
+        tc.generate()
 
     def build(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
-
-        with tools.environment_append(VisualStudioBuildEnvironment(self).vars) if self._is_msvc else tools.no_op():
-            meson = self._configure_meson()
-            meson.build()
+        apply_conandata_patches(self)
+        meson = Meson(self)
+        meson.configure()
+        meson.build()
 
     def _fix_library_names(self, path):
         # regression in 1.16
-        if self.settings.compiler == "Visual Studio":
-            with tools.chdir(path):
+        if is_msvc(self):
+            with chdir(self, path):
                 for filename_old in glob.glob("*.a"):
                     filename_new = filename_old[3:-2] + ".lib"
-                    self.output.info("rename %s into %s" % (filename_old, filename_new))
-                    shutil.move(filename_old, filename_new)
+                    self.output.info(f"rename {filename_old} into {filename_new}")
+                    rename(self, filename_old, filename_new)
 
     def package(self):
-        self.copy(pattern="COPYING", dst="licenses", src=self._source_subfolder)
-        with tools.environment_append(VisualStudioBuildEnvironment(self).vars) if self._is_msvc else tools.no_op():
-            meson = self._configure_meson()
-            meson.install()
+        copy(self, "COPYING", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        meson = Meson(self)
+        meson.install()
 
         self._fix_library_names(os.path.join(self.package_folder, "lib"))
         self._fix_library_names(os.path.join(self.package_folder, "lib", "gstreamer-1.0"))
-        tools.rmdir(os.path.join(self.package_folder, "share"))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "gstreamer-1.0", "pkgconfig"))
-        tools.remove_files_by_mask(self.package_folder, "*.pdb")
+        rmdir(self, os.path.join(self.package_folder, "share"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "gstreamer-1.0", "pkgconfig"))
+        rm(self, "*.pdb", self.package_folder, recursive=True)
+        fix_apple_shared_install_name(self)
+
+    @staticmethod
+    def _installed_plugin_libs(gst_plugin_path, plugins):
+        # The set of plugins actually built varies across gstreamer versions, so only
+        # expose the ones whose static library was installed to avoid CMakeDeps errors.
+        libs = []
+        for plugin in plugins:
+            lib = f"gst{plugin}"
+            candidates = [f"lib{lib}.a", f"{lib}.lib", f"lib{lib}.so", f"lib{lib}.dylib", f"{lib}.dll"]
+            if any(os.path.exists(os.path.join(gst_plugin_path, candidate)) for candidate in candidates):
+                libs.append(lib)
+        return libs
 
     def package_info(self):
-
-        plugins = ["accurip",
-                   "adpcmdec",
-                   "adpcmenc",
-                   "aiff",
-                   "asfmux",
-                   "audiobuffersplit",
-                   "audiofxbad",
-                   "audiolatency",
-                   "audiomixmatrix",
-                   "audiovisualizers",
-                   "autoconvert",
-                   "bayer",
-                   "camerabin",
-                   "codecalpha",
-                   "coloreffects",
-                   "debugutilsbad",
-                   "dvbsubenc",
-                   "dvbsuboverlay",
-                   "dvdspu",
-                   "faceoverlay",
-                   "festival",
-                   "fieldanalysis",
-                   "freeverb",
-                   "frei0r",
-                   "gaudieffects",
-                   "gdp",
-                   "geometrictransform",
-                   "id3tag",
-                   "inter",
-                   "interlace",
-                   "ivfparse",
-                   "ivtc",
-                   "jp2kdecimator",
-                   "jpegformat",
-                   "rfbsrc",
-                   "midi",
-                   "mpegpsdemux",
-                   "mpegpsmux",
-                   "mpegtsdemux",
-                   "mpegtsmux",
-                   "mxf",
-                   "netsim",
-                   "rtponvif",
-                   "pcapparse",
-                   "pnm",
-                   "proxy",
-                   "legacyrawparse",
-                   "removesilence",
-                   "rist",
-                   "rtmp2",
-                   "rtpmanagerbad",
-                   "sdpelem",
-                   "segmentclip",
-                   "siren",
-                   "smooth",
-                   "speed",
-                   "subenc",
-                   "switchbin",
-                   "timecode",
-                   "transcode",
-                   "videofiltersbad",
-                   "videoframe_audiolevel",
-                   "videoparsersbad",
-                   "videosignal",
-                   "vmnc",
-                   "y4mdec"]
+        plugins = [
+            "accurip", "adpcmdec", "adpcmenc", "aiff", "asfmux", "audiobuffersplit",
+            "audiofxbad", "audiolatency", "audiomixmatrix", "audiovisualizers",
+            "autoconvert", "bayer", "camerabin", "codecalpha", "coloreffects",
+            "debugutilsbad", "dvbsubenc", "dvbsuboverlay", "dvdspu", "faceoverlay",
+            "festival", "fieldanalysis", "freeverb", "frei0r", "gaudieffects", "gdp",
+            "geometrictransform", "id3tag", "inter", "interlace", "ivfparse", "ivtc",
+            "jp2kdecimator", "jpegformat", "rfbsrc", "midi", "mpegpsdemux", "mpegpsmux",
+            "mpegtsdemux", "mpegtsmux", "mxf", "netsim", "rtponvif", "pcapparse", "pnm",
+            "proxy", "legacyrawparse", "removesilence", "rist", "rtmp2", "rtpmanagerbad",
+            "sdpelem", "segmentclip", "siren", "smooth", "speed", "subenc", "switchbin",
+            "timecode", "transcode", "videofiltersbad", "videoframe_audiolevel",
+            "videoparsersbad", "videosignal", "vmnc", "y4mdec",
+        ]
 
         gst_plugin_path = os.path.join(self.package_folder, "lib", "gstreamer-1.0")
         if self.options.shared:
-            self.output.info("Appending GST_PLUGIN_PATH env var : %s" % gst_plugin_path)
-            self.cpp_info.bindirs.append(gst_plugin_path)
-            self.runenv_info.prepend_path("GST_PLUGIN_PATH", gst_plugin_path)
+            self.runenv_info.append_path("GST_PLUGIN_PATH", gst_plugin_path)
+            # TODO: remove the following when only Conan 2.0 is supported
             self.env_info.GST_PLUGIN_PATH.append(gst_plugin_path)
+            self.cpp_info.bindirs.append(gst_plugin_path)
         else:
             self.cpp_info.defines.append("GST_PLUGINS_BAD_STATIC")
             self.cpp_info.libdirs.append(gst_plugin_path)
-            self.cpp_info.libs.extend(["gst%s" % plugin for plugin in plugins])
+            self.cpp_info.libs.extend(self._installed_plugin_libs(gst_plugin_path, plugins))
 
-        self.cpp_info.includedirs = ["include", os.path.join("include", "gstreamer-1.0")]
+        self.cpp_info.includedirs = [
+            includedir for includedir in ["include", os.path.join("include", "gstreamer-1.0")]
+            if os.path.isdir(os.path.join(self.package_folder, includedir))
+        ]

--- a/recipes/gst-plugins-bad/all/test_package/CMakeLists.txt
+++ b/recipes/gst-plugins-bad/all/test_package/CMakeLists.txt
@@ -1,11 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
-project(test_package)
-
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
+project(test_package LANGUAGES CXX)
 
 find_package(gst-plugins-bad CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} gst-plugins-bad::gst-plugins-bad)
+target_link_libraries(${PROJECT_NAME} PRIVATE gst-plugins-bad::gst-plugins-bad)

--- a/recipes/gst-plugins-bad/all/test_package/conanfile.py
+++ b/recipes/gst-plugins-bad/all/test_package/conanfile.py
@@ -1,10 +1,30 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.env import Environment
 import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "PkgConfigDeps", "VirtualBuildEnv", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build_requirements(self):
+        if not self.conf.get("tools.gnu:pkg_config", check_type=str):
+            self.tool_requires("pkgconf/[>=2.2 <3]")
+
+    def generate(self):
+        # Print debug information from gstreamer at runtime
+        env = Environment()
+        env.define("GST_DEBUG", "7")
+        env.vars(self, scope="run").save_script("conanrun_gstdebug")
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +32,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/gst-plugins-bad/config.yml
+++ b/recipes/gst-plugins-bad/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.19.1":
+  "1.29.2":
     folder: all

--- a/recipes/gst-plugins-base/all/conandata.yml
+++ b/recipes/gst-plugins-base/all/conandata.yml
@@ -1,7 +1,4 @@
 sources:
-  "1.19.2":
-    url: "https://gitlab.freedesktop.org/gstreamer/gst-plugins-base/-/archive/1.19.2/gst-plugins-base-1.19.2.tar.gz"
-    sha256: "567b3bf2d08ed6602fb56b7aa9debbd5ff4b5957eb8fbb1f945b491695bc8198"
-  "1.19.1":
-    url: "https://gitlab.freedesktop.org/gstreamer/gst-plugins-base/-/archive/1.19.1/gst-plugins-base-1.19.1.tar.bz2"
-    sha256: "b39338e306502570b49043a9b9df5704043e02c8a2ccba3a5a4f1f6ea410d4b1"
+  "1.29.2":
+    url: "https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-1.29.2.tar.xz"
+    sha256: "eaaaa0bb455812e2277d14c9be8dd3136e2c607e34efd401a33d4b384b2f0253"

--- a/recipes/gst-plugins-base/all/conanfile.py
+++ b/recipes/gst-plugins-base/all/conanfile.py
@@ -1,8 +1,18 @@
-from conans import ConanFile, tools, Meson, VisualStudioBuildEnvironment
-from conans.errors import ConanInvalidConfiguration
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import fix_apple_shared_install_name
+from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
+from conan.tools.files import chdir, copy, get, rename, rm, rmdir, apply_conandata_patches, export_conandata_patches
+from conan.tools.gnu import PkgConfigDeps
+from conan.tools.layout import basic_layout
+from conan.tools.meson import Meson, MesonToolchain
+from conan.tools.microsoft import is_msvc, check_min_vs
+from conan.tools.scm import Version
+
 import glob
 import os
-import shutil
+
+required_conan_version = ">=1.60.0 <2 || >=2.0.5"
 
 
 class GStPluginsBaseConan(ConanFile):
@@ -13,6 +23,7 @@ class GStPluginsBaseConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://gstreamer.freedesktop.org/"
     license = "GPL-2.0-only"
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
@@ -31,7 +42,7 @@ class GStPluginsBaseConan(ConanFile):
         "with_wayland": [True, False],
         "with_xorg": [True, False],
         "with_introspection": [True, False],
-        }
+    }
     default_options = {
         "shared": False,
         "fPIC": True,
@@ -49,46 +60,25 @@ class GStPluginsBaseConan(ConanFile):
         "with_wayland": True,
         "with_xorg": True,
         "with_introspection": False,
-        }
-    _source_subfolder = "source_subfolder"
-    _build_subfolder = "build_subfolder"
-    exports_sources = ["patches/*.patch"]
-
-    generators = "pkg_config"
+    }
 
     _gl_api = None
     _gl_platform = None
     _gl_winsys = None
 
     @property
-    def _is_msvc(self):
-        return self.settings.compiler == "Visual Studio"
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
 
-    def validate(self):
-        if not self.options["glib"].shared and self.options.shared:
-            # https://gitlab.freedesktop.org/gstreamer/gst-build/-/issues/133
-            raise ConanInvalidConfiguration("shared GStreamer cannot link to static GLib")
-        if self.options.shared != self.options["gstreamer"].shared:
-            # https://gitlab.freedesktop.org/gstreamer/gst-build/-/issues/133
-            raise ConanInvalidConfiguration("GStreamer and GstPlugins must be either all shared, or all static")
-        if tools.Version(self.version) >= "1.18.2" and\
-           self.settings.compiler == "gcc" and\
-           tools.Version(self.settings.compiler.version) < "5":
-            raise ConanInvalidConfiguration(
-                "gst-plugins-base %s does not support gcc older than 5" % self.version
-            )
-        if self.options.with_gl and self.options.get_safe("with_wayland") and not self.options.get_safe("with_egl"):
-            raise ConanInvalidConfiguration("OpenGL support with Wayland requires 'with_egl' turned on!")
+    @property
+    def _is_legacy_one_profile(self):
+        return not hasattr(self, "settings_build")
 
-    def configure(self):
-        if self.options.shared:
-            del self.options.fPIC
-        del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
-        self.options['gstreamer'].shared = self.options.shared
+    def export_sources(self):
+        export_conandata_patches(self)
 
     def config_options(self):
-        if self.settings.os == 'Windows':
+        if self.settings.os == "Windows":
             del self.options.fPIC
         if self.settings.os != "Linux":
             del self.options.with_libalsa
@@ -97,64 +87,89 @@ class GStPluginsBaseConan(ConanFile):
             del self.options.with_egl
             del self.options.with_xorg
 
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
+        self.options["gstreamer"].shared = self.options.shared
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
     def requirements(self):
-        self.requires("zlib/1.2.12")
-        self.requires("glib/2.72.0")
-        self.requires("gstreamer/1.19.2")
+        self.requires("glib/2.78.3", transitive_headers=True, transitive_libs=True)
+        self.requires("gstreamer/1.29.2", transitive_headers=True, transitive_libs=True)
+        self.requires("zlib/[>=1.2.11 <2]")
         if self.options.get_safe("with_libalsa"):
-            self.requires("libalsa/1.2.5.1")
+            self.requires("libalsa/1.2.13")
         if self.options.get_safe("with_xorg"):
             self.requires("xorg/system")
         if self.options.with_gl:
             self.requires("opengl/system")
             if self.settings.os == "Windows":
                 self.requires("wglext/cci.20200813")
-                self.requires('glext/cci.20210420')
+                self.requires("glext/cci.20210420")
             if self.options.get_safe("with_egl"):
                 self.requires("egl/system")
             if self.options.get_safe("with_wayland"):
-                self.requires("wayland/1.20.0")
-                self.requires("wayland-protocols/1.25")
+                self.requires("wayland/1.24.0")
+                self.requires("wayland-protocols/1.45")
             if self.options.with_graphene:
                 self.requires("graphene/1.10.8")
             if self.options.with_libpng:
-                self.requires("libpng/1.6.37")
+                self.requires("libpng/[>=1.6 <2]")
             if self.options.with_libjpeg == "libjpeg":
-                self.requires("libjpeg/9d")
+                self.requires("libjpeg/9f")
             elif self.options.with_libjpeg == "libjpeg-turbo":
-                self.requires("libjpeg-turbo/2.1.2")
+                self.requires("libjpeg-turbo/3.1.4.1")
         if self.options.with_ogg:
             self.requires("ogg/1.3.5")
         if self.options.with_opus:
-            self.requires("opus/1.3.1")
+            self.requires("opus/1.5.2")
         if self.options.with_theora:
             self.requires("theora/1.1.1")
         if self.options.with_vorbis:
             self.requires("vorbis/1.3.7")
         if self.options.with_pango:
-            self.requires("pango/1.49.3")
+            self.requires("pango/1.54.0")
+
+    def validate(self):
+        if not self.dependencies.direct_host["glib"].options.shared and self.options.shared:
+            # https://gitlab.freedesktop.org/gstreamer/gst-build/-/issues/133
+            raise ConanInvalidConfiguration("shared GStreamer cannot link to static GLib")
+        if self.options.shared != self.dependencies.direct_host["gstreamer"].options.shared:
+            # https://gitlab.freedesktop.org/gstreamer/gst-build/-/issues/133
+            raise ConanInvalidConfiguration("GStreamer and GstPlugins must be either all shared, or all static")
+        if Version(self.version) >= "1.18.2" and \
+           self.settings.compiler == "gcc" and \
+           Version(self.settings.compiler.version) < "5":
+            raise ConanInvalidConfiguration(f"{self.ref} does not support gcc older than 5")
+        if self.options.with_gl and self.options.get_safe("with_wayland") and not self.options.get_safe("with_egl"):
+            raise ConanInvalidConfiguration("OpenGL support with Wayland requires 'with_egl' turned on!")
 
     def build_requirements(self):
-        self.build_requires("meson/0.61.2")
-        if not tools.which("pkg-config"):
-            self.build_requires("pkgconf/1.7.4")
-        if self.settings.os == 'Windows':
-            self.build_requires("winflexbison/2.5.24")
+        self.tool_requires("meson/[>=1.2.3 <2]")
+        if not self._is_legacy_one_profile:
+            self.tool_requires("glib/<host_version>")
+        if not self.conf.get("tools.gnu:pkg_config", check_type=str):
+            self.tool_requires("pkgconf/[>=2.2 <3]")
+        if self._settings_build.os == "Windows":
+            self.tool_requires("winflexbison/2.5.25")
         else:
-            self.build_requires("bison/3.7.6")
-            self.build_requires("flex/2.6.4")
+            self.tool_requires("bison/3.8.2")
+            self.tool_requires("flex/2.6.4")
         if self.options.with_introspection:
-            self.build_requires("gobject-introspection/1.70.0")
+            self.tool_requires("gobject-introspection/1.78.1")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def _gl_config(self):
         if not self._gl_api or not self._gl_platform or not self._gl_winsys:
             gl_api = set()
             gl_platform = set()
-            gl_winsys = set() # TODO: winrt, dispamnx, viv-fb, gbm, android
+            gl_winsys = set()  # TODO: winrt, dispamnx, viv-fb, gbm, android
             if self.options.get_safe("with_egl"):
                 gl_api.add("opengl")
                 gl_platform.add("egl")
@@ -184,97 +199,78 @@ class GStPluginsBaseConan(ConanFile):
             self._gl_winsys = list(gl_winsys)
         return self._gl_api, self._gl_platform, self._gl_winsys
 
-    def _configure_meson(self):
-        defs = dict()
-
-        def add_flag(name, value):
-            if name in defs:
-                defs[name] += " " + value
-            else:
-                defs[name] = value
-
-        def add_compiler_flag(value):
-            add_flag("c_args", value)
-            add_flag("cpp_args", value)
-
-        def add_linker_flag(value):
-            add_flag("c_link_args", value)
-            add_flag("cpp_link_args", value)
-
-        meson = Meson(self)
-        if self.settings.compiler == "Visual Studio":
-            add_linker_flag("-lws2_32")
-            add_compiler_flag("-%s" % self.settings.compiler.runtime)
-            if int(str(self.settings.compiler.version)) < 14:
-                add_compiler_flag("-Dsnprintf=_snprintf")
-        if self.settings.get_safe("compiler.runtime"):
-            defs["b_vscrt"] = str(self.settings.compiler.runtime).lower()
+    def generate(self):
+        virtual_build_env = VirtualBuildEnv(self)
+        virtual_build_env.generate()
+        if self._is_legacy_one_profile:
+            VirtualRunEnv(self).generate(scope="build")
+        pkg_config_deps = PkgConfigDeps(self)
+        pkg_config_deps.generate()
 
         gl_api, gl_platform, gl_winsys = self._gl_config()
 
-        defs["tools"] = "disabled"
-        defs["examples"] = "disabled"
-        defs["tests"] = "disabled"
-        defs["wrap_mode"] = "nofallback"
-        defs["introspection"] = "enabled" if self.options.with_introspection else "disabled"
-        defs["orc"] = "disabled" # TODO: orc
-        defs["gl"] = "enabled" if self.options.with_gl else "disabled"
-        defs["gl-graphene"] = "enabled" if self.options.with_gl and self.options.with_graphene else "disabled"
-        defs["gl-png"] = "enabled" if self.options.with_gl and self.options.with_libpng else "disabled"
-        defs["gl-jpeg"] = "enabled" if self.options.with_gl and self.options.with_libjpeg else "disabled"
-        defs["gl_api"] = gl_api
-        defs["gl_platform"] = gl_platform
-        defs["gl_winsys"] = gl_winsys
-        defs["alsa"] = "enabled" if self.options.get_safe("with_libalsa") else "disabled"
-        defs["cdparanoia"] = "disabled" # "enabled" if self.options.with_cdparanoia else "disabled" # TODO: cdparanoia
-        defs["libvisual"] = "disabled" # "enabled" if self.options.with_libvisual else "disabled" # TODO: libvisual
-        defs["ogg"] = "enabled" if self.options.with_ogg else "disabled"
-        defs["opus"] = "enabled" if self.options.with_opus else "disabled"
-        defs["pango"] = "enabled" if self.options.with_pango else "disabled"
-        defs["theora"] = "enabled" if self.options.with_theora else "disabled"
-        defs["tremor"] = "disabled" # "enabled" if self.options.with_tremor else "disabled" # TODO: tremor - only useful on machines without floating-point support
-        defs["vorbis"] = "enabled" if self.options.with_vorbis else "disabled"
-        defs["x11"] = "enabled" if self.options.get_safe("with_xorg") else "disabled"
-        defs["xshm"] = "enabled" if self.options.get_safe("with_xorg") else "disabled"
-        defs["xvideo"] = "enabled" if self.options.get_safe("with_xorg") else "disabled"
-        meson.configure(build_folder=self._build_subfolder,
-                        source_folder=self._source_subfolder,
-                        defs=defs)
-        return meson
+        tc = MesonToolchain(self)
+        if is_msvc(self) and not check_min_vs(self, "190", raise_invalid=False):
+            tc.c_args.append("-Dsnprintf=_snprintf")
+            tc.project_options["c_std"] = "c99"
+        if is_msvc(self):
+            tc.c_link_args.append("-lws2_32")
+            tc.cpp_link_args.append("-lws2_32")
+        tc.project_options["tools"] = "disabled"
+        tc.project_options["examples"] = "disabled"
+        tc.project_options["tests"] = "disabled"
+        tc.project_options["doc"] = "disabled"
+        tc.project_options["wrap_mode"] = "nofallback"
+        tc.project_options["introspection"] = "enabled" if self.options.with_introspection else "disabled"
+        tc.project_options["orc"] = "disabled"  # TODO: orc
+        tc.project_options["gl"] = "enabled" if self.options.with_gl else "disabled"
+        tc.project_options["gl-graphene"] = "enabled" if self.options.with_gl and self.options.with_graphene else "disabled"
+        tc.project_options["gl-png"] = "enabled" if self.options.with_gl and self.options.with_libpng else "disabled"
+        tc.project_options["gl-jpeg"] = "enabled" if self.options.with_gl and self.options.with_libjpeg else "disabled"
+        tc.project_options["gl_api"] = gl_api
+        tc.project_options["gl_platform"] = gl_platform
+        tc.project_options["gl_winsys"] = gl_winsys
+        tc.project_options["alsa"] = "enabled" if self.options.get_safe("with_libalsa") else "disabled"
+        tc.project_options["cdparanoia"] = "disabled"  # TODO: cdparanoia
+        tc.project_options["libvisual"] = "disabled"  # TODO: libvisual
+        tc.project_options["ogg"] = "enabled" if self.options.with_ogg else "disabled"
+        tc.project_options["opus"] = "enabled" if self.options.with_opus else "disabled"
+        tc.project_options["pango"] = "enabled" if self.options.with_pango else "disabled"
+        tc.project_options["theora"] = "enabled" if self.options.with_theora else "disabled"
+        tc.project_options["tremor"] = "disabled"  # TODO: tremor
+        tc.project_options["vorbis"] = "enabled" if self.options.with_vorbis else "disabled"
+        tc.project_options["x11"] = "enabled" if self.options.get_safe("with_xorg") else "disabled"
+        tc.project_options["xshm"] = "enabled" if self.options.get_safe("with_xorg") else "disabled"
+        tc.project_options["xvideo"] = "enabled" if self.options.get_safe("with_xorg") else "disabled"
+        tc.generate()
 
     def build(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
-
-        with tools.environment_append(VisualStudioBuildEnvironment(self).vars) if self._is_msvc else tools.no_op():
-            meson = self._configure_meson()
-            meson.build()
+        apply_conandata_patches(self)
+        meson = Meson(self)
+        meson.configure()
+        meson.build()
 
     def _fix_library_names(self, path):
         # regression in 1.16
-        if self.settings.compiler == "Visual Studio":
-            with tools.chdir(path):
+        if is_msvc(self):
+            with chdir(self, path):
                 for filename_old in glob.glob("*.a"):
                     filename_new = filename_old[3:-2] + ".lib"
-                    self.output.info("rename %s into %s" % (filename_old, filename_new))
-                    shutil.move(filename_old, filename_new)
+                    self.output.info(f"rename {filename_old} into {filename_new}")
+                    rename(self, filename_old, filename_new)
 
     def package(self):
-        self.copy(pattern="COPYING", dst="licenses", src=self._source_subfolder)
-        with tools.environment_append(VisualStudioBuildEnvironment(self).vars) if self._is_msvc else tools.no_op():
-            meson = self._configure_meson()
-            meson.install()
+        copy(self, "COPYING", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        meson = Meson(self)
+        meson.install()
 
         self._fix_library_names(os.path.join(self.package_folder, "lib"))
         self._fix_library_names(os.path.join(self.package_folder, "lib", "gstreamer-1.0"))
-        tools.rmdir(os.path.join(self.package_folder, "share"))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "gstreamer-1.0", "pkgconfig"))
-        tools.remove_files_by_mask(self.package_folder, "*.pdb")
-
-    def package_id(self):
-        self.info.requires["glib"].full_package_mode()
-        self.info.requires["gstreamer"].full_package_mode()
+        rmdir(self, os.path.join(self.package_folder, "share"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "gstreamer-1.0", "pkgconfig"))
+        rm(self, "*.pdb", self.package_folder, recursive=True)
+        fix_apple_shared_install_name(self)
 
     def package_info(self):
         gst_plugins = []
@@ -289,268 +285,102 @@ class GStPluginsBaseConan(ConanFile):
             "datadir": "${datarootdir}",
             "girdir": "${datadir}/gir-1.0",
             "typelibdir": "${libdir}/girepository-1.0",
-            "libexecdir": "${prefix}/libexec"
+            "libexecdir": "${prefix}/libexec",
         }
-        pkgconfig_custom_content = "\n".join("{}={}".format(key, value) for key, value in pkgconfig_variables.items())
+        pkgconfig_custom_content = "\n".join(f"{key}={value}" for key, value in pkgconfig_variables.items())
 
         if self.options.shared:
-            self.output.info("Appending GST_PLUGIN_PATH env var : %s" % gst_plugin_path)
+            self.runenv_info.append_path("GST_PLUGIN_PATH", gst_plugin_path)
+            # TODO: remove the following when only Conan 2.0 is supported
             self.env_info.GST_PLUGIN_PATH.append(gst_plugin_path)
 
-        # Plugins ('gst')
-        self.cpp_info.components["gstadder"].libs = ["gstadder"]
-        self.cpp_info.components["gstadder"].libdirs.append(gst_plugin_path)
-        self.cpp_info.components["gstadder"].requires = ["gstreamer-audio-1.0"] # TODO: orc
-        gst_plugins.append("gstadder")
+        # Plugins are only linkable in static builds; in shared builds they are
+        # loaded dynamically at runtime via GST_PLUGIN_PATH.
+        def _define_plugin(name, requires, system_libs=None, frameworks=None):
+            # Only register the plugin if its library was actually built and installed,
+            # since the available plugin set varies across gstreamer versions.
+            lib_candidates = [f"lib{name}.a", f"{name}.lib", f"lib{name}.so", f"lib{name}.dylib", f"{name}.dll"]
+            if not any(os.path.exists(os.path.join(gst_plugin_path, candidate)) for candidate in lib_candidates):
+                return
+            component = self.cpp_info.components[name]
+            component.libs = [name]
+            component.libdirs.append(gst_plugin_path)
+            component.requires = requires
+            if system_libs:
+                component.system_libs = system_libs
+            if frameworks:
+                component.frameworks = frameworks
+            gst_plugins.append(name)
 
-        self.cpp_info.components["gstapp"].libs = ["gstapp"]
-        self.cpp_info.components["gstapp"].libdirs.append(gst_plugin_path)
-        self.cpp_info.components["gstapp"].requires = ["gstreamer::gstreamer-base-1.0", "gstreamer-app-1.0", "gstreamer-tag-1.0"]
-        gst_plugins.append("gstapp")
+        if not self.options.shared:
+            _m = ["m"] if self.settings.os == "Linux" else None
 
-        self.cpp_info.components["gstaudioconvert"].libs = ["gstaudioconvert"]
-        self.cpp_info.components["gstaudioconvert"].libdirs.append(gst_plugin_path)
-        self.cpp_info.components["gstaudioconvert"].requires = ["gstreamer::gstreamer-base-1.0", "gstreamer-audio-1.0"]
-        gst_plugins.append("gstaudioconvert")
+            # Plugins ('gst')
+            _define_plugin("gstadder", ["gstreamer-audio-1.0"])  # TODO: orc
+            _define_plugin("gstapp", ["gstreamer::gstreamer-base-1.0", "gstreamer-app-1.0", "gstreamer-tag-1.0"])
+            _define_plugin("gstaudioconvert", ["gstreamer::gstreamer-base-1.0", "gstreamer-audio-1.0"])
+            _define_plugin("gstaudiomixer", ["gstreamer::gstreamer-base-1.0", "gstreamer-audio-1.0"])  # TODO: orc
+            _define_plugin("gstaudiorate", ["gstreamer::gstreamer-base-1.0", "gstreamer-audio-1.0"])
+            _define_plugin("gstaudioresample", ["gstreamer::gstreamer-base-1.0", "gstreamer-audio-1.0"], system_libs=_m)
+            _define_plugin("gstaudiotestsrc", ["gstreamer::gstreamer-base-1.0", "gstreamer-audio-1.0"], system_libs=_m)
+            _define_plugin("gstcompositor", ["gstreamer::gstreamer-base-1.0", "gstreamer-video-1.0"], system_libs=_m)  # TODO: orc
+            _define_plugin("gstencoding", ["gstreamer::gstreamer-base-1.0", "gstreamer-video-1.0", "gstreamer-pbutils-1.0"])
+            _define_plugin("gstgio", ["gstreamer::gstreamer-base-1.0", "glib::gio-2.0"])
+            _define_plugin("gstoverlaycomposition", ["gstreamer-video-1.0"])
+            _define_plugin("gstpbtypes", ["gstreamer-video-1.0"])
+            _define_plugin("gstplayback", ["gstreamer-audio-1.0", "gstreamer-video-1.0", "gstreamer-pbutils-1.0", "gstreamer-tag-1.0"])
+            _define_plugin("gstrawparse", ["gstreamer::gstreamer-base-1.0", "gstreamer-audio-1.0", "gstreamer-video-1.0"])
+            _define_plugin("gstsubparse", ["gstreamer::gstreamer-base-1.0"])
+            _define_plugin("gsttcp", ["gstreamer::gstreamer-base-1.0", "gstreamer::gstreamer-net-1.0", "glib::gio-2.0"])
+            _define_plugin("gsttypefindfunctions", ["gstreamer::gstreamer-base-1.0", "gstreamer-pbutils-1.0", "glib::gio-2.0"])
+            _define_plugin("gstvideoconvert", ["gstreamer-video-1.0"])
+            _define_plugin("gstvideorate", ["gstreamer-video-1.0"])
+            _define_plugin("gstvideoscale", ["gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0", "gstreamer-video-1.0", "glib::glib-2.0", "glib::gobject-2.0"])
+            _define_plugin("gstvideotestsrc", ["gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0", "gstreamer-video-1.0", "glib::glib-2.0", "glib::gobject-2.0"], system_libs=_m)  # TODO: orc
+            _define_plugin("gstvolume", ["gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0", "gstreamer-audio-1.0", "glib::glib-2.0", "glib::gobject-2.0"])  # TODO: orc
 
-        self.cpp_info.components["gstaudiomixer"].libs = ["gstaudiomixer"]
-        self.cpp_info.components["gstaudiomixer"].libdirs.append(gst_plugin_path)
-        self.cpp_info.components["gstaudiomixer"].requires = ["gstreamer::gstreamer-base-1.0", "gstreamer-audio-1.0"] # TODO: orc
-        gst_plugins.append("gstaudiomixer")
+            # Plugins ('ext')
+            if self.options.get_safe("with_libalsa"):
+                _define_plugin("gstalsa", ["gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0", "gstreamer-audio-1.0", "gstreamer-tag-1.0", "libalsa::libalsa", "glib::glib-2.0", "glib::gobject-2.0"])
 
-        self.cpp_info.components["gstaudiorate"].libs = ["gstaudiorate"]
-        self.cpp_info.components["gstaudiorate"].libdirs.append(gst_plugin_path)
-        self.cpp_info.components["gstaudiorate"].requires = ["gstreamer::gstreamer-base-1.0", "gstreamer-audio-1.0"]
-        gst_plugins.append("gstaudiorate")
+            if self.options.with_gl:
+                gstopengl_requires = ["gstreamer::gstreamer-base-1.0", "gstreamer::gstreamer-controller-1.0", "gstreamer-video-1.0", "gstreamer-allocators-1.0", "opengl::opengl"]  # TODO: bcm, nvbuf_utils
+                if self.options.with_graphene:
+                    gstopengl_requires.append("graphene::graphene-gobject-1.0")
+                if self.options.with_libpng:
+                    gstopengl_requires.append("libpng::libpng")
+                if self.options.with_libjpeg == "libjpeg":
+                    gstopengl_requires.append("libjpeg::libjpeg")
+                elif self.options.with_libjpeg == "libjpeg-turbo":
+                    gstopengl_requires.append("libjpeg-turbo::libjpeg-turbo")
+                if self.options.get_safe("with_xorg"):
+                    gstopengl_requires.append("xorg::x11")
+                _define_plugin("gstopengl", gstopengl_requires, system_libs=_m,
+                               frameworks=["CoreFoundation", "Foundation", "QuartzCore"] if self.settings.os == "Macos" else None)
 
-        self.cpp_info.components["gstaudioresample"].libs = ["gstaudioresample"]
-        self.cpp_info.components["gstaudioresample"].libdirs.append(gst_plugin_path)
-        self.cpp_info.components["gstaudioresample"].requires = ["gstreamer::gstreamer-base-1.0", "gstreamer-audio-1.0"]
-        if self.settings.os == "Linux":
-            self.cpp_info.components["gstaudioresample"].system_libs = ["m"]
-        gst_plugins.append("gstaudioresample")
+            if self.options.with_ogg:
+                _define_plugin("gstogg", ["gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0", "gstreamer-audio-1.0", "gstreamer-pbutils-1.0", "gstreamer-tag-1.0", "gstreamer-riff-1.0", "ogg::ogglib", "glib::glib-2.0", "glib::gobject-2.0"])
 
-        self.cpp_info.components["gstaudiotestsrc"].libs = ["gstaudiotestsrc"]
-        self.cpp_info.components["gstaudiotestsrc"].libdirs.append(gst_plugin_path)
-        self.cpp_info.components["gstaudiotestsrc"].requires = ["gstreamer::gstreamer-base-1.0", "gstreamer-audio-1.0"]
-        if self.settings.os == "Linux":
-            self.cpp_info.components["gstaudiotestsrc"].system_libs = ["m"]
-        gst_plugins.append("gstaudiotestsrc")
+            if self.options.with_opus:
+                _define_plugin("gstopus", ["gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0", "gstreamer-audio-1.0", "gstreamer-pbutils-1.0", "gstreamer-tag-1.0", "opus::libopus", "glib::glib-2.0", "glib::gobject-2.0"], system_libs=_m)
 
-        self.cpp_info.components["gstcompositor"].libs = ["gstcompositor"]
-        self.cpp_info.components["gstcompositor"].libdirs.append(gst_plugin_path)
-        self.cpp_info.components["gstcompositor"].requires = ["gstreamer::gstreamer-base-1.0", "gstreamer-video-1.0"] # TODO: orc
-        if self.settings.os == "Linux":
-            self.cpp_info.components["gstcompositor"].system_libs = ["m"]
-        gst_plugins.append("gstcompositor")
+            if self.options.with_pango:
+                _define_plugin("gstpango", ["gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0", "gstreamer-video-1.0", "pango::pangocairo", "glib::glib-2.0", "glib::gobject-2.0"], system_libs=_m)
 
-        self.cpp_info.components["gstencoding"].libs = ["gstencoding"]
-        self.cpp_info.components["gstencoding"].libdirs.append(gst_plugin_path)
-        self.cpp_info.components["gstencoding"].requires = ["gstreamer::gstreamer-base-1.0", "gstreamer-video-1.0", "gstreamer-pbutils-1.0"]
-        gst_plugins.append("gstencoding")
+            if self.options.with_theora:
+                _define_plugin("gsttheora", ["gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0", "gstreamer-video-1.0", "gstreamer-tag-1.0", "theora::theoraenc", "theora::theoradec", "glib::glib-2.0", "glib::gobject-2.0"])
 
-        self.cpp_info.components["gstgio"].libs = ["gstgio"]
-        self.cpp_info.components["gstgio"].libdirs.append(gst_plugin_path)
-        self.cpp_info.components["gstgio"].requires = ["gstreamer::gstreamer-base-1.0", "glib::gio-2.0"]
-        gst_plugins.append("gstgio")
+            if self.options.with_vorbis:
+                _define_plugin("gstvorbis", ["gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0", "gstreamer-audio-1.0", "gstreamer-tag-1.0", "vorbis::vorbismain", "vorbis::vorbisenc", "glib::glib-2.0", "glib::gobject-2.0"])
 
-        self.cpp_info.components["gstoverlaycomposition"].libs = ["gstoverlaycomposition"]
-        self.cpp_info.components["gstoverlaycomposition"].libdirs.append(gst_plugin_path)
-        self.cpp_info.components["gstoverlaycomposition"].requires = ["gstreamer-video-1.0"]
-        gst_plugins.append("gstoverlaycomposition")
-
-        self.cpp_info.components["gstpbtypes"].libs = ["gstpbtypes"]
-        self.cpp_info.components["gstpbtypes"].libdirs.append(gst_plugin_path)
-        self.cpp_info.components["gstpbtypes"].requires = ["gstreamer-video-1.0"]
-        gst_plugins.append("gstpbtypes")
-
-        self.cpp_info.components["gstplayback"].libs = ["gstplayback"]
-        self.cpp_info.components["gstplayback"].libdirs.append(gst_plugin_path)
-        self.cpp_info.components["gstplayback"].requires = ["gstreamer-audio-1.0", "gstreamer-video-1.0", "gstreamer-pbutils-1.0", "gstreamer-tag-1.0"]
-        gst_plugins.append("gstplayback")
-
-        self.cpp_info.components["gstrawparse"].libs = ["gstrawparse"]
-        self.cpp_info.components["gstrawparse"].libdirs.append(gst_plugin_path)
-        self.cpp_info.components["gstrawparse"].requires = ["gstreamer::gstreamer-base-1.0", "gstreamer-audio-1.0", "gstreamer-video-1.0"]
-        gst_plugins.append("gstrawparse")
-
-        self.cpp_info.components["gstsubparse"].libs = ["gstsubparse"]
-        self.cpp_info.components["gstsubparse"].libdirs.append(gst_plugin_path)
-        self.cpp_info.components["gstsubparse"].requires = ["gstreamer::gstreamer-base-1.0"]
-        gst_plugins.append("gstsubparse")
-
-        self.cpp_info.components["gsttcp"].libs = ["gsttcp"]
-        self.cpp_info.components["gsttcp"].libdirs.append(gst_plugin_path)
-        self.cpp_info.components["gsttcp"].requires = ["gstreamer::gstreamer-base-1.0", "gstreamer::gstreamer-net-1.0", "glib::gio-2.0"]
-        gst_plugins.append("gsttcp")
-
-        self.cpp_info.components["gsttypefindfunctions"].libs = ["gsttypefindfunctions"]
-        self.cpp_info.components["gsttypefindfunctions"].libdirs.append(gst_plugin_path)
-        self.cpp_info.components["gsttypefindfunctions"].requires = ["gstreamer::gstreamer-base-1.0", "gstreamer-pbutils-1.0", "glib::gio-2.0"]
-        gst_plugins.append("gsttypefindfunctions")
-
-        self.cpp_info.components["gstvideoconvert"].libs = ["gstvideoconvert"]
-        self.cpp_info.components["gstvideoconvert"].libdirs.append(gst_plugin_path)
-        self.cpp_info.components["gstvideoconvert"].requires = ["gstreamer-video-1.0"]
-        gst_plugins.append("gstvideoconvert")
-
-        self.cpp_info.components["gstvideorate"].libs = ["gstvideorate"]
-        self.cpp_info.components["gstvideorate"].libdirs.append(gst_plugin_path)
-        self.cpp_info.components["gstvideorate"].requires = ["gstreamer-video-1.0"]
-        gst_plugins.append("gstvideorate")
-
-        self.cpp_info.components["gstvideoscale"].libs = ["gstvideoscale"]
-        self.cpp_info.components["gstvideoscale"].libdirs.append(gst_plugin_path)
-        self.cpp_info.components["gstvideoscale"].requires = [
-            "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0",
-            "gstreamer-video-1.0", "glib::glib-2.0", "glib::gobject-2.0"]
-        gst_plugins.append("gstvideoscale")
-
-        self.cpp_info.components["gstvideotestsrc"].libs = ["gstvideotestsrc"]
-        self.cpp_info.components["gstvideotestsrc"].libdirs.append(gst_plugin_path)
-        self.cpp_info.components["gstvideotestsrc"].requires = [
-            "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0",
-            "gstreamer-video-1.0", "glib::glib-2.0", "glib::gobject-2.0"] # TODO: orc
-        if self.settings.os == "Linux":
-            self.cpp_info.components["gstvideotestsrc"].system_libs = ["m"]
-        gst_plugins.append("gstvideotestsrc")
-
-        self.cpp_info.components["gstvolume"].libs = ["gstvolume"]
-        self.cpp_info.components["gstvolume"].libdirs.append(gst_plugin_path)
-        self.cpp_info.components["gstvolume"].requires = [
-            "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0",
-            "gstreamer-audio-1.0", "glib::glib-2.0", "glib::gobject-2.0"] # TODO: orc
-        gst_plugins.append("gstvolume")
-
-        # Plugins ('ext')
-        if self.options.get_safe("with_libalsa"):
-            self.cpp_info.components["gstalsa"].libs = ["gstalsa"]
-            self.cpp_info.components["gstalsa"].libdirs.append(gst_plugin_path)
-            self.cpp_info.components["gstalsa"].requires = [
-                "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0",
-                "gstreamer-audio-1.0", "gstreamer-tag-1.0",
-                "libalsa::libalsa", "glib::glib-2.0", "glib::gobject-2.0"]
-            gst_plugins.append("gstalsa")
-
-        # if self.options.with_cdparanoia: # TODO: cdparanoia
-        #     self.cpp_info.components["gstcdparanoia"].libs = ["gstcdparanoia"]
-        #     self.cpp_info.components["gstcdparanoia"].libdirs.append(gst_plugin_path)
-        #     self.cpp_info.components["gstcdparanoia"].requires = [
-        #         "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0", "gstreamer-audio-1.0",
-        #         "cdparanoia::cdparanoia", "glib::glib-2.0", "glib::gobject-2.0"]
-        #     gst_plugins.append("gstcdparanoia")
-
-        if self.options.with_gl:
-            self.cpp_info.components["gstopengl"].libs = ["gstopengl"]
-            self.cpp_info.components["gstopengl"].libdirs.append(gst_plugin_path)
-            self.cpp_info.components["gstopengl"].requires = [
-                "gstreamer::gstreamer-base-1.0", "gstreamer::gstreamer-controller-1.0",
-                "gstreamer-video-1.0", "gstreamer-allocators-1.0", "opengl::opengl"] # TODO: bcm, nvbuf_utils
-            if self.settings.os == "Macos":
-                self.cpp_info.components["gstopengl"].frameworks = ["CoreFoundation", "Foundation", "QuartzCore"]
-            if self.options.with_graphene:
-                self.cpp_info.components["gstopengl"].requires.append("graphene::graphene-gobject-1.0")
-            if self.options.with_libpng:
-                self.cpp_info.components["gstopengl"].requires.append("libpng::libpng")
-            if self.options.with_libjpeg == "libjpeg":
-                self.cpp_info.components["gstopengl"].requires.append("libjpeg::libjpeg")
-            elif self.options.with_libjpeg == "libjpeg-turbo":
-                self.cpp_info.components["gstopengl"].requires.append("libjpeg-turbo::libjpeg-turbo")
+            # Plugins ('sys')
             if self.options.get_safe("with_xorg"):
-                self.cpp_info.components["gstopengl"].requires.append("xorg::x11")
-            if self.settings.os == "Linux":
-                self.cpp_info.components["gstopengl"].system_libs = ["m"]
-            gst_plugins.append("gstopengl")
+                _define_plugin("gstximagesink", ["gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0", "gstreamer-video-1.0", "xorg::x11", "xorg::xext", "glib::glib-2.0", "glib::gobject-2.0"])
+                _define_plugin("gstxvimagesink", ["gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0", "gstreamer-video-1.0", "xorg::x11", "xorg::xext", "xorg::xv", "glib::glib-2.0", "glib::gobject-2.0"], system_libs=_m)
 
-        # if self.options.with_libvisual: # TODO: libvisual
-        #     self.cpp_info.components["gstlibvisual"].libs = ["gstlibvisual"]
-        #     self.cpp_info.components["gstlibvisual"].libdirs.append(gst_plugin_path)
-        #     self.cpp_info.components["gstlibvisual"].requires = [
-        #         "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0",
-        #         "gstreamer-audio-1.0", "gstreamer-video-1.0", "gstreamer-pbutils-1.0",
-        #         "libvisual::libvisual", "glib::glib-2.0", "glib::gobject-2.0"]
-        #     gst_plugins.append("gstlibvisual")
-
-        if self.options.with_ogg:
-            self.cpp_info.components["gstogg"].libs = ["gstogg"]
-            self.cpp_info.components["gstogg"].libdirs.append(gst_plugin_path)
-            self.cpp_info.components["gstogg"].requires = [
-                "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0",
-                "gstreamer-audio-1.0", "gstreamer-pbutils-1.0", "gstreamer-tag-1.0", "gstreamer-riff-1.0",
-                "ogg::ogglib", "glib::glib-2.0", "glib::gobject-2.0"]
-            gst_plugins.append("gstogg")
-
-        if self.options.with_opus:
-            self.cpp_info.components["gstopus"].libs = ["gstopus"]
-            self.cpp_info.components["gstopus"].libdirs.append(gst_plugin_path)
-            self.cpp_info.components["gstopus"].requires = [
-                "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0",
-                "gstreamer-audio-1.0", "gstreamer-pbutils-1.0", "gstreamer-tag-1.0",
-                "opus::libopus", "glib::glib-2.0", "glib::gobject-2.0"]
-            if self.settings.os == "Linux":
-                self.cpp_info.components["gstopus"].system_libs = ["m"]
-            gst_plugins.append("gstopus")
-
-        if self.options.with_pango:
-            self.cpp_info.components["gstpango"].libs = ["gstpango"]
-            self.cpp_info.components["gstpango"].libdirs.append(gst_plugin_path)
-            self.cpp_info.components["gstpango"].requires = [
-                "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0",
-                "gstreamer-video-1.0",
-                "pango::pangocairo", "glib::glib-2.0", "glib::gobject-2.0"]
-            if self.settings.os == "Linux":
-                self.cpp_info.components["gstpango"].system_libs = ["m"]
-            gst_plugins.append("gstpango")
-
-        if self.options.with_theora:
-            self.cpp_info.components["gsttheora"].libs = ["gsttheora"]
-            self.cpp_info.components["gsttheora"].libdirs.append(gst_plugin_path)
-            self.cpp_info.components["gsttheora"].requires = [
-                "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0",
-                "gstreamer-video-1.0", "gstreamer-tag-1.0",
-                "theora::theoraenc", "theora::theoradec", "glib::glib-2.0", "glib::gobject-2.0"]
-            gst_plugins.append("gsttheora")
-
-        if self.options.with_vorbis:
-            self.cpp_info.components["gstvorbis"].libs = ["gstvorbis"]
-            self.cpp_info.components["gstvorbis"].libdirs.append(gst_plugin_path)
-            self.cpp_info.components["gstvorbis"].requires = [
-                "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0",
-                "gstreamer-audio-1.0", "gstreamer-tag-1.0",
-                "vorbis::vorbismain", "vorbis::vorbisenc", "glib::glib-2.0", "glib::gobject-2.0"]
-            gst_plugins.append("gstvorbis")
-
-        # if self.options.with_tremor: # TODO: tremor
-        #     self.cpp_info.components["gstivorbisdec"].libs = ["gstivorbisdec"]
-        #     self.cpp_info.components["gstivorbisdec"].libdirs.append(gst_plugin_path)
-        #     self.cpp_info.components["gstivorbisdec"].requires = [
-        #         "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0",
-        #         "gstreamer-audio-1.0", "gstreamer-tag-1.0",
-        #         "tremor::tremor", "glib::glib-2.0", "glib::gobject-2.0"]
-        #     gst_plugins.append("gstivorbisdec")
-
-        # Plugins ('sys')
-        if self.options.get_safe("with_xorg"):
-            self.cpp_info.components["gstximagesink"].libs = ["gstximagesink"]
-            self.cpp_info.components["gstximagesink"].libdirs.append(gst_plugin_path)
-            self.cpp_info.components["gstximagesink"].requires = [
-                "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0",
-                "gstreamer-video-1.0",
-                "xorg::x11", "xorg::xext", "glib::glib-2.0", "glib::gobject-2.0"]
-            gst_plugins.append("gstximagesink")
-
-            self.cpp_info.components["gstxvimagesink"].libs = ["gstxvimagesink"]
-            self.cpp_info.components["gstxvimagesink"].libdirs.append(gst_plugin_path)
-            self.cpp_info.components["gstxvimagesink"].requires = [
-                "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0",
-                "gstreamer-video-1.0",
-                "xorg::x11", "xorg::xext", "xorg::xv", "glib::glib-2.0", "glib::gobject-2.0"]
-            if self.settings.os == "Linux":
-                self.cpp_info.components["gstxvimagesink"].system_libs = ["m"]
-            gst_plugins.append("gstxvimagesink")
 
         # Libraries
-        self.cpp_info.components["gstreamer-plugins-base-1.0"].names["pkg_config"] = "gstreamer-plugins-base-1.0"
+        self.cpp_info.components["gstreamer-plugins-base-1.0"].set_property("pkg_config_name", "gstreamer-plugins-base-1.0")
         self.cpp_info.components["gstreamer-plugins-base-1.0"].requires = ["gstreamer::gstreamer-1.0"]
         self.cpp_info.components["gstreamer-plugins-base-1.0"].includedirs = [gst_include_path]
         if not self.options.shared:
@@ -560,27 +390,27 @@ class GStPluginsBaseConan(ConanFile):
             self.cpp_info.components["gstreamer-plugins-base-1.0"].bindirs.append(gst_plugin_path)
         self.cpp_info.components["gstreamer-plugins-base-1.0"].set_property("pkg_config_custom_content", pkgconfig_custom_content)
 
-        self.cpp_info.components["gstreamer-allocators-1.0"].names["pkg_config"] = "gstreamer-allocators-1.0"
+        self.cpp_info.components["gstreamer-allocators-1.0"].set_property("pkg_config_name", "gstreamer-allocators-1.0")
         self.cpp_info.components["gstreamer-allocators-1.0"].libs = ["gstallocators-1.0"]
         self.cpp_info.components["gstreamer-allocators-1.0"].requires = ["gstreamer::gstreamer-1.0"]
         self.cpp_info.components["gstreamer-allocators-1.0"].includedirs = [gst_include_path]
         self.cpp_info.components["gstreamer-allocators-1.0"].set_property("pkg_config_custom_content", pkgconfig_custom_content)
 
-        self.cpp_info.components["gstreamer-app-1.0"].names["pkg_config"] = "gstreamer-app-1.0"
+        self.cpp_info.components["gstreamer-app-1.0"].set_property("pkg_config_name", "gstreamer-app-1.0")
         self.cpp_info.components["gstreamer-app-1.0"].libs = ["gstapp-1.0"]
         self.cpp_info.components["gstreamer-app-1.0"].requires = ["gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0"]
         self.cpp_info.components["gstreamer-app-1.0"].includedirs = [gst_include_path]
         self.cpp_info.components["gstreamer-app-1.0"].set_property("pkg_config_custom_content", pkgconfig_custom_content)
 
-        self.cpp_info.components["gstreamer-audio-1.0"].names["pkg_config"] = "gstreamer-audio-1.0"
+        self.cpp_info.components["gstreamer-audio-1.0"].set_property("pkg_config_name", "gstreamer-audio-1.0")
         self.cpp_info.components["gstreamer-audio-1.0"].libs = ["gstaudio-1.0"]
-        self.cpp_info.components["gstreamer-audio-1.0"].requires = ["gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0", "gstreamer-tag-1.0"] # TODO: orc
+        self.cpp_info.components["gstreamer-audio-1.0"].requires = ["gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0", "gstreamer-tag-1.0"]  # TODO: orc
         self.cpp_info.components["gstreamer-audio-1.0"].includedirs = [gst_include_path]
         if self.settings.os == "Linux":
             self.cpp_info.components["gstreamer-audio-1.0"].system_libs = ["m"]
         self.cpp_info.components["gstreamer-audio-1.0"].set_property("pkg_config_custom_content", pkgconfig_custom_content)
 
-        self.cpp_info.components["gstreamer-fft-1.0"].names["pkg_config"] = "gstreamer-fft-1.0"
+        self.cpp_info.components["gstreamer-fft-1.0"].set_property("pkg_config_name", "gstreamer-fft-1.0")
         self.cpp_info.components["gstreamer-fft-1.0"].libs = ["gstfft-1.0"]
         self.cpp_info.components["gstreamer-fft-1.0"].requires = ["gstreamer::gstreamer-1.0"]
         self.cpp_info.components["gstreamer-fft-1.0"].includedirs = [gst_include_path]
@@ -594,16 +424,16 @@ class GStPluginsBaseConan(ConanFile):
                 **pkgconfig_variables,
                 "gl_apis": " ".join(gl_api),
                 "gl_platforms": " ".join(gl_platform),
-                "gl_winsys": " ".join(gl_winsys)
+                "gl_winsys": " ".join(gl_winsys),
             }
-            gl_custom_content = "\n".join("{}={}".format(key, value) for key, value in gl_variables.items())
+            gl_custom_content = "\n".join(f"{key}={value}" for key, value in gl_variables.items())
 
-            self.cpp_info.components["gstreamer-gl-1.0"].names["pkg_config"] = "gstreamer-gl-1.0"
+            self.cpp_info.components["gstreamer-gl-1.0"].set_property("pkg_config_name", "gstreamer-gl-1.0")
             self.cpp_info.components["gstreamer-gl-1.0"].libs = ["gstgl-1.0"]
             self.cpp_info.components["gstreamer-gl-1.0"].requires = [
                 "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0",
                 "gstreamer-allocators-1.0", "gstreamer-video-1.0",
-                "glib::gmodule-no-export-2.0", "opengl::opengl"] # TODO: bcm
+                "glib::gmodule-no-export-2.0", "opengl::opengl"]  # TODO: bcm
             if self.options.get_safe("with_egl"):
                 self.cpp_info.components["gstreamer-gl-1.0"].requires.extend(["egl::egl"])
             if self.options.get_safe("with_xorg"):
@@ -614,7 +444,7 @@ class GStPluginsBaseConan(ConanFile):
                     "wayland-protocols::wayland-protocols"])
             if self.settings.os == "Windows":
                 self.cpp_info.components["gstreamer-gl-1.0"].requires.append("wglext::wglext")
-                self.cpp_info.components["gstreamer-gl-1.0"].requires.extend(['glext::glext'])
+                self.cpp_info.components["gstreamer-gl-1.0"].requires.extend(["glext::glext"])
                 self.cpp_info.components["gstreamer-gl-1.0"].system_libs = ["gdi32"]
             if self.settings.os in ["Macos", "iOS", "tvOS", "watchOS"]:
                 self.cpp_info.components["gstreamer-gl-1.0"].frameworks = ["CoreFoundation", "Foundation", "QuartzCore", "Cocoa"]
@@ -624,24 +454,24 @@ class GStPluginsBaseConan(ConanFile):
             self.cpp_info.components["gstreamer-gl-1.0"].includedirs.append(os.path.join(gst_plugin_path, "include"))
             self.cpp_info.components["gstreamer-gl-1.0"].set_property("pkg_config_custom_content", gl_custom_content)
 
-            self.cpp_info.components["gstreamer-gl-prototypes-1.0"].names["pkg_config"] = "gstreamer-gl-prototypes-1.0"
+            self.cpp_info.components["gstreamer-gl-prototypes-1.0"].set_property("pkg_config_name", "gstreamer-gl-prototypes-1.0")
             self.cpp_info.components["gstreamer-gl-prototypes-1.0"].requires = ["gstreamer-gl-1.0", "opengl::opengl"]
 
             if self.options.get_safe("with_egl"):
-                self.cpp_info.components["gstreamer-gl-egl-1.0"].names["pkg_config"] = "gstreamer-gl-egl-1.0"
+                self.cpp_info.components["gstreamer-gl-egl-1.0"].set_property("pkg_config_name", "gstreamer-gl-egl-1.0")
                 self.cpp_info.components["gstreamer-gl-egl-1.0"].requires = ["gstreamer-gl-1.0", "egl::egl"]
 
             if self.options.get_safe("with_wayland"):
-                self.cpp_info.components["gstreamer-gl-wayland-1.0"].names["pkg_config"] = "gstreamer-gl-wayland-1.0"
+                self.cpp_info.components["gstreamer-gl-wayland-1.0"].set_property("pkg_config_name", "gstreamer-gl-wayland-1.0")
                 self.cpp_info.components["gstreamer-gl-wayland-1.0"].requires = [
                     "gstreamer-gl-1.0", "wayland::wayland-client", "wayland::wayland-egl",
                     "wayland-protocols::wayland-protocols"]
 
             if self.options.get_safe("with_xorg"):
-                self.cpp_info.components["gstreamer-gl-x11-1.0"].names["pkg_config"] = "gstreamer-gl-x11-1.0"
+                self.cpp_info.components["gstreamer-gl-x11-1.0"].set_property("pkg_config_name", "gstreamer-gl-x11-1.0")
                 self.cpp_info.components["gstreamer-gl-x11-1.0"].requires = ["gstreamer-gl-1.0", "xorg::x11-xcb"]
 
-        self.cpp_info.components["gstreamer-pbutils-1.0"].names["pkg_config"] = "gstreamer-pbutils-1.0"
+        self.cpp_info.components["gstreamer-pbutils-1.0"].set_property("pkg_config_name", "gstreamer-pbutils-1.0")
         self.cpp_info.components["gstreamer-pbutils-1.0"].libs = ["gstpbutils-1.0"]
         self.cpp_info.components["gstreamer-pbutils-1.0"].requires = [
             "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0",
@@ -649,19 +479,19 @@ class GStPluginsBaseConan(ConanFile):
         self.cpp_info.components["gstreamer-pbutils-1.0"].includedirs = [gst_include_path]
         self.cpp_info.components["gstreamer-pbutils-1.0"].set_property("pkg_config_custom_content", pkgconfig_custom_content)
 
-        self.cpp_info.components["gstreamer-riff-1.0"].names["pkg_config"] = "gstreamer-riff-1.0"
+        self.cpp_info.components["gstreamer-riff-1.0"].set_property("pkg_config_name", "gstreamer-riff-1.0")
         self.cpp_info.components["gstreamer-riff-1.0"].libs = ["gstriff-1.0"]
         self.cpp_info.components["gstreamer-riff-1.0"].requires = ["gstreamer::gstreamer-1.0", "gstreamer-audio-1.0", "gstreamer-tag-1.0"]
         self.cpp_info.components["gstreamer-riff-1.0"].includedirs = [gst_include_path]
         self.cpp_info.components["gstreamer-riff-1.0"].set_property("pkg_config_custom_content", pkgconfig_custom_content)
 
-        self.cpp_info.components["gstreamer-rtp-1.0"].names["pkg_config"] = "gstreamer-rtp-1.0"
+        self.cpp_info.components["gstreamer-rtp-1.0"].set_property("pkg_config_name", "gstreamer-rtp-1.0")
         self.cpp_info.components["gstreamer-rtp-1.0"].libs = ["gstrtp-1.0"]
         self.cpp_info.components["gstreamer-rtp-1.0"].requires = ["gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0", "gstreamer-audio-1.0"]
         self.cpp_info.components["gstreamer-rtp-1.0"].includedirs = [gst_include_path]
         self.cpp_info.components["gstreamer-rtp-1.0"].set_property("pkg_config_custom_content", pkgconfig_custom_content)
 
-        self.cpp_info.components["gstreamer-rtsp-1.0"].names["pkg_config"] = "gstreamer-rtsp-1.0"
+        self.cpp_info.components["gstreamer-rtsp-1.0"].set_property("pkg_config_name", "gstreamer-rtsp-1.0")
         self.cpp_info.components["gstreamer-rtsp-1.0"].libs = ["gstrtsp-1.0"]
         self.cpp_info.components["gstreamer-rtsp-1.0"].requires = [
             "gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0",
@@ -673,13 +503,13 @@ class GStPluginsBaseConan(ConanFile):
         self.cpp_info.components["gstreamer-rtsp-1.0"].includedirs = [gst_include_path]
         self.cpp_info.components["gstreamer-rtsp-1.0"].set_property("pkg_config_custom_content", pkgconfig_custom_content)
 
-        self.cpp_info.components["gstreamer-sdp-1.0"].names["pkg_config"] = "gstreamer-sdp-1.0"
+        self.cpp_info.components["gstreamer-sdp-1.0"].set_property("pkg_config_name", "gstreamer-sdp-1.0")
         self.cpp_info.components["gstreamer-sdp-1.0"].libs = ["gstsdp-1.0"]
         self.cpp_info.components["gstreamer-sdp-1.0"].requires = ["gstreamer::gstreamer-1.0", "gstreamer-rtp-1.0", "glib::glib-2.0", "glib::gio-2.0"]
         self.cpp_info.components["gstreamer-sdp-1.0"].includedirs = [gst_include_path]
         self.cpp_info.components["gstreamer-sdp-1.0"].set_property("pkg_config_custom_content", pkgconfig_custom_content)
 
-        self.cpp_info.components["gstreamer-tag-1.0"].names["pkg_config"] = "gstreamer-tag-1.0"
+        self.cpp_info.components["gstreamer-tag-1.0"].set_property("pkg_config_name", "gstreamer-tag-1.0")
         self.cpp_info.components["gstreamer-tag-1.0"].libs = ["gsttag-1.0"]
         self.cpp_info.components["gstreamer-tag-1.0"].requires = ["gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0", "zlib::zlib"]
         if self.settings.os == "Linux":
@@ -687,9 +517,9 @@ class GStPluginsBaseConan(ConanFile):
         self.cpp_info.components["gstreamer-tag-1.0"].includedirs = [gst_include_path]
         self.cpp_info.components["gstreamer-tag-1.0"].set_property("pkg_config_custom_content", pkgconfig_custom_content)
 
-        self.cpp_info.components["gstreamer-video-1.0"].names["pkg_config"] = "gstreamer-video-1.0"
+        self.cpp_info.components["gstreamer-video-1.0"].set_property("pkg_config_name", "gstreamer-video-1.0")
         self.cpp_info.components["gstreamer-video-1.0"].libs = ["gstvideo-1.0"]
-        self.cpp_info.components["gstreamer-video-1.0"].requires = ["gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0"] # TODO: orc
+        self.cpp_info.components["gstreamer-video-1.0"].requires = ["gstreamer::gstreamer-1.0", "gstreamer::gstreamer-base-1.0"]  # TODO: orc
         if self.settings.os == "Linux":
             self.cpp_info.components["gstreamer-video-1.0"].system_libs = ["m"]
         self.cpp_info.components["gstreamer-video-1.0"].includedirs = [gst_include_path]

--- a/recipes/gst-plugins-base/all/test_package/CMakeLists.txt
+++ b/recipes/gst-plugins-base/all/test_package/CMakeLists.txt
@@ -1,11 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
-project(test_package)
-
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
+project(test_package LANGUAGES CXX)
 
 find_package(gst-plugins-base CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} gst-plugins-base::gstreamer-plugins-base-1.0)
+target_link_libraries(${PROJECT_NAME} PRIVATE gst-plugins-base::gstreamer-plugins-base-1.0)

--- a/recipes/gst-plugins-base/all/test_package/conanfile.py
+++ b/recipes/gst-plugins-base/all/test_package/conanfile.py
@@ -1,10 +1,30 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.env import Environment
 import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "PkgConfigDeps", "VirtualBuildEnv", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build_requirements(self):
+        if not self.conf.get("tools.gnu:pkg_config", check_type=str):
+            self.tool_requires("pkgconf/[>=2.2 <3]")
+
+    def generate(self):
+        # Print debug information from gstreamer at runtime
+        env = Environment()
+        env.define("GST_DEBUG", "7")
+        env.vars(self, scope="run").save_script("conanrun_gstdebug")
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +32,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/gst-plugins-base/config.yml
+++ b/recipes/gst-plugins-base/config.yml
@@ -1,5 +1,3 @@
 versions:
-  "1.19.2":
-    folder: all
-  "1.19.1":
+  "1.29.2":
     folder: all

--- a/recipes/gst-plugins-good/all/conandata.yml
+++ b/recipes/gst-plugins-good/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "1.19.1":
-    url: "https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/archive/1.19.1/gst-plugins-good-1.19.1.tar.bz2"
-    sha256 : "c2c97b8bfeac812dbdca3a72a15a874de4845e4a042693dad8447272c8767a64"
+  "1.29.2":
+    url: "https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-1.29.2.tar.xz"
+    sha256: "4ce274d207bd7b404b8b07ed669b4ebac81849b23636e455b23150dee1e3595e"

--- a/recipes/gst-plugins-good/all/conanfile.py
+++ b/recipes/gst-plugins-good/all/conanfile.py
@@ -1,9 +1,18 @@
-from conans import ConanFile, tools, Meson, VisualStudioBuildEnvironment
-from conans.errors import ConanInvalidConfiguration
-from conan.tools.microsoft import msvc_runtime_flag
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import fix_apple_shared_install_name
+from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
+from conan.tools.files import chdir, copy, get, rename, rm, rmdir, apply_conandata_patches, export_conandata_patches
+from conan.tools.gnu import PkgConfigDeps
+from conan.tools.layout import basic_layout
+from conan.tools.meson import Meson, MesonToolchain
+from conan.tools.microsoft import is_msvc, is_msvc_static_runtime, check_min_vs
+from conan.tools.scm import Version
+
 import glob
 import os
-import shutil
+
+required_conan_version = ">=1.60.0 <2 || >=2.0.5"
 
 
 class GStPluginsGoodConan(ConanFile):
@@ -14,196 +23,163 @@ class GStPluginsGoodConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://gstreamer.freedesktop.org/"
     license = "GPL-2.0-only"
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
         "with_introspection": [True, False],
-        }
+    }
     default_options = {
         "shared": False,
         "fPIC": True,
         "with_introspection": False,
-        }
-    _source_subfolder = "source_subfolder"
-    _build_subfolder = "build_subfolder"
-    exports_sources = ["patches/*.patch"]
-
-    generators = "pkg_config"
+    }
 
     @property
-    def _is_msvc(self):
-        return self.settings.compiler == "Visual Studio"
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
 
-    def validate(self):
-        if self.options.shared != self.options["gstreamer"].shared or \
-            self.options.shared != self.options["glib"].shared or \
-            self.options.shared != self.options["gst-plugins-base"].shared:
-                # https://gitlab.freedesktop.org/gstreamer/gst-build/-/issues/133
-                raise ConanInvalidConfiguration("GLib, GStreamer and GstPlugins must be either all shared, or all static")
-        if tools.Version(self.version) >= "1.18.2" and\
-           self.settings.compiler == "gcc" and\
-           tools.Version(self.settings.compiler.version) < "5":
-            raise ConanInvalidConfiguration(
-                "gst-plugins-good %s does not support gcc older than 5" % self.version
-            )
-        if self.options.shared and str(msvc_runtime_flag(self)).startswith("MT"):
-            raise ConanInvalidConfiguration('shared build with static runtime is not supported due to the FlsAlloc limit')
+    @property
+    def _is_legacy_one_profile(self):
+        return not hasattr(self, "settings_build")
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
-        del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
-        self.options['gstreamer'].shared = self.options.shared
-        self.options['gst-plugins-base'].shared = self.options.shared
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
+        self.options["gstreamer"].shared = self.options.shared
+        self.options["gst-plugins-base"].shared = self.options.shared
 
-    def config_options(self):
-        if self.settings.os == 'Windows':
-            del self.options.fPIC
+    def layout(self):
+        basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("glib/2.70.0")
-        self.requires("gstreamer/1.19.1")
-        self.requires("gst-plugins-base/1.19.1")
+        self.requires("glib/2.78.3", transitive_headers=True, transitive_libs=True)
+        self.requires("gstreamer/1.29.2", transitive_headers=True, transitive_libs=True)
+        self.requires("gst-plugins-base/1.29.2", transitive_headers=True, transitive_libs=True)
+
+    def validate(self):
+        if self.options.shared != self.dependencies.direct_host["gstreamer"].options.shared or \
+           self.options.shared != self.dependencies.direct_host["glib"].options.shared or \
+           self.options.shared != self.dependencies.direct_host["gst-plugins-base"].options.shared:
+            # https://gitlab.freedesktop.org/gstreamer/gst-build/-/issues/133
+            raise ConanInvalidConfiguration("GLib, GStreamer and GstPlugins must be either all shared, or all static")
+        if Version(self.version) >= "1.18.2" and \
+           self.settings.compiler == "gcc" and \
+           Version(self.settings.compiler.version) < "5":
+            raise ConanInvalidConfiguration(f"{self.ref} does not support gcc older than 5")
+        if self.options.shared and is_msvc_static_runtime(self):
+            raise ConanInvalidConfiguration("shared build with static runtime is not supported due to the FlsAlloc limit")
 
     def build_requirements(self):
-        self.build_requires("meson/0.54.2")
-        if not tools.which("pkg-config"):
-            self.build_requires("pkgconf/1.7.4")
-        if self.settings.os == 'Windows':
-            self.build_requires("winflexbison/2.5.24")
+        self.tool_requires("meson/[>=1.2.3 <2]")
+        if not self._is_legacy_one_profile:
+            self.tool_requires("glib/<host_version>")
+        if not self.conf.get("tools.gnu:pkg_config", check_type=str):
+            self.tool_requires("pkgconf/[>=2.2 <3]")
+        if self._settings_build.os == "Windows":
+            self.tool_requires("winflexbison/2.5.25")
         else:
-            self.build_requires("bison/3.7.6")
-            self.build_requires("flex/2.6.4")
+            self.tool_requires("bison/3.8.2")
+            self.tool_requires("flex/2.6.4")
         if self.options.with_introspection:
-            self.build_requires("gobject-introspection/1.68.0")
+            self.tool_requires("gobject-introspection/1.78.1")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
-    def _configure_meson(self):
-        defs = dict()
-
-        def add_flag(name, value):
-            if name in defs:
-                defs[name] += " " + value
-            else:
-                defs[name] = value
-
-        def add_compiler_flag(value):
-            add_flag("c_args", value)
-            add_flag("cpp_args", value)
-
-        def add_linker_flag(value):
-            add_flag("c_link_args", value)
-            add_flag("cpp_link_args", value)
-
-        meson = Meson(self)
-        if self.settings.compiler == "Visual Studio":
-            add_linker_flag("-lws2_32")
-            add_compiler_flag("-%s" % self.settings.compiler.runtime)
-            if int(str(self.settings.compiler.version)) < 14:
-                add_compiler_flag("-Dsnprintf=_snprintf")
-        if self.settings.get_safe("compiler.runtime"):
-            defs["b_vscrt"] = str(self.settings.compiler.runtime).lower()
-        defs["tools"] = "disabled"
-        defs["examples"] = "disabled"
-        defs["benchmarks"] = "disabled"
-        defs["tests"] = "disabled"
-        defs["wrap_mode"] = "nofallback"
-        defs["introspection"] = "enabled" if self.options.with_introspection else "disabled"
-        meson.configure(build_folder=self._build_subfolder,
-                        source_folder=self._source_subfolder,
-                        defs=defs)
-        return meson
+    def generate(self):
+        virtual_build_env = VirtualBuildEnv(self)
+        virtual_build_env.generate()
+        if self._is_legacy_one_profile:
+            VirtualRunEnv(self).generate(scope="build")
+        pkg_config_deps = PkgConfigDeps(self)
+        pkg_config_deps.generate()
+        tc = MesonToolchain(self)
+        if is_msvc(self) and not check_min_vs(self, "190", raise_invalid=False):
+            tc.c_args.append("-Dsnprintf=_snprintf")
+            tc.project_options["c_std"] = "c99"
+        if is_msvc(self):
+            tc.c_link_args.append("-lws2_32")
+            tc.cpp_link_args.append("-lws2_32")
+        tc.project_options["examples"] = "disabled"
+        tc.project_options["tests"] = "disabled"
+        tc.project_options["doc"] = "disabled"
+        tc.project_options["wrap_mode"] = "nofallback"
+        tc.generate()
 
     def build(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
-
-        with tools.environment_append(VisualStudioBuildEnvironment(self).vars) if self._is_msvc else tools.no_op():
-            meson = self._configure_meson()
-            meson.build()
+        apply_conandata_patches(self)
+        meson = Meson(self)
+        meson.configure()
+        meson.build()
 
     def _fix_library_names(self, path):
         # regression in 1.16
-        if self.settings.compiler == "Visual Studio":
-            with tools.chdir(path):
+        if is_msvc(self):
+            with chdir(self, path):
                 for filename_old in glob.glob("*.a"):
                     filename_new = filename_old[3:-2] + ".lib"
-                    self.output.info("rename %s into %s" % (filename_old, filename_new))
-                    shutil.move(filename_old, filename_new)
+                    self.output.info(f"rename {filename_old} into {filename_new}")
+                    rename(self, filename_old, filename_new)
 
     def package(self):
-        self.copy(pattern="COPYING", dst="licenses", src=self._source_subfolder)
-        with tools.environment_append(VisualStudioBuildEnvironment(self).vars) if self._is_msvc else tools.no_op():
-            meson = self._configure_meson()
-            meson.install()
+        copy(self, "COPYING", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        meson = Meson(self)
+        meson.install()
 
         self._fix_library_names(os.path.join(self.package_folder, "lib"))
         self._fix_library_names(os.path.join(self.package_folder, "lib", "gstreamer-1.0"))
-        tools.rmdir(os.path.join(self.package_folder, "share"))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "gstreamer-1.0", "pkgconfig"))
-        tools.remove_files_by_mask(self.package_folder, "*.pdb")
+        rmdir(self, os.path.join(self.package_folder, "share"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "gstreamer-1.0", "pkgconfig"))
+        rm(self, "*.pdb", self.package_folder, recursive=True)
+        fix_apple_shared_install_name(self)
+
+    @staticmethod
+    def _installed_plugin_libs(gst_plugin_path, plugins):
+        # The set of plugins actually built varies across gstreamer versions, so only
+        # expose the ones whose static library was installed to avoid CMakeDeps errors.
+        libs = []
+        for plugin in plugins:
+            lib = f"gst{plugin}"
+            candidates = [f"lib{lib}.a", f"{lib}.lib", f"lib{lib}.so", f"lib{lib}.dylib", f"{lib}.dll"]
+            if any(os.path.exists(os.path.join(gst_plugin_path, candidate)) for candidate in candidates):
+                libs.append(lib)
+        return libs
 
     def package_info(self):
-
-        plugins = ["alpha", "alphacolor",
-                   "apetag",
-                   "audiofx",
-                   "audioparsers",
-                   "auparse",
-                   "autodetect",
-                   "avi",
-                   "cutter",
-                   "debug",
-                   "deinterlace",
-                   "dtmf",
-                   "effectv",
-                   "equalizer",
-                   "flv",
-                   "flxdec",
-                   "goom",
-                   "goom2k1",
-                   "icydemux",
-                   "id3demux",
-                   "imagefreeze",
-                   "interleave",
-                   "isomp4",
-                   "alaw", "mulaw",
-                   "level",
-                   "matroska",
-                   "monoscope",
-                   "multifile",
-                   "multipart",
-                   "replaygain",
-                   "rtp",
-                   "rtpmanager",
-                   "rtsp",
-                   "shapewipe",
-                   "smpte",
-                   "spectrum",
-                   "udp",
-                   "videobox",
-                   "videocrop",
-                   "videofilter",
-                   "videomixer",
-                   "wavenc",
-                   "wavparse",
-                   "y4menc"]
+        plugins = [
+            "alpha", "alphacolor", "apetag", "audiofx", "audioparsers", "auparse",
+            "autodetect", "avi", "cutter", "debug", "deinterlace", "dtmf", "effectv",
+            "equalizer", "flv", "flxdec", "goom", "goom2k1", "icydemux", "id3demux",
+            "imagefreeze", "interleave", "isomp4", "alaw", "mulaw", "level", "matroska",
+            "monoscope", "multifile", "multipart", "replaygain", "rtp", "rtpmanager",
+            "rtsp", "shapewipe", "smpte", "spectrum", "udp", "videobox", "videocrop",
+            "videofilter", "videomixer", "wavenc", "wavparse", "y4menc",
+        ]
 
         gst_plugin_path = os.path.join(self.package_folder, "lib", "gstreamer-1.0")
         if self.options.shared:
-            self.output.info("Appending GST_PLUGIN_PATH env var : %s" % gst_plugin_path)
-            self.cpp_info.bindirs.append(gst_plugin_path)
-            self.runenv_info.prepend_path("GST_PLUGIN_PATH", gst_plugin_path)
+            self.runenv_info.append_path("GST_PLUGIN_PATH", gst_plugin_path)
+            # TODO: remove the following when only Conan 2.0 is supported
             self.env_info.GST_PLUGIN_PATH.append(gst_plugin_path)
+            self.cpp_info.bindirs.append(gst_plugin_path)
         else:
             self.cpp_info.defines.append("GST_PLUGINS_GOOD_STATIC")
             self.cpp_info.libdirs.append(gst_plugin_path)
-            self.cpp_info.libs.extend(["gst%s" % plugin for plugin in plugins])
+            self.cpp_info.libs.extend(self._installed_plugin_libs(gst_plugin_path, plugins))
 
-        self.cpp_info.includedirs = ["include", os.path.join("include", "gstreamer-1.0")]
+        self.cpp_info.includedirs = [
+            includedir for includedir in ["include", os.path.join("include", "gstreamer-1.0")]
+            if os.path.isdir(os.path.join(self.package_folder, includedir))
+        ]

--- a/recipes/gst-plugins-good/all/test_package/CMakeLists.txt
+++ b/recipes/gst-plugins-good/all/test_package/CMakeLists.txt
@@ -1,11 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
-project(test_package)
-
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
+project(test_package LANGUAGES CXX)
 
 find_package(gst-plugins-good CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} gst-plugins-good::gst-plugins-good)
+target_link_libraries(${PROJECT_NAME} PRIVATE gst-plugins-good::gst-plugins-good)

--- a/recipes/gst-plugins-good/all/test_package/conanfile.py
+++ b/recipes/gst-plugins-good/all/test_package/conanfile.py
@@ -1,10 +1,30 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.env import Environment
 import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "PkgConfigDeps", "VirtualBuildEnv", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build_requirements(self):
+        if not self.conf.get("tools.gnu:pkg_config", check_type=str):
+            self.tool_requires("pkgconf/[>=2.2 <3]")
+
+    def generate(self):
+        # Print debug information from gstreamer at runtime
+        env = Environment()
+        env.define("GST_DEBUG", "7")
+        env.vars(self, scope="run").save_script("conanrun_gstdebug")
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +32,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/gst-plugins-good/config.yml
+++ b/recipes/gst-plugins-good/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.19.1":
+  "1.29.2":
     folder: all

--- a/recipes/gst-plugins-ugly/all/conandata.yml
+++ b/recipes/gst-plugins-ugly/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "1.19.1":
-    url: "https://gitlab.freedesktop.org/gstreamer/gst-plugins-ugly/-/archive/1.19.1/gst-plugins-ugly-1.19.1.tar.bz2"
-    sha256 : "b9ae94a04eaf9d93bc36500b3d7eda864f82142d2ce950c1e92a4288924227e6"
+  "1.29.2":
+    url: "https://gstreamer.freedesktop.org/src/gst-plugins-ugly/gst-plugins-ugly-1.29.2.tar.xz"
+    sha256: "64019b97890e0d888b0ed09548e1b6c8e789911d13c7c0a5211ca3e4a8cb621e"

--- a/recipes/gst-plugins-ugly/all/conanfile.py
+++ b/recipes/gst-plugins-ugly/all/conanfile.py
@@ -1,9 +1,18 @@
-from conans import ConanFile, tools, Meson, VisualStudioBuildEnvironment
-from conans.errors import ConanInvalidConfiguration
-from conan.tools.microsoft import msvc_runtime_flag
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import fix_apple_shared_install_name
+from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
+from conan.tools.files import chdir, copy, get, rename, rm, rmdir, apply_conandata_patches, export_conandata_patches
+from conan.tools.gnu import PkgConfigDeps
+from conan.tools.layout import basic_layout
+from conan.tools.meson import Meson, MesonToolchain
+from conan.tools.microsoft import is_msvc, is_msvc_static_runtime, check_min_vs
+from conan.tools.scm import Version
+
 import glob
 import os
-import shutil
+
+required_conan_version = ">=1.60.0 <2 || >=2.0.5"
 
 
 class GStPluginsUglyConan(ConanFile):
@@ -14,158 +23,154 @@ class GStPluginsUglyConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://gstreamer.freedesktop.org/"
     license = "GPL-2.0-only"
+    package_type = "library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
         "with_introspection": [True, False],
-        }
+    }
     default_options = {
         "shared": False,
         "fPIC": True,
         "with_introspection": False,
-        }
-    _source_subfolder = "source_subfolder"
-    _build_subfolder = "build_subfolder"
-    exports_sources = ["patches/*.patch"]
-
-    generators = "pkg_config"
+    }
 
     @property
-    def _is_msvc(self):
-        return self.settings.compiler == "Visual Studio"
+    def _settings_build(self):
+        return getattr(self, "settings_build", self.settings)
 
-    def validate(self):
-        if self.options.shared != self.options["gstreamer"].shared or \
-            self.options.shared != self.options["glib"].shared or \
-            self.options.shared != self.options["gst-plugins-base"].shared:
-                # https://gitlab.freedesktop.org/gstreamer/gst-build/-/issues/133
-                raise ConanInvalidConfiguration("GLib, GStreamer and GstPlugins must be either all shared, or all static")
-        if tools.Version(self.version) >= "1.18.2" and\
-           self.settings.compiler == "gcc" and\
-           tools.Version(self.settings.compiler.version) < "5":
-            raise ConanInvalidConfiguration(
-                "gst-plugins-ugly%s does not support gcc older than 5" % self.version
-            )
-        if self.options.shared and str(msvc_runtime_flag(self)).startswith("MT"):
-            raise ConanInvalidConfiguration('shared build with static runtime is not supported due to the FlsAlloc limit')
+    @property
+    def _is_legacy_one_profile(self):
+        return not hasattr(self, "settings_build")
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
 
     def configure(self):
         if self.options.shared:
-            del self.options.fPIC
-        del self.settings.compiler.libcxx
-        del self.settings.compiler.cppstd
-        self.options['gstreamer'].shared = self.options.shared
-        self.options['gst-plugins-base'].shared = self.options.shared
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.libcxx")
+        self.settings.rm_safe("compiler.cppstd")
+        self.options["gstreamer"].shared = self.options.shared
+        self.options["gst-plugins-base"].shared = self.options.shared
 
-    def config_options(self):
-        if self.settings.os == 'Windows':
-            del self.options.fPIC
+    def layout(self):
+        basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("glib/2.70.1")
-        self.requires("gstreamer/1.19.1")
-        self.requires("gst-plugins-base/1.19.1")
+        self.requires("glib/2.78.3", transitive_headers=True, transitive_libs=True)
+        self.requires("gstreamer/1.29.2", transitive_headers=True, transitive_libs=True)
+        self.requires("gst-plugins-base/1.29.2", transitive_headers=True, transitive_libs=True)
+
+    def validate(self):
+        if self.options.shared != self.dependencies.direct_host["gstreamer"].options.shared or \
+           self.options.shared != self.dependencies.direct_host["glib"].options.shared or \
+           self.options.shared != self.dependencies.direct_host["gst-plugins-base"].options.shared:
+            # https://gitlab.freedesktop.org/gstreamer/gst-build/-/issues/133
+            raise ConanInvalidConfiguration("GLib, GStreamer and GstPlugins must be either all shared, or all static")
+        if Version(self.version) >= "1.18.2" and \
+           self.settings.compiler == "gcc" and \
+           Version(self.settings.compiler.version) < "5":
+            raise ConanInvalidConfiguration(f"{self.ref} does not support gcc older than 5")
+        if self.options.shared and is_msvc_static_runtime(self):
+            raise ConanInvalidConfiguration("shared build with static runtime is not supported due to the FlsAlloc limit")
 
     def build_requirements(self):
-        self.build_requires("meson/0.54.2")
-        if not tools.which("pkg-config"):
-            self.build_requires("pkgconf/1.7.4")
-        if self.settings.os == 'Windows':
-            self.build_requires("winflexbison/2.5.24")
+        self.tool_requires("meson/[>=1.2.3 <2]")
+        if not self._is_legacy_one_profile:
+            self.tool_requires("glib/<host_version>")
+        if not self.conf.get("tools.gnu:pkg_config", check_type=str):
+            self.tool_requires("pkgconf/[>=2.2 <3]")
+        if self._settings_build.os == "Windows":
+            self.tool_requires("winflexbison/2.5.25")
         else:
-            self.build_requires("bison/3.7.6")
-            self.build_requires("flex/2.6.4")
+            self.tool_requires("bison/3.8.2")
+            self.tool_requires("flex/2.6.4")
         if self.options.with_introspection:
-            self.build_requires("gobject-introspection/1.68.0")
+            self.tool_requires("gobject-introspection/1.78.1")
 
     def source(self):
-        tools.get(**self.conan_data["sources"][self.version],
-                  destination=self._source_subfolder, strip_root=True)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
-    def _configure_meson(self):
-        defs = dict()
-
-        def add_flag(name, value):
-            if name in defs:
-                defs[name] += " " + value
-            else:
-                defs[name] = value
-
-        def add_compiler_flag(value):
-            add_flag("c_args", value)
-            add_flag("cpp_args", value)
-
-        def add_linker_flag(value):
-            add_flag("c_link_args", value)
-            add_flag("cpp_link_args", value)
-
-        meson = Meson(self)
-        if self.settings.compiler == "Visual Studio":
-            add_linker_flag("-lws2_32")
-            add_compiler_flag("-%s" % self.settings.compiler.runtime)
-            if int(str(self.settings.compiler.version)) < 14:
-                add_compiler_flag("-Dsnprintf=_snprintf")
-        if self.settings.get_safe("compiler.runtime"):
-            defs["b_vscrt"] = str(self.settings.compiler.runtime).lower()
-        defs["tools"] = "disabled"
-        defs["examples"] = "disabled"
-        defs["benchmarks"] = "disabled"
-        defs["tests"] = "disabled"
-        defs["wrap_mode"] = "nofallback"
-        defs["introspection"] = "enabled" if self.options.with_introspection else "disabled"
-        meson.configure(build_folder=self._build_subfolder,
-                        source_folder=self._source_subfolder,
-                        defs=defs)
-        return meson
+    def generate(self):
+        virtual_build_env = VirtualBuildEnv(self)
+        virtual_build_env.generate()
+        if self._is_legacy_one_profile:
+            VirtualRunEnv(self).generate(scope="build")
+        pkg_config_deps = PkgConfigDeps(self)
+        pkg_config_deps.generate()
+        tc = MesonToolchain(self)
+        if is_msvc(self) and not check_min_vs(self, "190", raise_invalid=False):
+            tc.c_args.append("-Dsnprintf=_snprintf")
+            tc.project_options["c_std"] = "c99"
+        if is_msvc(self):
+            tc.c_link_args.append("-lws2_32")
+            tc.cpp_link_args.append("-lws2_32")
+        tc.project_options["tests"] = "disabled"
+        tc.project_options["doc"] = "disabled"
+        tc.project_options["wrap_mode"] = "nofallback"
+        tc.generate()
 
     def build(self):
-        for patch in self.conan_data.get("patches", {}).get(self.version, []):
-            tools.patch(**patch)
-
-        with tools.environment_append(VisualStudioBuildEnvironment(self).vars) if self._is_msvc else tools.no_op():
-            meson = self._configure_meson()
-            meson.build()
+        apply_conandata_patches(self)
+        meson = Meson(self)
+        meson.configure()
+        meson.build()
 
     def _fix_library_names(self, path):
         # regression in 1.16
-        if self.settings.compiler == "Visual Studio":
-            with tools.chdir(path):
+        if is_msvc(self):
+            with chdir(self, path):
                 for filename_old in glob.glob("*.a"):
                     filename_new = filename_old[3:-2] + ".lib"
-                    self.output.info("rename %s into %s" % (filename_old, filename_new))
-                    shutil.move(filename_old, filename_new)
+                    self.output.info(f"rename {filename_old} into {filename_new}")
+                    rename(self, filename_old, filename_new)
 
     def package(self):
-        self.copy(pattern="COPYING", dst="licenses", src=self._source_subfolder)
-        with tools.environment_append(VisualStudioBuildEnvironment(self).vars) if self._is_msvc else tools.no_op():
-            meson = self._configure_meson()
-            meson.install()
+        copy(self, "COPYING", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        meson = Meson(self)
+        meson.install()
 
         self._fix_library_names(os.path.join(self.package_folder, "lib"))
         self._fix_library_names(os.path.join(self.package_folder, "lib", "gstreamer-1.0"))
-        tools.rmdir(os.path.join(self.package_folder, "share"))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
-        tools.rmdir(os.path.join(self.package_folder, "lib", "gstreamer-1.0", "pkgconfig"))
-        tools.remove_files_by_mask(self.package_folder, "*.pdb")
+        rmdir(self, os.path.join(self.package_folder, "share"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "gstreamer-1.0", "pkgconfig"))
+        rm(self, "*.pdb", self.package_folder, recursive=True)
+        fix_apple_shared_install_name(self)
+
+    @staticmethod
+    def _installed_plugin_libs(gst_plugin_path, plugins):
+        # The set of plugins actually built varies across gstreamer versions, so only
+        # expose the ones whose static library was installed to avoid CMakeDeps errors.
+        libs = []
+        for plugin in plugins:
+            lib = f"gst{plugin}"
+            candidates = [f"lib{lib}.a", f"{lib}.lib", f"lib{lib}.so", f"lib{lib}.dylib", f"{lib}.dll"]
+            if any(os.path.exists(os.path.join(gst_plugin_path, candidate)) for candidate in candidates):
+                libs.append(lib)
+        return libs
 
     def package_info(self):
-
-        plugins = ["asf",
-                   "dvdlpcmdec",
-                   "dvdsub",
-                   "realmedia",
-                   "xingmux"]
+        plugins = ["asf", "dvdlpcmdec", "dvdsub", "realmedia", "xingmux"]
 
         gst_plugin_path = os.path.join(self.package_folder, "lib", "gstreamer-1.0")
         if self.options.shared:
-            self.output.info("Appending GST_PLUGIN_PATH env var : %s" % gst_plugin_path)
-            self.cpp_info.bindirs.append(gst_plugin_path)
-            self.runenv_info.prepend_path("GST_PLUGIN_PATH", gst_plugin_path)
+            self.runenv_info.append_path("GST_PLUGIN_PATH", gst_plugin_path)
+            # TODO: remove the following when only Conan 2.0 is supported
             self.env_info.GST_PLUGIN_PATH.append(gst_plugin_path)
+            self.cpp_info.bindirs.append(gst_plugin_path)
         else:
             self.cpp_info.defines.append("GST_PLUGINS_UGLY_STATIC")
             self.cpp_info.libdirs.append(gst_plugin_path)
-            self.cpp_info.libs.extend(["gst%s" % plugin for plugin in plugins])
+            self.cpp_info.libs.extend(self._installed_plugin_libs(gst_plugin_path, plugins))
 
-        self.cpp_info.includedirs = ["include", os.path.join("include", "gstreamer-1.0")]
+        self.cpp_info.includedirs = [
+            includedir for includedir in ["include", os.path.join("include", "gstreamer-1.0")]
+            if os.path.isdir(os.path.join(self.package_folder, includedir))
+        ]

--- a/recipes/gst-plugins-ugly/all/test_package/CMakeLists.txt
+++ b/recipes/gst-plugins-ugly/all/test_package/CMakeLists.txt
@@ -1,11 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
-project(test_package)
-
-
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
+project(test_package LANGUAGES CXX)
 
 find_package(gst-plugins-ugly CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} gst-plugins-ugly::gst-plugins-ugly)
+target_link_libraries(${PROJECT_NAME} PRIVATE gst-plugins-ugly::gst-plugins-ugly)

--- a/recipes/gst-plugins-ugly/all/test_package/conanfile.py
+++ b/recipes/gst-plugins-ugly/all/test_package/conanfile.py
@@ -1,10 +1,30 @@
-from conans import ConanFile, CMake, tools
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.env import Environment
 import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake", "cmake_find_package_multi"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "PkgConfigDeps", "VirtualBuildEnv", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build_requirements(self):
+        if not self.conf.get("tools.gnu:pkg_config", check_type=str):
+            self.tool_requires("pkgconf/[>=2.2 <3]")
+
+    def generate(self):
+        # Print debug information from gstreamer at runtime
+        env = Environment()
+        env.define("GST_DEBUG", "7")
+        env.vars(self, scope="run").save_script("conanrun_gstdebug")
 
     def build(self):
         cmake = CMake(self)
@@ -12,6 +32,6 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        if not tools.cross_building(self):
-            bin_path = os.path.join("bin", "test_package")
-            self.run(bin_path, run_environment=True)
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/gst-plugins-ugly/config.yml
+++ b/recipes/gst-plugins-ugly/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.19.1":
+  "1.29.2":
     folder: all

--- a/recipes/gstreamer/all/conandata.yml
+++ b/recipes/gstreamer/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.29.2":
+    url: "https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-1.29.2.tar.xz"
+    sha256: "e4e1dccc92cb4be7c34dc513216f0ffc3610fe071d87e28ceecf784b43d6ccf3"
   "1.28.1":
     url: "https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-1.28.1.tar.xz"
     sha256: "b65e2ffa35bdbf8798cb75c23ffc3d05e484e48346ff7546844ba85217664504"

--- a/recipes/gstreamer/config.yml
+++ b/recipes/gstreamer/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.29.2":
+    folder: all
   "1.28.1":
     folder: all
   "1.24.7":


### PR DESCRIPTION
### Summary
Changes to recipes: **gst-plugins-base / gst-plugins-good / gst-plugins-bad / gst-plugins-ugly / gst-libav / gstreamer — [1.29.2]**

#### Motivation
These five recipes were never migrated to Conan 2. They still imported `from conans import ConanFile, tools, Meson, VisualStudioBuildEnvironment`, which Conan 2.x cannot load, so on ConanCenter every version shows "It has not been possible to load this information. Please, check if this recipe version is compatible with Conan v2.x" instead of the package metadata (affected: gst-libav/1.19.1, gst-plugins-bad/1.19.1, gst-plugins-base/1.19.2, gst-plugins-good/1.19.1, gst-plugins-ugly/1.19.1).

On top of the API problem, the pinned dependencies (glib 2.70, zlib 1.2.12, ffmpeg 4.4, etc.) no longer exist in the index, and the plugins' `glib` requirement had drifted away from the version the `gstreamer` recipe now uses, which would cause a version conflict. The whole stack needed to move together, so the recipes are also bumped to 1.29.2.

#### Details
- Port all five recipes to Conan 2: `from conan import ConanFile` +  `conan.tools.*`, replacing `VisualStudioBuildEnvironment` and the manual
  MSVC environment with `VirtualBuildEnv` + `MesonToolchain` +  `PkgConfigDeps`.
- Add `layout()` (`basic_layout`), `generate()`, `package_type` and  `required_conan_version = ">=1.60.0 <2 || >=2.0.5"`; move  source/build/package over to `conan.tools.files`.
- `validate()` now reads `self.dependencies.direct_host[...]` instead of  `self.options[...]` for the shared/static consistency checks.
- Bump dependencies to versions available in the index and align `glib`  with `gstreamer` (`glib/2.78.3`) to avoid a conflict; `gst-libav` moves  to `ffmpeg/7.1.4`.
- Add `gstreamer/1.29.2` to the core recipe (`config.yml` +  `conandata.yml`) so the plugins can resolve it.
- Drop the meson options removed upstream since 1.19 (`tools`,  `benchmarks`, and `introspection` on the plugin modules).
- Register only the plugins/include dirs that were actually installed, so  CMakeDeps doesn't error when the built set differs across versions.
- Migrate all `test_package` folders to the Conan 2 layout  (`CMakeToolchain`/`CMakeDeps`/`PkgConfigDeps`, `cmake_layout`, `tested_reference_str`).

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan