### PR TITLE
lcms: add version 2.19.1

### DIFF
--- a/recipes/lcms/all/conandata.yml
+++ b/recipes/lcms/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.19.1":
+    url: "https://github.com/mm2/Little-CMS/releases/download/lcms2.19.1/lcms2-2.19.1.tar.gz"
+    sha256: "bfc54f7bab59fbc921012014a8032e4cba4abd46db47d46b76416a8c0b2815c8"
   "2.17":
     url: "https://github.com/mm2/Little-CMS/releases/download/lcms2.17/lcms2-2.17.tar.gz"
     sha256: "d11af569e42a1baa1650d20ad61d12e41af4fead4aa7964a01f93b08b53ab074"

--- a/recipes/lcms/all/conandata.yml
+++ b/recipes/lcms/all/conandata.yml
@@ -2,9 +2,6 @@ sources:
   "2.19.1":
     url: "https://github.com/mm2/Little-CMS/releases/download/lcms2.19.1/lcms2-2.19.1.tar.gz"
     sha256: "bfc54f7bab59fbc921012014a8032e4cba4abd46db47d46b76416a8c0b2815c8"
-  "2.17":
-    url: "https://github.com/mm2/Little-CMS/releases/download/lcms2.17/lcms2-2.17.tar.gz"
-    sha256: "d11af569e42a1baa1650d20ad61d12e41af4fead4aa7964a01f93b08b53ab074"
   "2.16":
     url: "https://github.com/mm2/Little-CMS/releases/download/lcms2.16/lcms2-2.16.tar.gz"
     sha256: "d873d34ad8b9b4cea010631f1a6228d2087475e4dc5e763eb81acc23d9d45a51"

--- a/recipes/lcms/config.yml
+++ b/recipes/lcms/config.yml
@@ -1,7 +1,5 @@
 versions:
   "2.19.1":
     folder: all
-  "2.17":
-    folder: all
   "2.16":
     folder: all

--- a/recipes/lcms/config.yml
+++ b/recipes/lcms/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.19.1":
+    folder: all
   "2.17":
     folder: all
   "2.16":


### PR DESCRIPTION
Adds lcms 2.19.1. No recipe/patch changes needed; package build and test_package pass locally (msvc). Specify library name and version: **lcms/2.19.1**