### PR TITLE
libyaml: CMake 4 support and cleanup

### DIFF
--- a/recipes/libyaml/all/conandata.yml
+++ b/recipes/libyaml/all/conandata.yml
@@ -2,6 +2,3 @@ sources:
   "0.2.5":
     url: "https://github.com/yaml/libyaml/archive/0.2.5.tar.gz"
     sha256: "fa240dbf262be053f3898006d502d514936c818e422afdcf33921c63bed9bf2e"
-  "0.2.2":
-    url: "https://github.com/yaml/libyaml/archive/0.2.2.tar.gz"
-    sha256: "46bca77dc8be954686cff21888d6ce10ca4016b360ae1f56962e6882a17aa1fe"

--- a/recipes/libyaml/all/conanfile.py
+++ b/recipes/libyaml/all/conanfile.py
@@ -1,11 +1,10 @@
 from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, get, rmdir, save
+from conan.tools.files import copy, get, rmdir
 from conan.tools.microsoft import is_msvc
 import os
-import textwrap
 
-required_conan_version = ">=1.54.0"
+required_conan_version = ">=2.4"
 
 
 class LibYAMLConan(ConanFile):
@@ -45,8 +44,9 @@ class LibYAMLConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["INSTALL_CMAKE_DIR"] = "lib/cmake/libyaml"
-        tc.variables["YAML_STATIC_LIB_NAME"] = "yaml"
+        tc.cache_variables["INSTALL_CMAKE_DIR"] = "lib/cmake/libyaml"
+        tc.cache_variables["YAML_STATIC_LIB_NAME"] = "yaml"
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
 
     def build(self):
@@ -55,33 +55,11 @@ class LibYAMLConan(ConanFile):
         cmake.build()
 
     def package(self):
-        # 0.2.2 has LICENSE, 0.2.5 has License, so ignore case
         copy(self, pattern="License", src=self.source_folder,
-             dst=os.path.join(self.package_folder, "licenses"), ignore_case=True)
+             dst=os.path.join(self.package_folder, "licenses"))
         cmake = CMake(self)
         cmake.install()
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
-
-        # TODO: to remove in conan v2 once cmake_find_package* generators removed
-        self._create_cmake_module_alias_targets(
-            os.path.join(self.package_folder, self._module_file_rel_path),
-            {"yaml": "yaml::yaml"}
-        )
-
-    def _create_cmake_module_alias_targets(self, module_file, targets):
-        content = ""
-        for alias, aliased in targets.items():
-            content += textwrap.dedent(f"""\
-                if(TARGET {aliased} AND NOT TARGET {alias})
-                    add_library({alias} INTERFACE IMPORTED)
-                    set_property(TARGET {alias} PROPERTY INTERFACE_LINK_LIBRARIES {aliased})
-                endif()
-            """)
-        save(self, module_file, content)
-
-    @property
-    def _module_file_rel_path(self):
-        return os.path.join("lib", "cmake", f"conan-official-{self.name}-targets.cmake")
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "yaml")
@@ -92,9 +70,3 @@ class LibYAMLConan(ConanFile):
                 "YAML_DECLARE_EXPORT" if self.options.shared
                 else "YAML_DECLARE_STATIC"
             ]
-
-        # TODO: to remove in conan v2 once cmake_find_package* generators removed
-        self.cpp_info.names["cmake_find_package"] = "yaml"
-        self.cpp_info.names["cmake_find_package_multi"] = "yaml"
-        self.cpp_info.build_modules["cmake_find_package"] = [self._module_file_rel_path]
-        self.cpp_info.build_modules["cmake_find_package_multi"] = [self._module_file_rel_path]

--- a/recipes/libyaml/config.yml
+++ b/recipes/libyaml/config.yml
@@ -1,5 +1,3 @@
 versions:
   "0.2.5":
     folder: all
-  "0.2.2":
-    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **libyaml**

#### Motivation

Reported in https://github.com/conan-io/conan-center-index/issues/26878#issuecomment-4873905173

#### Details

Give recipe CMake 4 support by setting `CMAKE_POLICY_VERSION_MINIMUM` to `3.5`.
Other maintainer changes:
- Removed conan v1 legacy `module_alias_targets`
- Fix linter warnings
- Stop publishing new recipe revisions for `v0.2.2`

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
