### PR TITLE
Add capnproto/1.4.0

### DIFF
--- a/recipes/capnproto/all/conandata.yml
+++ b/recipes/capnproto/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.4.0":
+    url: "https://github.com/capnproto/capnproto/archive/v1.4.0.tar.gz"
+    sha256: "d14a9149b79c055fee9d5aa778defe8e8cee0d2a11f0729865cd30dcc345eef2"
   "1.3.0":
     url: "https://github.com/capnproto/capnproto/archive/v1.3.0.tar.gz"
     sha256: "01ab2ba7f52fcc3c51a10e22935aae56f3bc5e99b726b7e507fe6700cb12147d"
@@ -9,6 +12,8 @@ sources:
     url: "https://github.com/capnproto/capnproto/archive/v1.0.2.tar.gz"
     sha256: "3cfd0ed58080d78b3a3381305489f2175cdaf1ef1cb55425d8fc8246a76bdff3"
 patches:
+  "1.4.0":
+    - patch_file: "patches/0015-disable-tests-for-1.0.0.patch"
   "1.3.0":
     - patch_file: "patches/0015-disable-tests-for-1.0.0.patch"
       patch_description: "disable test build"

--- a/recipes/capnproto/config.yml
+++ b/recipes/capnproto/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.4.0":
+    folder: all
   "1.3.0":
     folder: all
   "1.1.0":


### PR DESCRIPTION
### Summary
Changes to recipe: **capnproto/1.4.0**

#### Motivation
Add support for capnproto 1.4.0, a security/bugfix release.

#### Details
- Added version 1.4.0 to `conandata.yml` and `config.yml`.
- Reused the existing `0015-disable-tests-for-1.0.0.patch` (no build system changes between 1.3.0 and 1.4.0, so it applies cleanly).
- No changes needed to `conanfile.py`.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
