### PR TITLE
Add depz-sensor-sdk-c and depz-sensor-sdk-cpp/0.1.4

### DIFF
--- a/recipes/depz-sensor-sdk-c/all/conandata.yml
+++ b/recipes/depz-sensor-sdk-c/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "0.1.0":
-    url: "https://github.com/depz-ai/depz-sensor-sdk/archive/refs/tags/v0.1.0.tar.gz"
-    sha256: "259f2a6aea357cf26237c1ff8d6e1b4b36ea24782e5df32297d683e0e55dcd90"
+  "0.1.1":
+    url: "https://github.com/depz-ai/depz-sensor-sdk/archive/refs/tags/v0.1.1.tar.gz"
+    sha256: "40537313b7a05e48002bf218d951efb335e0deeb5587391e20ff6d0991c116f5"

--- a/recipes/depz-sensor-sdk-c/all/conandata.yml
+++ b/recipes/depz-sensor-sdk-c/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.1.0":
+    url: "https://github.com/depz-ai/depz-sensor-sdk/archive/refs/tags/v0.1.0.tar.gz"
+    sha256: "259f2a6aea357cf26237c1ff8d6e1b4b36ea24782e5df32297d683e0e55dcd90"

--- a/recipes/depz-sensor-sdk-c/all/conandata.yml
+++ b/recipes/depz-sensor-sdk-c/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "0.1.1":
-    url: "https://github.com/depz-ai/depz-sensor-sdk/archive/refs/tags/v0.1.1.tar.gz"
-    sha256: "40537313b7a05e48002bf218d951efb335e0deeb5587391e20ff6d0991c116f5"
+  "0.1.3":
+    url: "https://github.com/depz-ai/depz-sensor-sdk/archive/refs/tags/v0.1.3.tar.gz"
+    sha256: "a9a87574c762981893a7651c84e516106e07c1319b91db0df3ea66931cde6576"

--- a/recipes/depz-sensor-sdk-c/all/conandata.yml
+++ b/recipes/depz-sensor-sdk-c/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "0.1.3":
-    url: "https://github.com/depz-ai/depz-sensor-sdk/archive/refs/tags/v0.1.3.tar.gz"
-    sha256: "a9a87574c762981893a7651c84e516106e07c1319b91db0df3ea66931cde6576"
+  "0.1.4":
+    url: "https://github.com/depz-ai/depz-sensor-sdk/archive/refs/tags/v0.1.4.tar.gz"
+    sha256: "ff66d1d513c1434b2168b926c3896eae24d70e20b93a1458a83432f389ab654d"

--- a/recipes/depz-sensor-sdk-c/all/conandata.yml
+++ b/recipes/depz-sensor-sdk-c/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "0.1.4":
     url: "https://github.com/depz-ai/depz-sensor-sdk/archive/refs/tags/v0.1.4.tar.gz"
-    sha256: "ff66d1d513c1434b2168b926c3896eae24d70e20b93a1458a83432f389ab654d"
+    sha256: "2d2126a4ae53caeccae7adb8e01dd1f9160ea336ff6d208158464c7bd52451b8"

--- a/recipes/depz-sensor-sdk-c/all/conanfile.py
+++ b/recipes/depz-sensor-sdk-c/all/conanfile.py
@@ -59,9 +59,9 @@ class DepzSensorSdkCConan(ConanFile):
         cmake.build()
 
     def package(self):
-        # The monorepo ships a single top-level MIT license file.
+        # The C package ships its own MIT license file.
         copy(self, "LICENSE",
-             src=os.path.join(self.source_folder, "packages", "depz-sensor-sdk-cpp"),
+             src=os.path.join(self.source_folder, self._subfolder),
              dst=os.path.join(self.package_folder, "licenses"))
         cmake = CMake(self)
         cmake.install()

