### PR TITLE
glib: add version 2.86.5

### DIFF
--- a/recipes/glib/all/conandata.yml
+++ b/recipes/glib/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.86.5":
+    url: "https://download.gnome.org/sources/glib/2.86/glib-2.86.5.tar.xz"
+    sha256: "ce85a947bb8b3c0204dbeff79aec39bcb46371c6fafb64ba5b8726c71e038d5f"
   "2.85.3":
     url: "https://download.gnome.org/sources/glib/2.85/glib-2.85.3.tar.xz"
     sha256: "af229e1de191d66aebcdb03c7493c724fd4d0a6628b1ca4ea1f35739259b311d"

--- a/recipes/glib/config.yml
+++ b/recipes/glib/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.86.5":
+    folder: all
   "2.85.3":
     folder: all
   "2.81.0":


### PR DESCRIPTION
Adds glib 2.86.5, the first stable 2.86.x release (supersedes the 2.85.x development series currently listed). No recipe/patch changes needed. Specify library name and version: **glib/2.86.5**