### PR TITLE
manifold, thrust, xtensor: when using tbb, propagate `litbb` dependency only

### DIFF
--- a/recipes/manifold/all/conanfile.py
+++ b/recipes/manifold/all/conanfile.py
@@ -75,6 +75,9 @@ class ManifoldConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["manifold"]
+        self.cpp_info.requires = ["clipper2::clipper2"]
+        if self.options.with_parallel_acceleration:
+            self.cpp_info.requires.append('onetbb::libtbb')
 
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("m")

--- a/recipes/thrust/all/conanfile.py
+++ b/recipes/thrust/all/conanfile.py
@@ -72,3 +72,7 @@ class ThrustConan(ConanFile):
         self.cpp_info.defines = [f"THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_{dev}"]
         # Since CUB and Thrust are provided separately, their versions are not guaranteed to match
         self.cpp_info.defines += ["THRUST_IGNORE_CUB_VERSION_CHECK=1"]
+
+        self.cpp_info.requires = ["cub::cub"]
+        if self.options.device_system == "tbb":
+            self.cpp_info.requires.append("onetbb::libtbb")

--- a/recipes/xtensor/all/conanfile.py
+++ b/recipes/xtensor/all/conanfile.py
@@ -93,6 +93,11 @@ class XtensorConan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "xtensor")
         self.cpp_info.set_property("cmake_target_name", "xtensor")
         self.cpp_info.set_property("pkg_config_name", "xtensor")
+        self.cpp_info.requires = ['xtl::xtl', 'nlohmann_json::nlohmann_json']
+        if self.options.xsimd:
+            self.cpp_info.requires.append('xsimd::xsimd')
+        if self.options.tbb:
+            self.cpp_info.requires.append('onetbb::libtbb')
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
         if self.options.xsimd:


### PR DESCRIPTION
### Summary

See https://github.com/conan-io/conan-center-index/pull/28693 - the `TBB::TBB` target is what should be propagated in most cases



Leftover from https://github.com/conan-io/conan-center-index/pull/30478

cc/ @xandox

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
