### PR TITLE
premake: add version 5.0.0-beta8

### DIFF
--- a/recipes/premake/5.x/conandata.yml
+++ b/recipes/premake/5.x/conandata.yml
@@ -1,4 +1,16 @@
 sources:
-  "5.0.0-beta7":
-    url: "https://github.com/premake/premake-core/releases/download/v5.0.0-beta7/premake-5.0.0-beta7-src.zip"
-    sha256: "d39874aed04e317a46bdd281b193fe58c70457cd07bbd50e1bdcb4729c3a4860"
+  "5.0.0-beta8":
+    url: "https://github.com/premake/premake-core/archive/refs/tags/v5.0.0-beta8.tar.gz"
+    sha256: "2a55195fd2b27e5aa3de8ff6d22cdb127232a86f801d06e7f673d30a0eba09ac"
+
+bootstrap:
+  "5.0.0-beta8":
+    Linux:
+      url: "https://github.com/premake/premake-core/releases/download/v5.0.0-beta8/premake-5.0.0-beta8-linux.tar.gz"
+      sha256: "63edd3e7461eebdd45b500a3c7e8ad4e7a67d68f230010f9a97cbb71b4ec59c8"
+    Macos:
+      url: "https://github.com/premake/premake-core/releases/download/v5.0.0-beta8/premake-5.0.0-beta8-macosx.tar.gz"
+      sha256: "fa73a46f093fa6f17494a3d063421aa6cae3ea825a61c62dd59fc2f07a256d03"
+    Windows:
+      url: "https://github.com/premake/premake-core/releases/download/v5.0.0-beta8/premake-5.0.0-beta8-windows.zip"
+      sha256: "e64ce2ed8778e0098f63674cca61fe33941b5f0c8d9a4afd651152bdea3758ab"

--- a/recipes/premake/5.x/conandata.yml
+++ b/recipes/premake/5.x/conandata.yml
@@ -2,15 +2,3 @@ sources:
   "5.0.0-beta8":
     url: "https://github.com/premake/premake-core/archive/refs/tags/v5.0.0-beta8.tar.gz"
     sha256: "2a55195fd2b27e5aa3de8ff6d22cdb127232a86f801d06e7f673d30a0eba09ac"
-
-bootstrap:
-  "5.0.0-beta8":
-    Linux:
-      url: "https://github.com/premake/premake-core/releases/download/v5.0.0-beta8/premake-5.0.0-beta8-linux.tar.gz"
-      sha256: "63edd3e7461eebdd45b500a3c7e8ad4e7a67d68f230010f9a97cbb71b4ec59c8"
-    Macos:
-      url: "https://github.com/premake/premake-core/releases/download/v5.0.0-beta8/premake-5.0.0-beta8-macosx.tar.gz"
-      sha256: "fa73a46f093fa6f17494a3d063421aa6cae3ea825a61c62dd59fc2f07a256d03"
-    Windows:
-      url: "https://github.com/premake/premake-core/releases/download/v5.0.0-beta8/premake-5.0.0-beta8-windows.zip"
-      sha256: "e64ce2ed8778e0098f63674cca61fe33941b5f0c8d9a4afd651152bdea3758ab"

--- a/recipes/premake/5.x/conanfile.py
+++ b/recipes/premake/5.x/conanfile.py
@@ -1,13 +1,13 @@
-import glob
 import os
 
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import cross_building
-from conan.tools.files import chdir, copy, get, replace_in_file
-from conan.tools.gnu import Autotools, AutotoolsToolchain, AutotoolsDeps
+from conan.tools.files import chdir, copy, get
+from conan.tools.gnu import AutotoolsDeps, AutotoolsToolchain
 from conan.tools.layout import basic_layout
-from conan.tools.microsoft import MSBuild, MSBuildToolchain, is_msvc
+from conan.tools.microsoft import MSBuild, MSBuildToolchain, VCVars, is_msvc
+from conan.tools.scm import Version
 
 required_conan_version = ">=2.1"
 
