### PR TITLE
dqlite: add recipe 1.18.7

### DIFF
--- a/recipes/dqlite/all/conandata.yml
+++ b/recipes/dqlite/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.18.7":
+    url: "https://github.com/canonical/dqlite/archive/refs/tags/v1.18.7.tar.gz"
+    sha256: "7a9087460f3296313379e95a25761c88081c508ae0742bec6fb63e895eb807a9"

--- a/recipes/dqlite/all/conanfile.py
+++ b/recipes/dqlite/all/conanfile.py
@@ -1,0 +1,122 @@
+import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.files import copy, get, rm, rmdir
+from conan.tools.gnu import Autotools, AutotoolsDeps, AutotoolsToolchain, PkgConfigDeps
+from conan.tools.layout import basic_layout
+
+required_conan_version = ">=2.0"
+
+
+class DqliteConan(ConanFile):
+    name = "dqlite"
+    description = "Embeddable and replicated SQL database engine with high availability and automatic failover"
+    license = "LGPL-3.0-only"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/canonical/dqlite"
+    topics = ("database", "sqlite", "raft", "replication")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "with_lz4": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "with_lz4": True,
+    }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("sqlite3/[>=3.34.0 <4]")
+        self.requires("libuv/[>=1.34.0 <2]")
+        if self.options.with_lz4:
+            self.requires("lz4/[>=1.7.1 <2]")
+
+    def validate(self):
+        if self.settings.os != "Linux":
+            raise ConanInvalidConfiguration(f"{self.ref} only supports Linux")
+
+    def build_requirements(self):
+        self.tool_requires("autoconf/2.71")
+        self.tool_requires("automake/1.16.5")
+        self.tool_requires("libtool/2.4.7")
+        self.tool_requires("pkgconf/2.5.1")
+        self.tool_requires("gnu-config/cci.20210814")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        env = VirtualBuildEnv(self)
+        env.generate()
+
+        tc = AutotoolsToolchain(self)
+        tc.configure_args.extend([
+            "--disable-dependency-tracking",
+            "--disable-backtrace",
+            "--enable-build-raft",
+        ])
+        # dqlite 1.18.7 builds with -Werror and keeps several variables alive through assert().
+        tc.extra_cflags.append("-UNDEBUG")
+        if self.options.with_lz4:
+            tc.configure_args.extend(["--with-lz4", "--enable-lz4"])
+        else:
+            tc.configure_args.append("--without-lz4")
+        tc.generate()
+
+        deps = AutotoolsDeps(self)
+        deps.generate()
+
+        pkg_config = PkgConfigDeps(self)
+        pkg_config.set_property("libuv", "pkg_config_name", "libuv")
+        pkg_config.generate()
+
+    def _patch_sources(self):
+        for gnu_config in [
+            self.conf.get("user.gnu-config:config_guess", check_type=str),
+            self.conf.get("user.gnu-config:config_sub", check_type=str),
+        ]:
+            if gnu_config:
+                copy(self, os.path.basename(gnu_config), src=os.path.dirname(gnu_config), dst=os.path.join(self.source_folder, "ac"))
+
+    def build(self):
+        self._patch_sources()
+        autotools = Autotools(self)
+        autotools.autoreconf()
+        autotools.configure()
+        autotools.make()
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        autotools = Autotools(self)
+        autotools.install()
+        rm(self, "*.la", self.package_folder, recursive=True)
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "dqlite")
+        self.cpp_info.set_property("cmake_target_name", "dqlite::dqlite")
+        self.cpp_info.set_property("pkg_config_name", "dqlite")
+        self.cpp_info.libs = ["dqlite"]
+        self.cpp_info.requires = ["sqlite3::sqlite3", "libuv::libuv"]
+        if self.options.with_lz4:
+            self.cpp_info.requires.append("lz4::lz4")
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("pthread")

--- a/recipes/dqlite/all/conanfile.py
+++ b/recipes/dqlite/all/conanfile.py
@@ -44,7 +44,7 @@ class DqliteConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("sqlite3/[>=3.34.0 <4]")
+        self.requires("sqlite3/[>=3.34.0 <4]", transitive_headers=True)
         self.requires("libuv/[>=1.34.0 <2]")
         if self.options.with_lz4:
             self.requires("lz4/[>=1.7.1 <2]")

--- a/recipes/dqlite/all/test_package/CMakeLists.txt
+++ b/recipes/dqlite/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES C)
+
+find_package(dqlite REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE dqlite::dqlite)

--- a/recipes/dqlite/all/test_package/conanfile.py
+++ b/recipes/dqlite/all/test_package/conanfile.py
@@ -1,0 +1,31 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/dqlite/all/test_package/test_package.c
+++ b/recipes/dqlite/all/test_package/test_package.c
@@ -1,0 +1,8 @@
+#include <dqlite.h>
+#include <stdio.h>
+
+int main(void)
+{
+    printf("dqlite version: %s (%d)\n", dqlite_version_string, dqlite_version_number());
+    return dqlite_version_number() > 0 ? 0 : 1;
+}

--- a/recipes/dqlite/config.yml
+++ b/recipes/dqlite/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.18.7":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **dqlite/1.18.7**

#### Motivation
Fixes #30551

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->
Adds a new Conan v2 recipe for `dqlite/1.18.7`.
`dqlite` is a C library that implements an embeddable, replicated SQL database engine with high availability and automatic failover. It extends SQLite with a Raft-based replication layer and uses libuv for asynchronous I/O.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
