### PR TITLE
Incorporate the new version of libtiff 4.7.2 into the Conan recipe

### DIFF
--- a/recipes/libtiff/all/conandata.yml
+++ b/recipes/libtiff/all/conandata.yml
@@ -1,20 +1,13 @@
 sources:
-  "4.7.1":
-    url: "https://download.osgeo.org/libtiff/tiff-4.7.1.tar.xz"
-    sha256: "b92017489bdc1db3a4c97191aa4b75366673cb746de0dce5d7a749d5954681ba"
-  "4.7.0":
-    url: "https://download.osgeo.org/libtiff/tiff-4.7.0.tar.xz"
-    sha256: "273a0a73b1f0bed640afee4a5df0337357ced5b53d3d5d1c405b936501f71017"
+  "4.7.2":
+    url: "https://download.osgeo.org/libtiff/tiff-4.7.2.tar.xz"
+    sha256: "4996f0c4f93094719b1ca5c6279b20e588773ba8a247533e486416fb662ddb88"
   "4.6.0":
     url: "https://download.osgeo.org/libtiff/tiff-4.6.0.tar.gz"
     sha256: "88b3979e6d5c7e32b50d7ec72fb15af724f6ab2cbf7e10880c360a77e4b5d99a"
 patches:
-  "4.7.1":
-    - patch_file: "patches/4.7.1-0001-cmake-dependencies.patch"
-      patch_description: "CMake: robust handling of dependencies"
-      patch_type: "conan"
-  "4.7.0":
-    - patch_file: "patches/4.5.1-0001-cmake-dependencies.patch"
+  "4.7.2":
+    - patch_file: "patches/4.7.2-0001-cmake-dependencies.patch"
       patch_description: "CMake: robust handling of dependencies"
       patch_type: "conan"
   "4.6.0":

--- a/recipes/libtiff/all/conanfile.py
+++ b/recipes/libtiff/all/conanfile.py
@@ -113,8 +113,8 @@ class LibtiffConan(ConanFile):
         cxx_option_name = "cxx" if Version(self.version) < "4.7.1" else "tiff-cxx"
         tc.variables[cxx_option_name] = self.options.cxx
         # Disable framwork option for libtiff on Apple/iOS
-        if is_apple_os(self) and Version(self.version) >= "4.7.2":
-            tc.variables["tiff-framework"] = False
+        if is_apple_os(self) and self.settings.os != "Macos" and Version(self.version) >= "4.7.2":
+            tc.cache_variables["tiff-framework"] = False
         # BUILD_SHARED_LIBS must be set in command line because defined upstream before project()
         tc.cache_variables["BUILD_SHARED_LIBS"] = bool(self.options.shared)
         tc.cache_variables["CMAKE_FIND_PACKAGE_PREFER_CONFIG"] = True

--- a/recipes/libtiff/all/conanfile.py
+++ b/recipes/libtiff/all/conanfile.py
@@ -1,5 +1,6 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import is_apple_os
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, replace_in_file, rm, rmdir
 from conan.tools.microsoft import is_msvc
@@ -111,6 +112,9 @@ class LibtiffConan(ConanFile):
         tc.variables["tiff-docs"] = False
         cxx_option_name = "cxx" if Version(self.version) < "4.7.1" else "tiff-cxx"
         tc.variables[cxx_option_name] = self.options.cxx
+        # Disable framwork option for libtiff on Apple/iOS
+        if is_apple_os(self) and Version(self.version) >= "4.7.2":
+            tc.variables["tiff-framework"] = False
         # BUILD_SHARED_LIBS must be set in command line because defined upstream before project()
         tc.cache_variables["BUILD_SHARED_LIBS"] = bool(self.options.shared)
         tc.cache_variables["CMAKE_FIND_PACKAGE_PREFER_CONFIG"] = True

--- a/recipes/libtiff/all/patches/4.7.2-0001-cmake-dependencies.patch
+++ b/recipes/libtiff/all/patches/4.7.2-0001-cmake-dependencies.patch
@@ -15,31 +15,42 @@ diff --git a/cmake/JPEGCodec.cmake b/cmake/JPEGCodec.cmake
 index 8455a3ec..09fe975a 100644
 --- a/cmake/JPEGCodec.cmake
 +++ b/cmake/JPEGCodec.cmake