--- a/recipes/depz-sensor-sdk-c/all/conanfile.py
+++ b/recipes/depz-sensor-sdk-c/all/conanfile.py
@@ -1,0 +1,74 @@
+import os
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get
+
+required_conan_version = ">=2.0"
+
+
+class DepzSensorSdkCConan(ConanFile):
+    name = "depz-sensor-sdk-c"
+    description = (
+        "Contract-first C11 decode/codec SDK for the DEPZ USB sensor line "
+        "(SR04, VL53L8CX/CH, BNO086): CRCs, packet framing, USB identity, "
+        "firmware container parsing, and the per-sensor decode layer."
+    )
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/depz-ai/depz-sensor-sdk"
+    topics = ("sensors", "usb", "codec", "vl53l8", "bno086", "sr04", "embedded")
+    package_type = "static-library"
+    settings = "os", "compiler", "build_type", "arch"
+    options = {
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "fPIC": True,
+    }
+
+    # The library lives in a subdirectory of the DEPZ monorepo tarball.
+    _subfolder = "packages/depz-sensor-sdk-c"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        # Pure C library: no C++ standard library nor C++ ABI.
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        # Consumers never build the monorepo golden-vector test suite.
+        tc.cache_variables["DEPZ_SENSOR_SDK_C_BUILD_TESTS"] = False
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure(build_script_folder=self._subfolder)
+        cmake.build()
+
+    def package(self):
+        # The monorepo ships a single top-level MIT license file.
+        copy(self, "LICENSE",
+             src=os.path.join(self.source_folder, "packages", "depz-sensor-sdk-cpp"),
+             dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["depz_sensor_sdk"]
+        self.cpp_info.set_property("cmake_file_name", "depz-sensor-sdk-c")
+        self.cpp_info.set_property("cmake_target_name", "depz::sensor_sdk_c")
+        if self.settings.os in ("Linux", "FreeBSD"):
+            self.cpp_info.system_libs = ["m"]

--- a/recipes/depz-sensor-sdk-c/all/test_package/CMakeLists.txt
+++ b/recipes/depz-sensor-sdk-c/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES C)
+
+find_package(depz-sensor-sdk-c REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE depz::sensor_sdk_c)

--- a/recipes/depz-sensor-sdk-c/all/test_package/conanfile.py
+++ b/recipes/depz-sensor-sdk-c/all/test_package/conanfile.py
@@ -1,0 +1,27 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/depz-sensor-sdk-c/all/test_package/test_package.c
+++ b/recipes/depz-sensor-sdk-c/all/test_package/test_package.c
@@ -1,0 +1,11 @@
+#include <depz_sensor_sdk.h>
+
+#include <stdint.h>
+#include <stdio.h>
+
+int main(void) {
+    const uint8_t data[] = {0x01, 0x02, 0x03, 0x04};
+    uint8_t crc = depz_crc8_maxim(data, sizeof(data));
+    printf("depz_crc8_maxim -> 0x%02X\n", crc);
+    return 0;
+}

--- a/recipes/depz-sensor-sdk-c/config.yml
+++ b/recipes/depz-sensor-sdk-c/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.1.0":
+    folder: all

--- a/recipes/depz-sensor-sdk-c/config.yml
+++ b/recipes/depz-sensor-sdk-c/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.1.3":
+  "0.1.4":
     folder: all

--- a/recipes/depz-sensor-sdk-c/config.yml
+++ b/recipes/depz-sensor-sdk-c/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.1.0":
+  "0.1.1":
     folder: all

--- a/recipes/depz-sensor-sdk-c/config.yml
+++ b/recipes/depz-sensor-sdk-c/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.1.1":
+  "0.1.3":
     folder: all

--- a/recipes/depz-sensor-sdk-cpp/all/conandata.yml
+++ b/recipes/depz-sensor-sdk-cpp/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "0.1.0":
-    url: "https://github.com/depz-ai/depz-sensor-sdk/archive/refs/tags/v0.1.0.tar.gz"
-    sha256: "259f2a6aea357cf26237c1ff8d6e1b4b36ea24782e5df32297d683e0e55dcd90"
+  "0.1.1":
+    url: "https://github.com/depz-ai/depz-sensor-sdk/archive/refs/tags/v0.1.1.tar.gz"
+    sha256: "40537313b7a05e48002bf218d951efb335e0deeb5587391e20ff6d0991c116f5"

