### PR TITLE
box3d: add version 0.1.0

### DIFF
--- a/recipes/box3d/all/conandata.yml
+++ b/recipes/box3d/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.1.0":
+    url: "https://github.com/erincatto/box3d/archive/refs/tags/v0.1.0.tar.gz"
+    sha256: "df232c7618c0d0d3927b798044559ee56eabadeb9d8ff9dc526d4b384d7b415d"

--- a/recipes/box3d/all/conanfile.py
+++ b/recipes/box3d/all/conanfile.py
@@ -4,7 +4,7 @@ from conan.tools.build import check_min_cppstd
 from conan.tools.files import get, copy, rmdir
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 
-required_conan_version = ">=2"
+required_conan_version = ">=2.4"
 
 
 class Box3dConan(ConanFile):
@@ -19,29 +19,23 @@ class Box3dConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
-        "sanitize": [True, False],
-        "disable_simd": [True, False]
+        "disable_simd": [True, False],
+        "double_precision": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
-        "sanitize": False,
-        "disable_simd": False
+        "disable_simd": False,
+        "double_precision": False,
     }
 
-    def config_options(self):
-        if self.settings.os == "Windows":
-            del self.options.fPIC
-
-    def configure(self):
-        if self.options.shared:
-            self.options.rm_safe("fPIC")
+    implements = ["auto_shared_fpic"]
 
     def validate(self):
         check_min_cppstd(self, 17)
 
     def build_requirements(self):
-        self.tool_requires("cmake/[>=3.22 <5]")
+        self.tool_requires("cmake/[>=3.22]")
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -51,17 +45,19 @@ class Box3dConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["BOX3D_SANITIZE"] =  self.options.sanitize
-        tc.variables["BOX3D_DISABLE_SIMD"] = self.options.disable_simd
-        tc.variables["BOX3D_COMPILE_WARNING_AS_ERROR"] = False
-
-        tc.variables["BOX3D_SAMPLES"] = False
-        tc.variables["BOX3D_BENCHMARKS"] = False
-        tc.variables["BOX3D_DOCS"] = False
-        tc.variables["BOX3D_PROFILE"] = False
-        tc.variables["BOX3D_VALIDATE"] = False
-        tc.variables["BOX3D_UNIT_TESTS"] = False
-        tc.variables["BOX3D_BUILD_SHADERS"] = False
+        tc.cache_variables["BOX3D_DISABLE_SIMD"] = self.options.disable_simd
+        tc.cache_variables["BOX3D_DOUBLE_PRECISION"] = self.options.double_precision
+        tc.cache_variables["BOX3D_COMPILE_WARNING_AS_ERROR"] = False
+        tc.cache_variables["BOX3D_SANITIZE"] =  False
+        tc.cache_variables["BOX3D_SAMPLES"] = False
+        tc.cache_variables["BOX3D_BENCHMARKS"] = False
+        tc.cache_variables["BOX3D_DOCS"] = False
+        tc.cache_variables["BOX3D_PROFILE"] = False
+        # Off by default, not set so that users can override from profile,
+        # useful only in Debug builds
+        # tc.cache_variables["BOX3D_VALIDATE"] = False
+        tc.cache_variables["BOX3D_UNIT_TESTS"] = False
+        tc.cache_variables["BOX3D_BUILD_SHADERS"] = False
         tc.generate()
 
         deps = CMakeDeps(self)
@@ -83,3 +79,7 @@ class Box3dConan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "box3d")
         self.cpp_info.set_property("cmake_target_name", "box3d::box3d")
         self.cpp_info.libs = ["box3d"]
+        if self.options.double_precision:
+            self.cpp_info.defines.append("BOX3D_DOUBLE_PRECISION")
+        if self.options.shared and self.settings.compiler == "msvc":
+            self.cpp_info.defines.append("BOX3D_DLL")

--- a/recipes/box3d/all/conanfile.py
+++ b/recipes/box3d/all/conanfile.py
@@ -1,0 +1,85 @@
+import os
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import get, copy, rmdir
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+
+required_conan_version = ">=2"
+
+
+class Box3dConan(ConanFile):
+    name = "box3d"
+    description = "Box3D is a 3D physics engine for games"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "http://box2d.org/"
+    topics = ("physics-engine", "graphic", "3d", "collision")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "sanitize": [True, False],
+        "disable_simd": [True, False]
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "sanitize": False,
+        "disable_simd": False
+    }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def validate(self):
+        check_min_cppstd(self, 17)
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.22 <5]")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["BOX3D_SANITIZE"] =  self.options.sanitize
+        tc.variables["BOX3D_DISABLE_SIMD"] = self.options.disable_simd
+        tc.variables["BOX3D_COMPILE_WARNING_AS_ERROR"] = False
+
+        tc.variables["BOX3D_SAMPLES"] = False
+        tc.variables["BOX3D_BENCHMARKS"] = False
+        tc.variables["BOX3D_DOCS"] = False
+        tc.variables["BOX3D_PROFILE"] = False
+        tc.variables["BOX3D_VALIDATE"] = False
+        tc.variables["BOX3D_UNIT_TESTS"] = False
+        tc.variables["BOX3D_BUILD_SHADERS"] = False
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        cmake = CMake(self)
+        cmake.install()
+
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "box3d")
+        self.cpp_info.set_property("cmake_target_name", "box3d::box3d")
+        self.cpp_info.libs = ["box3d"]