-@@ -42,25 +42,6 @@ endif()
+@@ -94,34 +94,4 @@ endif()
  if (JPEG_SUPPORT)
      # Check for jpeg12_read_scanlines() which has been added in libjpeg-turbo 3.0
      # for dual 8/12 bit mode.
--    include(CheckCSourceCompiles)
+-    include(CheckSymbolExists)
 -    include(CMakePushCheckState)
 -    cmake_push_check_state(RESET)
--    set(CMAKE_REQUIRED_INCLUDES "${JPEG_INCLUDE_DIRS}")
+-
+-    # Set up includes and libraries for the check
+-    # For targets, we need to explicitly get the include directories
+-    if(TARGET ${JPEG_LIBRARIES})
+-        # It's an imported target - extract properties
+-        get_target_property(_jpeg_includes ${JPEG_LIBRARIES} INTERFACE_INCLUDE_DIRECTORIES)
+-        if(_jpeg_includes)
+-            set(CMAKE_REQUIRED_INCLUDES "${_jpeg_includes}")
+-        endif()
+-        unset(_jpeg_includes)
+-    elseif(JPEG_INCLUDE_DIRS)
+-        # It's a plain library - use the provided includes
+-        set(CMAKE_REQUIRED_INCLUDES "${JPEG_INCLUDE_DIRS}")
+-    endif()
+-
 -    set(CMAKE_REQUIRED_LIBRARIES "${JPEG_LIBRARIES}")
--    check_c_source_compiles(
--        "
--        #include <stddef.h>
--        #include <stdio.h>
--        #include \"jpeglib.h\"
--        int main()
--        {
--            jpeg_read_scanlines(0,0,0);
--            jpeg12_read_scanlines(0,0,0);
--            return 0;
--        }
--        "
--        HAVE_JPEGTURBO_DUAL_MODE_8_12)
+-
+-    # Check if the jpeg12_read_scanlines symbol exists in jpeglib.h
+-    # This is more reliable than trying to compile code that calls it
+-    check_symbol_exists(jpeg_read_scanlines "stdio.h;jpeglib.h" HAVE_JPEGTURBO_DUAL_MODE_8)
+-    check_symbol_exists(jpeg12_read_scanlines "stdio.h;jpeglib.h" HAVE_JPEGTURBO_DUAL_MODE_12)
+-    set(HAVE_JPEGTURBO_DUAL_MODE_8_12 OFF)
+-    if (HAVE_JPEGTURBO_DUAL_MODE_8 AND HAVE_JPEGTURBO_DUAL_MODE_12)
+-        set(HAVE_JPEGTURBO_DUAL_MODE_8_12 ON)
+-    endif()
+-
 -    cmake_pop_check_state()
  endif()
- 
+
  if (NOT HAVE_JPEGTURBO_DUAL_MODE_8_12)
 diff --git a/cmake/LZMACodec.cmake b/cmake/LZMACodec.cmake
 index c51afe82..53ef874e 100644
@@ -48,7 +59,7 @@ index c51afe82..53ef874e 100644
 @@ -28,7 +28,7 @@
  set(LZMA_SUPPORT FALSE)
  find_package(liblzma)
- 
+
 -option(lzma "use liblzma (required for LZMA2 compression)" ${LIBLZMA_FOUND})
 -if (lzma AND LIBLZMA_FOUND)
 +option(lzma "use liblzma (required for LZMA2 compression)" ${liblzma_FOUND})

--- a/recipes/libtiff/config.yml
+++ b/recipes/libtiff/config.yml
@@ -1,7 +1,5 @@
 versions:
-  "4.7.1":
-    folder: all
-  "4.7.0":
+  "4.7.2":
     folder: all
   "4.6.0":
     folder: all


### PR DESCRIPTION
Incorporate the new version of libtiff 4.7.2 into the Conan recipe

### Summary
Changes to recipe:  **libtiff/4.7.2**

#### Motivation

Libtiff 4.7.2 fixes a number of vulnerabilities and other bugs. Among them are
 - CVE-2026-36849
 - CVE-2025-61145
 - CVE-2025-61144
 - CVE-2025-61143

Remove the older vulnerable 4.7.x versions


#### Details

Tested on MacOS w/ Xcode 26.2 ARM

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