--- a/recipes/depz-sensor-sdk-cpp/all/conandata.yml
+++ b/recipes/depz-sensor-sdk-cpp/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.1.0":
+    url: "https://github.com/depz-ai/depz-sensor-sdk/archive/refs/tags/v0.1.0.tar.gz"
+    sha256: "259f2a6aea357cf26237c1ff8d6e1b4b36ea24782e5df32297d683e0e55dcd90"

--- a/recipes/depz-sensor-sdk-cpp/all/conandata.yml
+++ b/recipes/depz-sensor-sdk-cpp/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "0.1.1":
-    url: "https://github.com/depz-ai/depz-sensor-sdk/archive/refs/tags/v0.1.1.tar.gz"
-    sha256: "40537313b7a05e48002bf218d951efb335e0deeb5587391e20ff6d0991c116f5"
+  "0.1.3":
+    url: "https://github.com/depz-ai/depz-sensor-sdk/archive/refs/tags/v0.1.3.tar.gz"
+    sha256: "a9a87574c762981893a7651c84e516106e07c1319b91db0df3ea66931cde6576"

--- a/recipes/depz-sensor-sdk-cpp/all/conandata.yml
+++ b/recipes/depz-sensor-sdk-cpp/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "0.1.3":
-    url: "https://github.com/depz-ai/depz-sensor-sdk/archive/refs/tags/v0.1.3.tar.gz"
-    sha256: "a9a87574c762981893a7651c84e516106e07c1319b91db0df3ea66931cde6576"
+  "0.1.4":
+    url: "https://github.com/depz-ai/depz-sensor-sdk/archive/refs/tags/v0.1.4.tar.gz"
+    sha256: "ff66d1d513c1434b2168b926c3896eae24d70e20b93a1458a83432f389ab654d"

--- a/recipes/depz-sensor-sdk-cpp/all/conandata.yml
+++ b/recipes/depz-sensor-sdk-cpp/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "0.1.4":
     url: "https://github.com/depz-ai/depz-sensor-sdk/archive/refs/tags/v0.1.4.tar.gz"
-    sha256: "ff66d1d513c1434b2168b926c3896eae24d70e20b93a1458a83432f389ab654d"
+    sha256: "2d2126a4ae53caeccae7adb8e01dd1f9160ea336ff6d208158464c7bd52451b8"

--- a/recipes/depz-sensor-sdk-cpp/all/conanfile.py
+++ b/recipes/depz-sensor-sdk-cpp/all/conanfile.py
@@ -1,0 +1,71 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get
+
+required_conan_version = ">=2.0"
+
+
+class DepzSensorSdkCppConan(ConanFile):
+    name = "depz-sensor-sdk-cpp"
+    description = (
+        "C++17 decode-layer SDK for the DEPZ USB sensor line: framed-protocol "
+        "parser and per-sensor wire codecs (SR04, VL53L8CX/CH, BNO086). "
+        "Pure codecs, no I/O."
+    )
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/depz-ai/depz-sensor-sdk"
+    topics = ("sensors", "usb", "decode", "protocol", "vl53l8", "bno086", "sr04")
+    package_type = "static-library"
+    settings = "os", "compiler", "build_type", "arch"
+    options = {
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "fPIC": True,
+    }
+
+    # The library lives in a subdirectory of the DEPZ monorepo tarball.
+    _subfolder = "packages/depz-sensor-sdk-cpp"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def validate(self):
+        check_min_cppstd(self, 17)
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        # Consumers never build the monorepo golden-vector test suite.
+        tc.cache_variables["DEPZ_SENSOR_SDK_CPP_BUILD_TESTS"] = False
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure(build_script_folder=self._subfolder)
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE",
+             src=os.path.join(self.source_folder, self._subfolder),
+             dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.libs = ["depz_sensor_sdk"]
+        self.cpp_info.set_property("cmake_file_name", "depz-sensor-sdk-cpp")
+        self.cpp_info.set_property("cmake_target_name", "depz::sensor_sdk_cpp")
+        self.cpp_info.set_property("cmake_target_aliases", ["depz::sensor_sdk"])

