### PR TITLE
nodejs: add version 24.18.0

### DIFF
--- a/recipes/nodejs/all/conandata.yml
+++ b/recipes/nodejs/all/conandata.yml
@@ -1,4 +1,26 @@
 sources:
+    "24.18.0":
+        Linux:
+            "x86_64":
+                url: "https://nodejs.org/dist/v24.18.0/node-v24.18.0-linux-x64.tar.xz"
+                sha256: "55aa7153f9d88f28d765fcdad5ae6945b5c0f98a36881703817e4c450fa76742"
+            "armv8":
+                url: "https://nodejs.org/dist/v24.18.0/node-v24.18.0-linux-arm64.tar.xz"
+                sha256: "58c9520501f6ae2b52d5b210444e24b9d0c029a58c5011b797bc1fe7105886f6"
+        Macos:
+            "x86_64":
+                url: "https://nodejs.org/dist/v24.18.0/node-v24.18.0-darwin-x64.tar.gz"
+                sha256: "dfd0dbd3e721503434df7b7205e719f61b3a3a31b2bcf9729b8b91fea240f080"
+            "armv8":
+                url: "https://nodejs.org/dist/v24.18.0/node-v24.18.0-darwin-arm64.tar.gz"
+                sha256: "e1a97e14c99c803e96c7339403282ea05a499c32f8d83defe9ef5ec66f979ed1"
+        Windows:
+            "x86_64":
+                url: "https://nodejs.org/dist/v24.18.0/node-v24.18.0-win-x64.zip"
+                sha256: "0ae68406b42d7725661da979b1403ec9926da205c6770827f33aac9d8f26e821"
+            "armv8":
+                url: "https://nodejs.org/dist/v24.18.0/node-v24.18.0-win-arm64.zip"
+                sha256: "f274669adb93b1fd0fbf8f21fd078609e9dcc84333d4f2718d2dde3f9a161a01"
     "22.20.0":
         Linux:
             "x86_64":

--- a/recipes/nodejs/config.yml
+++ b/recipes/nodejs/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "24.18.0":
+    folder: all
   "22.20.0":
     folder: all
   "20.16.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **nodejs/24.18.0**

#### Motivation
adds latest LTS version of [nodejs](https://github.com/nodejs/node/releases/tag/v24.18.0)

#### Details
archives [URL](https://nodejs.org/dist/latest-v24.x/) and [SHASUMS256.txt](https://nodejs.org/dist/latest-v24.x/SHASUMS256.txt)

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
