### PR TITLE
hdf5: add version 2.0.0

### DIFF
--- a/recipes/hdf5/all/conandata.yml
+++ b/recipes/hdf5/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.0.0":
+    url: "https://github.com/HDFGroup/hdf5/archive/refs/tags/2.0.0.tar.gz"
+    sha256: "3e6ae0430995c8ae724688c866f4dbb6feba9c6220583d72049fbb9b006c1cd5"
   "1.14.6":
     url: "https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5_1.14.6.tar.gz"
     sha256: "09ee1c671a87401a5201c06106650f62badeea5a3b3941e9b1e2e1e08317357f"

--- a/recipes/hdf5/config.yml
+++ b/recipes/hdf5/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "2.0.0":
+    folder: all
   "1.14.6":
     folder: all
   "1.14.3":


### PR DESCRIPTION
Adds HDF5 2.0.0 (released 2025-11-11). Builds and test_package pass locally (msvc, C and C++ APIs) with no recipe changes — only a conandata entry, using the GitHub archive tarball consistent with the existing 1.14.6 source. Specify library name and version: **hdf5/2.0.0**