--- a/recipes/depz-sensor-sdk-cpp/all/test_package/CMakeLists.txt
+++ b/recipes/depz-sensor-sdk-cpp/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(depz-sensor-sdk-cpp REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE depz::sensor_sdk_cpp)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/depz-sensor-sdk-cpp/all/test_package/conanfile.py
+++ b/recipes/depz-sensor-sdk-cpp/all/test_package/conanfile.py
@@ -1,0 +1,27 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/depz-sensor-sdk-cpp/all/test_package/test_package.cpp
+++ b/recipes/depz-sensor-sdk-cpp/all/test_package/test_package.cpp
@@ -1,0 +1,14 @@
+#include <depz/crc.hpp>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+
+int main() {
+    std::array<std::byte, 4> data{
+        std::byte{0x01}, std::byte{0x02}, std::byte{0x03}, std::byte{0x04}};
+    std::uint8_t crc = depz::crc8_maxim(data);
+    std::printf("depz::crc8_maxim -> 0x%02X\n", static_cast<unsigned>(crc));
+    return 0;
+}

--- a/recipes/depz-sensor-sdk-cpp/config.yml
+++ b/recipes/depz-sensor-sdk-cpp/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.1.0":
+    folder: all

--- a/recipes/depz-sensor-sdk-cpp/config.yml
+++ b/recipes/depz-sensor-sdk-cpp/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.1.3":
+  "0.1.4":
     folder: all

--- a/recipes/depz-sensor-sdk-cpp/config.yml
+++ b/recipes/depz-sensor-sdk-cpp/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.1.0":
+  "0.1.1":
     folder: all

--- a/recipes/depz-sensor-sdk-cpp/config.yml
+++ b/recipes/depz-sensor-sdk-cpp/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.1.1":
+  "0.1.3":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **depz-sensor-sdk-c/0.1.0** and **depz-sensor-sdk-cpp/0.1.0** (two new recipes)

#### Motivation
Adds ConanCenter recipes for the two DEPZ sensor-line SDK libraries, so consumers can pull them via Conan instead of vendoring the sources.

Both are small, dependency-free, MIT-licensed decode/codec libraries for the DEPZ USB sensor line (SR04, VL53L8CX/CH, BNO086): CRCs, packet framing, USB identity, firmware-container parsing and per-sensor wire codecs. Pure codecs, no I/O.

- `depz-sensor-sdk-c` — C11, CMake target `depz::sensor_sdk_c`.
- `depz-sensor-sdk-cpp` — C++17, CMake target `depz::sensor_sdk_cpp` (with legacy alias `depz::sensor_sdk`).

Upstream: https://github.com/depz-ai/depz-sensor-sdk (tag `v0.1.0`).

#### Details
- Each recipe builds only its own subdirectory of the upstream monorepo tarball (`packages/depz-sensor-sdk-c` / `packages/depz-sensor-sdk-cpp`) via `cmake.configure(build_script_folder=...)`. Each subdir has a self-contained `CMakeLists.txt` that installs the lib + headers and exports the namespaced target.
- The package's own test suite (golden-vector harness that needs the monorepo `contracts/vectors/`) is forced OFF through `DEPZ_SENSOR_SDK_C_BUILD_TESTS` / `DEPZ_SENSOR_SDK_CPP_BUILD_TESTS`.
- `static-library` package type; no `shared` option (upstream builds a static archive only). C recipe strips `compiler.cppstd`/`compiler.libcxx` and links `m` on Linux/FreeBSD; C++ recipe enforces C++17 via `check_min_cppstd`.
- The upstream monorepo carries a single top-level MIT `LICENSE`; both recipes package it into `licenses/`.
- Both recipes were validated locally with `conan create` (Conan 2.30, gcc 13, Linux/x86_64): build + `test_package` pass for each.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan