### PR TITLE
ffmpeg: publish versions 8.1.2, 7.1.5

### DIFF
--- a/recipes/ffmpeg/all/conandata.yml
+++ b/recipes/ffmpeg/all/conandata.yml
@@ -2,9 +2,6 @@ sources:
   "8.1.2":
     url: "https://ffmpeg.org/releases/ffmpeg-8.1.2.tar.xz"
     sha256: "464beb5e7bf0c311e68b45ae2f04e9cc2af88851abb4082231742a74d97b524c"
-  "8.1.1":
-    url: "https://ffmpeg.org/releases/ffmpeg-8.1.1.tar.xz"
-    sha256: "b6863adde98898f42602017462871b5f6333e65aec803fdd7a6308639c52edf3"
-  "7.1.4":
-    url: "https://ffmpeg.org/releases/ffmpeg-7.1.4.tar.bz2"
-    sha256: "de02003e8a7f7b08179ddf4a1fdc2599570ca02725fec9a1e465374fd4e514aa"
+  "7.1.5":
+    url: "https://ffmpeg.org/releases/ffmpeg-7.1.5.tar.xz"
+    sha256: "de668509caf9e35e3cd162473441fdb29538c6d96ed080292b3cf9e6fc5d558f"

--- a/recipes/ffmpeg/all/conandata.yml
+++ b/recipes/ffmpeg/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "8.1.2":
     url: "https://ffmpeg.org/releases/ffmpeg-8.1.2.tar.xz"
-    sha256: "sdada3"
+    sha256: "464beb5e7bf0c311e68b45ae2f04e9cc2af88851abb4082231742a74d97b524c"
   "8.1.1":
     url: "https://ffmpeg.org/releases/ffmpeg-8.1.1.tar.xz"
     sha256: "b6863adde98898f42602017462871b5f6333e65aec803fdd7a6308639c52edf3"

--- a/recipes/ffmpeg/all/conandata.yml
+++ b/recipes/ffmpeg/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "8.1.2":
+    url: "https://ffmpeg.org/releases/ffmpeg-8.1.2.tar.xz"
+    sha256: "sdada3"
   "8.1.1":
     url: "https://ffmpeg.org/releases/ffmpeg-8.1.1.tar.xz"
     sha256: "b6863adde98898f42602017462871b5f6333e65aec803fdd7a6308639c52edf3"

--- a/recipes/ffmpeg/config.yml
+++ b/recipes/ffmpeg/config.yml
@@ -1,7 +1,5 @@
 versions:
   "8.1.2":
     folder: "all"
-  "8.1.1":
-    folder: "all"
-  "7.1.4":
+  "7.1.5":
     folder: "all"

--- a/recipes/ffmpeg/config.yml
+++ b/recipes/ffmpeg/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "8.1.2":
+    folder: "all"
   "8.1.1":
     folder: "all"
   "7.1.4":


### PR DESCRIPTION
### Summary
Changes to recipe:  **ffmpeg/8.1.2**

#### Motivation

https://github.com/advisories/GHSA-qff7-4q6c-m8h6 (CVE-2026-8461)

#### Details

Minor version bump of ffmpeg

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