@@ -26,16 +26,6 @@ class PremakeConan(ConanFile):
 
     package_type = "application"
     settings = "os", "arch", "compiler", "build_type"
-    options = {
-        "lto": [True, False],
-    }
-    default_options = {
-        "lto": False,
-    }
-
-    def config_options(self):
-        if self.settings.os != "Windows" or is_msvc(self):
-            self.options.rm_safe("lto")
 
     def layout(self):
         basic_layout(self, src_folder="src")
@@ -45,112 +35,89 @@ class PremakeConan(ConanFile):
 
     def requirements(self):
         if self.settings.os != "Windows":
-            self.requires("util-linux-libuuid/2.39")
+            self.requires("util-linux-libuuid/2.39.2")
 
     def validate(self):
-        if hasattr(self, "settings_build") and cross_building(self, skip_x64_x86=True):
+        if cross_building(self, skip_x64_x86=True):
             raise ConanInvalidConfiguration("Cross-building not implemented")
-        if self.settings.os == "FreeBSD":
-            raise ConanInvalidConfiguration("FreeBSD is not supported (no pre-built bootstrap binary available)")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     @property
     def _ide_version(self):
-        compiler_version = str(self.settings.compiler.version)
-        if str(self.settings.compiler) == "Visual Studio":
-            return {"18": "2026",
-                    "17": "2022",
-                    "16": "2019",
-                    "15": "2017",
-                    "14": "2015",
-                    "12": "2013"}.get(compiler_version)
-        else:
-            return {"195": "2026",
-                    "194": "2022",
-                    "193": "2022",
-                    "192": "2019",
-                    "191": "2017",
-                    "190": "2015",
-                    "180": "2013"}.get(compiler_version)
+        return {"195": "2026",
+                "194": "2022",
+                "193": "2022",
+                "192": "2019",
+                "191": "2017",
+                "190": "2015",
+                "180": "2013"}.get(str(self.settings.compiler.version))
 
     @property
-    def _msvc_build_dir(self):
-        return os.path.join(self.source_folder, "build", f"vs{self._ide_version}")
+    def _msvc_sln(self):
+        # VS2026 switched to the newer .slnx solution format
+        ext = "sln" if Version(self.settings.compiler.version) < 195 else "slnx"
+        return f"Premake5.{ext}"
 
     @property
-    def _gmake_platform(self):
+    def _bootstrap_arch(self):
         return {
-            "FreeBSD": "bsd",
-            "Windows": "windows",
-            "Linux": "unix",
-            "Macos": "macosx",
-        }[str(self.settings.os)]
+            "x86": "x86",
+            "x86_64": "x86_64",
+            "armv8": "AARCH64",
+        }.get(str(self.settings.arch), str(self.settings.arch))
 
     @property
-    def _gmake_build_dir(self):
-        return os.path.join(self.source_folder, "build", f"gmake.{self._gmake_platform}")
+    def _bootstrap_config(self):
+        return "debug" if self.settings.build_type == "Debug" else "release"
 
     @property
-    def _gmake_config(self):
-        build_type = "debug" if self.settings.build_type == "Debug" else "release"
-        if self.settings.os == "Windows":
-            arch = {
-                "x86": "x86",
-                "x86_64": "x64",
-            }[str(self.settings.arch)]
-            config = f"{build_type}_{arch}"
-        else:
-            config = build_type
-        return config
+    def _bootstrap_dir(self):
+        return os.path.join(self.source_folder, "build", "bootstrap")
 
     def generate(self):
         if is_msvc(self):
+            VCVars(self).generate()
             tc = MSBuildToolchain(self)
             tc.generate()
         else:
             tc = AutotoolsToolchain(self)
-            tc.make_args = ["verbose=1", f"config={self._gmake_config}"]
             tc.generate()
             deps = AutotoolsDeps(self)
             deps.generate()
 
     def _generate_build_files(self):
-        """Download pre-built premake and use it to generate build files."""
-        # Download pre-built premake binary for the build platform
-        bootstrap_data = self.conan_data["bootstrap"][self.version][str(self.settings.os)]
-        bootstrap_dir = os.path.join(self.source_folder, "build", "bootstrap")
-        get(self, **bootstrap_data, destination=bootstrap_dir)
-
-        premake_bin = "premake5.exe" if self.settings.os == "Windows" else "premake5"
-        bootstrap_premake = os.path.join(bootstrap_dir, premake_bin)
-
+        """Bootstrap premake using its own Bootstrap.mak/Bootstrap.bat, following
+        https://premake.github.io/docs/Building-Premake#using-the-git-code-repository
+        """
         with chdir(self, self.source_folder):
             if is_msvc(self):
-                self.run(f".\\{os.path.relpath(bootstrap_premake, self.source_folder)} embed")
-                self.run(f".\\{os.path.relpath(bootstrap_premake, self.source_folder)} --to=build/vs{self._ide_version} vs{self._ide_version}")
+                # Stops before the devenv build so we can build with Conan's own MSBuild below.
+                self.run(
+                    f"nmake -f Bootstrap.mak windows-base "
+                    f"MSDEV=vs{self._ide_version} PLATFORM={self._bootstrap_arch}"
+                )
             else:
-                os.chmod(bootstrap_premake, 0o755)
-                self.run(f"{bootstrap_premake} embed")
-                self.run(f"{bootstrap_premake} --to={self._gmake_build_dir} gmake")
-
-    def _patch_sources(self):
-        if self.options.get_safe("lto", None) is False:
-            for fn in glob.glob(os.path.join(self._gmake_build_dir, "*.make")):
-                replace_in_file(self, fn, "-flto", "", strict=False)
+                # These targets bootstrap a minimal premake, embed the Lua scripts, generate the
+                # gmake project files, and build the final premake5 binary, all in one go.
+                make, target = {
+                    "Linux": ("make", "linux"),
+                    "Macos": ("make", "osx"),
+                    "FreeBSD": ("gmake", "bsd"),
+                    "Windows": ("mingw32-make", "mingw"),
+                }[str(self.settings.os)]
+                self.run(
+                    f"{make} -f Bootstrap.mak {target} "
+                    f"PLATFORM={self._bootstrap_arch} CONFIG={self._bootstrap_config}"
+                )
 
     def build(self):
         self._generate_build_files()
-        self._patch_sources()
         if is_msvc(self):
-            with chdir(self, self._msvc_build_dir):
+            with chdir(self, self._bootstrap_dir):
                 msbuild = MSBuild(self)