--- a/recipes/box3d/all/conanfile.py
+++ b/recipes/box3d/all/conanfile.py
@@ -30,9 +30,7 @@ class Box3dConan(ConanFile):
     }
 
     implements = ["auto_shared_fpic"]
-
-    def validate(self):
-        check_min_cppstd(self, 17)
+    languages = "C"
 
     def build_requirements(self):
         self.tool_requires("cmake/[>=3.22]")
@@ -78,7 +76,10 @@ class Box3dConan(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "box3d")
         self.cpp_info.set_property("cmake_target_name", "box3d::box3d")
-        self.cpp_info.libs = ["box3d"]
+        postfix = "d" if self.settings.build_type == "Debug" else ""
+        self.cpp_info.libs = [f"box3d{postfix}"]
+        if self.settings.os in ("Linux", "FreeBSD"):
+            self.cpp_info.system_libs.append("m")
         if self.options.double_precision:
             self.cpp_info.defines.append("BOX3D_DOUBLE_PRECISION")
         if self.options.shared and self.settings.compiler == "msvc":

--- a/recipes/box3d/all/test_package/CMakeLists.txt
+++ b/recipes/box3d/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES C CXX)
 
 find_package(box3d REQUIRED CONFIG)

--- a/recipes/box3d/all/test_package/CMakeLists.txt
+++ b/recipes/box3d/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.22)
+project(test_package LANGUAGES C CXX)
+
+find_package(box3d REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+target_link_libraries(${PROJECT_NAME} PRIVATE box3d::box3d)

--- a/recipes/box3d/all/test_package/conanfile.py
+++ b/recipes/box3d/all/test_package/conanfile.py
@@ -2,22 +2,17 @@ import os
 from conan import ConanFile
 from conan.tools.build import can_run
 from conan.tools.cmake import CMake, cmake_layout
-from conan.tools.scm import Version
 
 
 class Box3DTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def layout(self):
         cmake_layout(self)
 
     def requirements(self):
         self.requires(self.tested_reference_str)
-
-    def build_requirements(self):
-        self.tool_requires("cmake/[>=3.22 <5]")
 
     def build(self):
         cmake = CMake(self)
@@ -26,5 +21,5 @@ class Box3DTestConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
             self.run(bin_path, env="conanrun")

--- a/recipes/box3d/all/test_package/conanfile.py
+++ b/recipes/box3d/all/test_package/conanfile.py
@@ -1,0 +1,30 @@
+import os
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.scm import Version
+
+
+class Box3DTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.22 <5]")
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/box3d/all/test_package/test_package.cpp
+++ b/recipes/box3d/all/test_package/test_package.cpp
@@ -1,21 +1,17 @@
 #include "box3d/box3d.h"
