### PR TITLE
cryptopp-modern: Initial version of cryptopp-modern recipe

### DIFF
--- a/recipes/cryptopp-modern/all/conandata.yml
+++ b/recipes/cryptopp-modern/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2026.6.0":
+    url: "https://github.com/cryptopp-modern/cryptopp-modern/archive/refs/tags/2026.6.0.tar.gz"
+    sha256: "b55a2868de1389e95a21fb9991862f5fac5c892b85f3384c6708d228a4fe76ae"

--- a/recipes/cryptopp-modern/all/conanfile.py
+++ b/recipes/cryptopp-modern/all/conanfile.py
@@ -1,0 +1,95 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, replace_in_file, rmdir
+
+import os
+
+required_conan_version = ">=2"
+
+
+class CryptoPPModernConan(ConanFile):
+    name = "cryptopp-modern"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/cryptopp-modern/cryptopp-modern"
+    license = "BSL-1.0"
+    description = "An actively maintained fork of Crypto++ that modernizes the build system and codebase."
+    topics = ("crypto", "cryptographic", "security")
+
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "use_openmp": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "use_openmp": False,
+    }
+
+    implements = ["auto_shared_fpic"]
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        if self.options.use_openmp:
+            # cryptopp links OpenMP into the (static) library, so the runtime must
+            # be propagated to consumers. Depend on the OpenMP runtime explicitly
+            # instead of relying on a system/Homebrew libomp being present.
+            self.requires("llvm-openmp/20.1.6")
+
+    def validate(self):
+        # Crypto++ does not properly support shared/DLL builds; the bundled CMake
+        # errors out when CRYPTOPP_BUILD_SHARED is enabled.
+        if self.options.shared:
+            raise ConanInvalidConfiguration(f"{self.ref} does not support shared builds")
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.20]")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        # Honor the fPIC option instead of the unconditional PIC the project forces.
+        replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
+                        "set(CMAKE_POSITION_INDEPENDENT_CODE 1)", "")
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.cache_variables["CRYPTOPP_BUILD_TESTING"] = False
+        tc.cache_variables["CRYPTOPP_USE_INTERMEDIATE_OBJECTS_TARGET"] = False
+        tc.cache_variables["CRYPTOPP_USE_OPENMP"] = self.options.use_openmp
+        tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_Git"] = True
+        if self.options.use_openmp:
+            # Make the project's find_package(OpenMP) resolve to the llvm-openmp
+            # Conan package (config mode) rather than a system libomp.
+            tc.cache_variables["CMAKE_FIND_PACKAGE_PREFER_CONFIG"] = True
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "share"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "cryptopp-modern")
+        self.cpp_info.set_property("cmake_target_name", "cryptopp::cryptopp")
+        self.cpp_info.set_property("pkg_config_name", "cryptopp-modern")
+
+        self.cpp_info.libs = ["cryptopp"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs = ["pthread", "m"]
+        elif self.settings.os == "Windows":
+            self.cpp_info.system_libs = ["bcrypt", "ws2_32"]
+        # When use_openmp is enabled the OpenMP runtime is pulled in (and
+        # propagated to consumers) via the llvm-openmp dependency.

--- a/recipes/cryptopp-modern/all/test_package/CMakeLists.txt
+++ b/recipes/cryptopp-modern/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(cryptopp-modern REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE cryptopp::cryptopp)

--- a/recipes/cryptopp-modern/all/test_package/conanfile.py
+++ b/recipes/cryptopp-modern/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/cryptopp-modern/all/test_package/test_package.cpp
+++ b/recipes/cryptopp-modern/all/test_package/test_package.cpp
@@ -1,0 +1,8 @@
+#include <cryptopp/cryptlib.h>
+#include <iostream>
+
+int main() {
+  std::cout << "CryptoPP LibraryVersion() = " << CryptoPP::LibraryVersion() << std::endl;
+  std::cout << "CryptoPP HeaderVersion() = " << CryptoPP::HeaderVersion() << std::endl;
+  return 0;
+}

--- a/recipes/cryptopp-modern/config.yml
+++ b/recipes/cryptopp-modern/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2026.6.0":
+    folder: "all"


### PR DESCRIPTION
### Summary
Initial version of cryptopp-modern recipe (based on the existing cryptopp recipe).

#### Motivation
The original cryptopp had been abandoned and is no longer maintained. Cryptopp-modern is actively maintained fork of Crypto++ with modern algorithms, better organisation, and regular security updates.
Upstream project: https://cryptopp-modern.com

#### Details
Based on the existing cryptopp recipe - removed historical cruft and patches, trimmed down.
It is a drop-in replacement for cryptopp, therefore it's made available as `cryptopp::cryptopp` in cmake.

---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
