### PR TITLE
geos: CMake 4 support and recipe cleanup

### DIFF
--- a/recipes/geos/all/conanfile.py
+++ b/recipes/geos/all/conanfile.py
@@ -1,5 +1,4 @@
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd, stdcpp_library
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir, replace_in_file
@@ -33,18 +32,6 @@ class GeosConan(ConanFile):
     def _min_cppstd(self):
         return "17" if Version(self.version) >= "3.14.0" else "14"
 
-    @property
-    def _compilers_minimum_version(self):
-        return {
-            "14": {
-                "gcc": "6",
-                "clang": "5",
-                "apple-clang": "10",
-                "Visual Studio": "15",
-                "msvc": "191",
-            },
-        }.get(self._min_cppstd, {})
-
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -57,13 +44,7 @@ class GeosConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def validate(self):
-        if self.settings.compiler.cppstd:
-            check_min_cppstd(self, self._min_cppstd)
-        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
-        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
-            raise ConanInvalidConfiguration(
-                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
-            )
+        check_min_cppstd(self, self._min_cppstd)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -71,11 +52,11 @@ class GeosConan(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.cache_variables["CMAKE_BUILD_TYPE"] = str(self.settings.build_type)
-
-        tc.variables["BUILD_TESTING"] = False
-        tc.variables["BUILD_DOCUMENTATION"] = False
-        tc.variables["BUILD_ASTYLE"] = False
-        tc.variables["BUILD_GEOSOP"] = self.options.utils
+        tc.cache_variables["BUILD_TESTING"] = False
+        tc.cache_variables["BUILD_DOCUMENTATION"] = False
+        tc.cache_variables["BUILD_ASTYLE"] = False
+        tc.cache_variables["BUILD_GEOSOP"] = self.options.utils
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
 
     def _patch_sources(self):
@@ -106,23 +87,14 @@ class GeosConan(ConanFile):
         self.cpp_info.set_property("cmake_target_name", "GEOS::geos_c")
         self.cpp_info.set_property("pkg_config_name", "geos")
 
-        self.cpp_info.filenames["cmake_find_package"] = "geos"
-        self.cpp_info.filenames["cmake_find_package_multi"] = "geos"
-        self.cpp_info.names["cmake_find_package"] = "GEOS"
-        self.cpp_info.names["cmake_find_package_multi"] = "GEOS"
-
         # GEOS::geos_cxx_flags
         self.cpp_info.components["geos_cxx_flags"].set_property("cmake_target_name", "GEOS::geos_cxx_flags")
         self.cpp_info.components["geos_cxx_flags"].defines.append("USE_UNSTABLE_GEOS_CPP_API")
-        if self.options.get_safe("inline"):
-            self.cpp_info.components["geos_cxx_flags"].defines.append("GEOS_INLINE")
         if self.settings.os == "Windows":
             self.cpp_info.components["geos_cxx_flags"].defines.append("TTMATH_NOASM")
 
         # GEOS::geos
         self.cpp_info.components["geos_cpp"].set_property("cmake_target_name", "GEOS::geos")
-        self.cpp_info.components["geos_cpp"].names["cmake_find_package"] = "geos"
-        self.cpp_info.components["geos_cpp"].names["cmake_find_package_multi"] = "geos"
         self.cpp_info.components["geos_cpp"].libs = ["geos"]
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["geos_cpp"].system_libs.append("m")
@@ -136,6 +108,3 @@ class GeosConan(ConanFile):
         self.cpp_info.components["geos_c"].set_property("cmake_target_name", "GEOS::geos_c")
         self.cpp_info.components["geos_c"].libs = ["geos_c"]
         self.cpp_info.components["geos_c"].requires = ["geos_cpp"]
-
-        if self.options.utils:
-            self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))


### PR DESCRIPTION
### Summary
Changes to recipe:  **geos**

#### Motivation

Reported in https://github.com/conan-io/conan-center-index/issues/26878#issuecomment-4873905173.
`geos/3.12.0` is the only version non compatible with CMake 4, and it is the one used by the following consumers:

```
Usages of geos
  3.13.0
    - osgearth/3.8
        version range: [>=3.12.0 <4]
  3.12.0
    - librttopo/1.1.0
    - libspatialite/5.1.0
        condition: self.options.with_geos
        default: True
    - libspatialite/5.0.1
        condition: self.options.with_geos
        default: True
    - gdal/3.13.0
        condition: self.options.with_geos
        default: True
    - gdal/3.8.3
        condition: self.options.with_geos
        default: True
```

#### Details

This PR gives CMake 4 support by setting `CMAKE_POLICY_VERSION_MINIMUM` to `3.5`.
It also removes Conan v1 code and fix linter warnings -> such as removing `inline` option access conditional branch (when that recipe option does not exist).


---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