+#include <iostream>
 
 int main(void) {
+    auto version = b3GetVersion();
+    auto major = version.major;
+    auto minor = version.minor;
+    auto revision = version.revision;
+    std::cout << "Box3D version: " << major << "." << minor << "." << revision << std::endl;
+    std::cout << "Is double precision: " << b3IsDoublePrecision() << std::endl;
+
     b3WorldDef worldDef = b3DefaultWorldDef();
-    worldDef.gravity = b3Vec3{ 0.0f, -10.0f, 0.0f };
-
+    // This has undefined symbols if double precision is mismatched
     b3WorldId worldId = b3CreateWorld(&worldDef);
-
-    b3BodyDef groundBodyDef = b3DefaultBodyDef();
-    groundBodyDef.position = b3Vec3{ 0.0f, -10.0f, 0.0f };
-
-    b3BodyId groundId = b3CreateBody(worldId, &groundBodyDef);
-
-    b3BoxHull groundBox = b3MakeBoxHull(50.0f, 10.0f, 50.0f);
-
-    b3ShapeDef groundShapeDef = b3DefaultShapeDef();
-    b3CreateHullShape(groundId, &groundShapeDef, &groundBox.base);
-
     b3DestroyWorld(worldId);
 
     return 0;

--- a/recipes/box3d/all/test_package/test_package.cpp
+++ b/recipes/box3d/all/test_package/test_package.cpp
@@ -1,0 +1,22 @@
+#include "box3d/box3d.h"
+
+int main(void) {
+    b3WorldDef worldDef = b3DefaultWorldDef();
+    worldDef.gravity = b3Vec3{ 0.0f, -10.0f, 0.0f };
+
+    b3WorldId worldId = b3CreateWorld(&worldDef);
+
+    b3BodyDef groundBodyDef = b3DefaultBodyDef();
+    groundBodyDef.position = b3Vec3{ 0.0f, -10.0f, 0.0f };
+
+    b3BodyId groundId = b3CreateBody(worldId, &groundBodyDef);
+
+    b3BoxHull groundBox = b3MakeBoxHull(50.0f, 10.0f, 50.0f);
+
+    b3ShapeDef groundShapeDef = b3DefaultShapeDef();
+    b3CreateHullShape(groundId, &groundShapeDef, &groundBox.base);
+
+    b3DestroyWorld(worldId);
+
+    return 0;
+}

--- a/recipes/box3d/config.yml
+++ b/recipes/box3d/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.1.0":
+    folder: "all"


### PR DESCRIPTION
### Summary
Changes to recipe:  **box3d/[0.1.0]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Box3D is a recently released physics simulation engine similar to Box2D. Both engines share the same authors. The core planned functionality has been implemented, but documentation updates and testing are needed.

[https://github.com/erincatto/box3d](https://github.com/erincatto/box3d)
[https://github.com/erincatto/box2d](https://github.com/erincatto/box2d)

The Box3D engine was created by the Kintsugiyama studio during the development of the new 3D shooter *The Legend of California*. The game uses the Unreal Engine, but the developers were not satisfied with its built-in Chaos physics engine.

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->

For testing the recipe:
recipes/box3d/all/test_package/CMakeLists.txt
recipes/box3d/all/test_package/conanfile.py
recipes/box3d/all/test_package/test_package.cpp

For building the recipe:
recipes/box3d/all/conandata.yml
recipes/box3d/all/conanfile.py
recipes/box3d/config.yml

### Mantainer changes
- `conanfile.py`: replaced manual `config_options`/`configure` fPIC handling with `implements = ["auto_shared_fpic"]`
- `conanfile.py`: removed `sanitize` option; added `double_precision` option
- `conanfile.py`: switched `tc.variables` → `tc.cache_variables`
- `conanfile.py`: hardcoded `BOX3D_SANITIZE` to `False`
- `conanfile.py`: wired `BOX3D_DOUBLE_PRECISION` cache variable to the new option
- `conanfile.py`: left `BOX3D_VALIDATE` unset (commented out) with explanatory comment
- `conanfile.py`: dropped upper bound on cmake tool_requires
- `conanfile.py`: `package_info()` now appends `BOX3D_DOUBLE_PRECISION` define when the option is enabled
- `test_package/CMakeLists.txt`: lowered `cmake_minimum_required` from 3.22 to 3.15, the consumers typically don't need to match the library minimum version
- `test_package/test_package.cpp`: rewritten — drops body/hull/shape creation, adds version print and `b3IsDoublePrecision()` check

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

Tested on Linux:
conan create . --version=0.1.0

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!

<hr>

[Box3D Debuts As New Open-Source 3D Physics Engine](https://www.phoronix.com/news/Box3D-Open-Source-3D-Physics)

> Who is using Box3D?
> Box3D is used in a few places already. Besides [The Legend of California](https://www.kintsugiyama.com/game), it’s used in:
> 
> [s&box](https://sbox.game/), a game platform by Facepunch Studios
> [Esoterica](https://github.com/BobbyAnguelov/Esoterica), an open source game engine led by Bobby Anguelov
> [A 1000-player space game](https://mas-bandwidth.com/so-im-making-a-space-game/), a multiplayer game by Glenn Fiedler

[Announcing Box3D](https://box2d.org/posts/2026/06/announcing-box3d/)

> You can think of Box3D as a fork of Box2D, extended with many features needed for 3D games. Some additions:
> 
> Triangle mesh collision
> Height-field collision
> Baked compound collision
> The core architecture of Box3D remains almost identical to Box2D.
> 
> C API
> All library source is C17
> Sub-stepping solver
> Continuous collision
> Graph coloring for large islands
> Wide SIMD contact solver
> Multi-threading hooks
> Optional internal scheduler
> Large world support with doubles for position
> Cross platform determinism
> Recording and replay

[https://github.com/erincatto/box3d](https://github.com/erincatto/box3d)

I copied the example from [Hello Box3D](https://box2d.org/documentation3d/hello.html)