-                msbuild.build(sln="Premake5.sln")
-        else:
-            with chdir(self, self._gmake_build_dir):
-                autotools = Autotools(self)
-                autotools.make(target="Premake5")
+                msbuild.build(sln=self._msvc_sln)
 
     def package(self):
         copy(self, "LICENSE.txt",

--- a/recipes/premake/5.x/conanfile.py
+++ b/recipes/premake/5.x/conanfile.py
@@ -1,6 +1,5 @@
 import glob
 import os
-import re
 
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
@@ -51,21 +50,25 @@ class PremakeConan(ConanFile):
     def validate(self):
         if hasattr(self, "settings_build") and cross_building(self, skip_x64_x86=True):
             raise ConanInvalidConfiguration("Cross-building not implemented")
+        if self.settings.os == "FreeBSD":
+            raise ConanInvalidConfiguration("FreeBSD is not supported (no pre-built bootstrap binary available)")
 
     def source(self):
-        get(self, **self.conan_data["sources"][self.version], strip_root=False)
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     @property
     def _ide_version(self):
         compiler_version = str(self.settings.compiler.version)
         if str(self.settings.compiler) == "Visual Studio":
-            return {"17": "2022",
+            return {"18": "2026",
+                    "17": "2022",
                     "16": "2019",
                     "15": "2017",
                     "14": "2015",
                     "12": "2013"}.get(compiler_version)
         else:
-            return {"194": "2022",
+            return {"195": "2026",
+                    "194": "2022",
                     "193": "2022",
                     "192": "2019",
                     "191": "2017",
@@ -75,18 +78,6 @@ class PremakeConan(ConanFile):
     @property
     def _msvc_build_dir(self):
         return os.path.join(self.source_folder, "build", f"vs{self._ide_version}")
-
-    def _version_info(self, version):
-        res = []
-        for p in re.split("[.-]|(alpha|beta)", version):
-            if p is None:
-                continue
-            try:
-                res.append(int(p))
-                continue
-            except ValueError:
-                res.append(p)
-        return tuple(res)
 
     @property
     def _gmake_platform(self):
@@ -125,12 +116,32 @@ class PremakeConan(ConanFile):
             deps = AutotoolsDeps(self)
             deps.generate()
 
+    def _generate_build_files(self):
+        """Download pre-built premake and use it to generate build files."""
+        # Download pre-built premake binary for the build platform
+        bootstrap_data = self.conan_data["bootstrap"][self.version][str(self.settings.os)]
+        bootstrap_dir = os.path.join(self.source_folder, "build", "bootstrap")
+        get(self, **bootstrap_data, destination=bootstrap_dir)
+
+        premake_bin = "premake5.exe" if self.settings.os == "Windows" else "premake5"
+        bootstrap_premake = os.path.join(bootstrap_dir, premake_bin)
+
+        with chdir(self, self.source_folder):
+            if is_msvc(self):
+                self.run(f".\\{os.path.relpath(bootstrap_premake, self.source_folder)} embed")
+                self.run(f".\\{os.path.relpath(bootstrap_premake, self.source_folder)} --to=build/vs{self._ide_version} vs{self._ide_version}")
+            else:
+                os.chmod(bootstrap_premake, 0o755)
+                self.run(f"{bootstrap_premake} embed")
+                self.run(f"{bootstrap_premake} --to={self._gmake_build_dir} gmake")
+
     def _patch_sources(self):
         if self.options.get_safe("lto", None) is False:
             for fn in glob.glob(os.path.join(self._gmake_build_dir, "*.make")):
                 replace_in_file(self, fn, "-flto", "", strict=False)
 
     def build(self):
+        self._generate_build_files()
         self._patch_sources()
         if is_msvc(self):
             with chdir(self, self._msvc_build_dir):

--- a/recipes/premake/5.x/test_package/conanfile.py
+++ b/recipes/premake/5.x/test_package/conanfile.py
@@ -1,11 +1,14 @@
 from conan import ConanFile
 from conan.tools.build import can_run
+from conan.tools.layout import basic_layout
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "VirtualBuildEnv"
-    test_type = "explicit"
+
+    def layout(self):
+        basic_layout(self)
 
     def build_requirements(self):
         self.tool_requires(self.tested_reference_str)

--- a/recipes/premake/config.yml
+++ b/recipes/premake/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "5.0.0-beta7":
+  "5.0.0-beta8":
     folder: "5.x"


### PR DESCRIPTION
### Summary
Changes to recipe:  **premake/5.0.0-beta8**

#### Motivation

This PR adds the lates premake version https://github.com/premake/premake-core/releases/tag/v5.0.0-beta8 released the later month.
This version includes plenty of changes, and some breaking changes.

With the purpose of improving Premake's integration in Conan, this PR was opened https://github.com/conan-io/conan/pull/20123, which introduces some changes which are no longer compatible with `premake/5.0.0-beta7`.

#### Details

#### Bootstrap process changes

Since 5.0.0-beta8, upstream no longer ships pre-generated build files. Premake is self-hosted, so a working Premake binary is now needed just to generate its own makefile/solution before the recipe can compile it.

The recipe now bootstraps by shelling out to upstream's own Bootstrap.mak/Bootstrap.bat (`make -f Bootstrap.mak {linux,osx,bsd,mingw}`, or `nmake -f Bootstrap.mak` windows-base + Conan's MSBuild on MSVC), instead of downloading prebuilt binaries.

#### Mainaner changes
- Removed conan v1 legacy code
- Bump `util-linux-libuuid` to `2.39.2` -> version used by whole CCI
- Added `basic_layout` in `test_package` in order to avoid bloating the folder after recipe creation
 
---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
