### PR TITLE
[Userspace-rcu] Update to version 0.15.6

### DIFF
--- a/recipes/userspace-rcu/all/conandata.yml
+++ b/recipes/userspace-rcu/all/conandata.yml
@@ -1,7 +1,4 @@
 sources:
-  "0.14.0":
-    url: "https://github.com/urcu/userspace-rcu/archive/refs/tags/v0.14.0.tar.gz"
-    sha256: "42fb5129a3fffe5a4b790dfe1ea3a734c69ee095fefbf649326269bba94c262d"
-  "0.11.4":
-    url: "https://github.com/urcu/userspace-rcu/archive/refs/tags/v0.11.4.tar.gz"
-    sha256: "d995598482221587ff6753d2a8da6ac74ff0fa79fbea29ccee196f295834531d"
+  "0.15.6":
+    url: "https://github.com/urcu/userspace-rcu/archive/refs/tags/v0.15.6.tar.gz"
+    sha256: "15c341ce8b93d3b70bec120c1df90b2b02a219d65593cddeb4b52521a950e45e"

--- a/recipes/userspace-rcu/all/conanfile.py
+++ b/recipes/userspace-rcu/all/conanfile.py
@@ -3,7 +3,7 @@ import os
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.env import VirtualBuildEnv
-from conan.tools.files import chdir, copy, get, rm, rmdir
+from conan.tools.files import copy, get, rm, rmdir
 from conan.tools.gnu import Autotools, AutotoolsToolchain
 from conan.tools.layout import basic_layout
 
@@ -41,9 +41,6 @@ class UserspaceRCUConan(ConanFile):
     def validate(self):
         if self.settings.os not in ["Linux", "FreeBSD", "Macos"]:
             raise ConanInvalidConfiguration(f"Building for {self.settings.os} unsupported")
-        if self.version == "0.11.4" and self.settings.compiler == "apple-clang":
-            # Fails with "cds_hlist_add_head_rcu.c:19:10: fatal error: 'urcu/urcu-memb.h' file not found"
-            raise ConanInvalidConfiguration(f"{self.ref} is not compatible with apple-clang")
 
     def build_requirements(self):
         self.tool_requires("libtool/2.4.7")
@@ -75,7 +72,7 @@ class UserspaceRCUConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "share"))
 
     def package_info(self):
-        for lib_type in ["", "-bp", "-cds", "-mb", "-memb", "-qsbr", "-signal"]:
+        for lib_type in ["", "-bp", "-cds", "-mb", "-memb", "-qsbr"]:
             component_name = f"urcu{lib_type}"
             self.cpp_info.components[component_name].libs = ["urcu-common", component_name]
             self.cpp_info.components[component_name].set_property("pkg_config_name", f"lib{component_name}")
@@ -85,4 +82,3 @@ class UserspaceRCUConan(ConanFile):
 
         # Some definitions needed for MB and Signal variants
         self.cpp_info.components["urcu-mb"].defines = ["RCU_MB"]
-        self.cpp_info.components["urcu-signal"].defines = ["RCU_SIGNAL"]

--- a/recipes/userspace-rcu/all/conanfile.py
+++ b/recipes/userspace-rcu/all/conanfile.py
@@ -72,13 +72,16 @@ class UserspaceRCUConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "share"))
 
     def package_info(self):
-        for lib_type in ["", "-bp", "-cds", "-mb", "-memb", "-qsbr"]:
+        for lib_type in ["", "-bp", "-cds", "-mb", "-memb", "-qsbr", "-common"]:
             component_name = f"urcu{lib_type}"
-            self.cpp_info.components[component_name].libs = ["urcu-common", component_name]
+            self.cpp_info.components[component_name].libs = [component_name]
             self.cpp_info.components[component_name].set_property("pkg_config_name", f"lib{component_name}")
             self.cpp_info.components[component_name].set_property("pkg_config_aliases", [component_name])
             if self.settings.os in ["Linux", "FreeBSD"]:
                 self.cpp_info.components[component_name].system_libs = ["pthread"]
 
-        # Some definitions needed for MB and Signal variants
+            if lib_type != "-common":
+                self.cpp_info.components[component_name].requires = ["urcu-common"]
+
+        # Some definitions needed for MB variants
         self.cpp_info.components["urcu-mb"].defines = ["RCU_MB"]

--- a/recipes/userspace-rcu/all/conanfile.py
+++ b/recipes/userspace-rcu/all/conanfile.py
@@ -2,6 +2,7 @@ import os
 
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
+from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import copy, get, rm, rmdir
 from conan.tools.gnu import Autotools, AutotoolsToolchain
@@ -66,6 +67,8 @@ class UserspaceRCUConan(ConanFile):
             dst=os.path.join(self.package_folder, "licenses"))
         autotools = Autotools(self)
         autotools.install()
+
+        fix_apple_shared_install_name(self)
 
         rm(self, "*.la", self.package_folder, recursive=True)
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))

--- a/recipes/userspace-rcu/all/test_package/CMakeLists.txt
+++ b/recipes/userspace-rcu/all/test_package/CMakeLists.txt
@@ -10,6 +10,3 @@ target_link_libraries(${PROJECT_NAME} userspace-rcu::urcu)
 
 add_executable(${PROJECT_NAME}-mb ${TEST_SRC})
 target_link_libraries(${PROJECT_NAME}-mb userspace-rcu::urcu-mb)
-
-add_executable(${PROJECT_NAME}-signal ${TEST_SRC})
-target_link_libraries(${PROJECT_NAME}-signal userspace-rcu::urcu-signal)

--- a/recipes/userspace-rcu/all/test_package/conanfile.py
+++ b/recipes/userspace-rcu/all/test_package/conanfile.py
@@ -26,6 +26,6 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            for test in ["", "-mb", "-signal"]:
+            for test in ["", "-mb"]:
                 bin_path = os.path.join(self.cpp.build.bindir, f"test_package{test}")
                 self.run(bin_path, env="conanrun")

--- a/recipes/userspace-rcu/config.yml
+++ b/recipes/userspace-rcu/config.yml
@@ -1,5 +1,3 @@
 versions:
-  "0.14.0":
-    folder: all
-  "0.11.4":
+  "0.15.6":
     folder: all


### PR DESCRIPTION
### Summary
Updated recipe  **userspace-rcu/0.15.6**

#### Motivation
The last version is 0.14.0 which is pretty old and quite a lot of changes seem to have been added since (cf. https://github.com/urcu/userspace-rcu/blob/master/ChangeLog) - v0.15.6 is from January 2026 (https://github.com/urcu/userspace-rcu/tags).

#### Details
I added the new version and removed the older versions. The most signficant change to the recipe is the removal of the urcu-signal target which has been removed in v0.15.0 (cf. the changelog linked above).

The recipe contains required_conan_version = ">=1.53.0" - should this be upated or removed?

I added a separate component for "urcu-common" and added it to the other components with "requires" instead of adding it to the list of libraries - this was done because a warning in the PR checks mentioned that libs should only contain only entry.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
