### PR TITLE
async-mutex: new recipe - 0.1.0

### DIFF
--- a/recipes/async-mutex/all/conandata.yml
+++ b/recipes/async-mutex/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.1.0":
+    url: "https://github.com/CatalinSerafimescu/async_mutex/archive/refs/tags/v0.1.0.tar.gz"
+    sha256: "5fbaa3b421d1cda96bd3f5a45b4a111c449ff51cab5a4f6cc0817d76818d14ed"

--- a/recipes/async-mutex/all/conanfile.py
+++ b/recipes/async-mutex/all/conanfile.py
@@ -1,0 +1,111 @@
+import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get
+from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
+
+required_conan_version = ">=2.0"
+
+
+class AsyncMutexConan(ConanFile):
+    name = "async-mutex"
+    description = (
+        "Awaitable, header-only, Asio-based asynchronous mutex for C++23 coroutines."
+    )
+    license = "AGPL-3.0-or-later"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/CatalinSerafimescu/async_mutex"
+    topics = ("mutex", "async", "coroutines", "asio", "concurrency", "header-only")
+
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    @property
+    def _min_cppstd(self):
+        return 23
+
+    @property
+    def _compilers_minimum_version(self):
+        # C++23 floors — the binding features are std::expected and coroutines.
+        #   gcc 12   : libstdc++ shipped <expected> in GCC 12.
+        #   clang 17 : libc++ first shipped <expected> in 16, but it is only
+        #              reliably complete from 17 (this header stores a move-only
+        #              value in std::expected); a reviewer may lower to 16.
+        #   apple-clang 16 : Apple's libc++ lags; <expected> is not complete
+        #              before Xcode 16.
+        #   msvc 193 : MSVC STL shipped <expected> in VS 2022 17.3 (_MSC_VER 1933).
+        # Only clang 22 / gcc 13 are exercised in our CI (macOS uses Homebrew
+        # LLVM, not apple-clang); these floors are researched, not all locally
+        # built — CCI's CI matrix is the real gate and reviewers may tune them.
+        return {
+            "gcc": "12",
+            "clang": "17",
+            "apple-clang": "16",
+            "msvc": "193",
+        }
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def requirements(self):
+        # transitive_headers: the public header #includes <asio/...>, so any
+        # consumer must see Asio's include dirs at compile time.
+        # Range floor 1.26 is the lowest asio that compiles this header (1.24
+        # lacks asio::awaitable/use_awaitable_t as used here); verified locally.
+        # A range (not an exact pin) lets a consumer that also pins asio itself
+        # — e.g. fixpp on 1.38.0 — resolve without a diamond conflict.
+        self.requires("asio/[>=1.26 <2]", transitive_headers=True)
+
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        check_min_cppstd(self, self._min_cppstd)
+        minimum = self._compilers_minimum_version.get(str(self.settings.compiler))
+        if minimum and Version(self.settings.compiler.version) < minimum:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which needs "
+                f"{self.settings.compiler} >= {minimum} "
+                f"(have {self.settings.compiler.version})."
+            )
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
+
+    def build(self):
+        pass
+
+    def package(self):
+        copy(
+            self,
+            "LICENSE",
+            self.source_folder,
+            os.path.join(self.package_folder, "licenses"),
+        )
+        copy(
+            self,
+            "*.hpp",
+            os.path.join(self.source_folder, "include"),
+            os.path.join(self.package_folder, "include"),
+        )
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+
+        # Match the in-tree CMake package so `find_package` consumers (e.g.
+        # fixpp) keep linking the exact target the repo advertises.
+        self.cpp_info.set_property("cmake_file_name", "catseraf-async-mutex")
+        self.cpp_info.set_property("cmake_target_name", "catseraf::async_mutex")
+        self.cpp_info.requires = ["asio::asio"]
+
+        if self.settings.os in ("Linux", "FreeBSD"):
+            self.cpp_info.system_libs.append("pthread")

--- a/recipes/async-mutex/all/test_package/CMakeLists.txt
+++ b/recipes/async-mutex/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(catseraf-async-mutex CONFIG REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE catseraf::async_mutex)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_23)

--- a/recipes/async-mutex/all/test_package/conanfile.py
+++ b/recipes/async-mutex/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/async-mutex/all/test_package/test_package.cpp
+++ b/recipes/async-mutex/all/test_package/test_package.cpp
@@ -1,0 +1,33 @@
+// Minimal smoke test: acquire and release the async mutex once on a
+// single-threaded io_context. Proves the header parses, the Asio transitive
+// dependency is wired, and the advertised catseraf::async_mutex target links.
+
+#include <asio/co_spawn.hpp>
+#include <asio/detached.hpp>
+#include <asio/io_context.hpp>
+
+#include "catseraf/sync/async_mutex.hpp"
+
+#include <cassert>
+#include <cstdio>
+
+namespace {
+
+asio::awaitable<void> use_mutex(catseraf::sync::async_mutex& m) {
+    auto guard = co_await m.async_lock();
+    assert(guard.has_value());
+    // `guard` releases the lock when it goes out of scope here.
+}
+
+}  // namespace
+
+int main() {
+    asio::io_context ioc;
+    catseraf::sync::async_mutex m;
+
+    asio::co_spawn(ioc, use_mutex(m), asio::detached);
+    ioc.run();
+
+    std::puts("async-mutex test_package OK");
+    return 0;
+}

--- a/recipes/async-mutex/config.yml
+++ b/recipes/async-mutex/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.1.0":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe: **async-mutex/0.1.0**

#### Motivation
New recipe. `async-mutex` (`catseraf::sync::async_mutex`) is a header-only, Asio-based awaitable mutex for C++23 coroutines — lock-free state encoding, FIFO fairness, and cancellation/drain support. This adds it to ConanCenter.

#### Details
- Header-only: `package_type = "header-library"`, `package_id().clear()`.
- Single dependency `asio/[>=1.26 <2]` with `transitive_headers=True` (the public header `#include`s `<asio/...>`). 1.26 is the lowest asio that compiles the header (verified locally; 1.24 lacks `asio::awaitable`/`use_awaitable_t` as used here).
- Requires C++23 (`std::expected` + coroutines); compiler minimums enforced in `validate()`.
- Advertises CMake `cmake_file_name = catseraf-async-mutex` / `cmake_target_name = catseraf::async_mutex`, matching upstream's own installed CMake config.
- Tested locally with Conan 2.27 (clang 22, libstdc++ and libc++): `conan create` is green and `test_package` builds and runs.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details (N/A — new recipe)
- [x] Tested locally with at least one configuration using a recent version of Conan
