### PR TITLE
fast-dds-python: new recipe (2.4.1)

### DIFF
--- a/recipes/fast-dds-python/all/conandata.yml
+++ b/recipes/fast-dds-python/all/conandata.yml
@@ -1,0 +1,6 @@
+sources:
+  "2.4.1":
+    url: "https://github.com/eProsima/Fast-DDS-python/archive/refs/tags/v2.4.1.tar.gz"
+    sha256: "e708b1b3517fe40c2e0564a00b0ca413288d84ac3433d08b7bc2f9c01088cce7"
+fastdds_versions:
+  "2.4.1": "3.4.3"

--- a/recipes/fast-dds-python/all/conanfile.py
+++ b/recipes/fast-dds-python/all/conanfile.py
@@ -1,0 +1,110 @@
+import os
+import shutil
+
+from conan import ConanFile
+from conan.errors import ConanException, ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, replace_in_file, rmdir
+
+required_conan_version = ">=2.0.9"
+
+
+class FastDDSPythonConan(ConanFile):
+    name = "fast-dds-python"
+    description = "Python bindings for eProsima Fast DDS, generated with SWIG"
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/eProsima/Fast-DDS-python"
+    topics = ("dds", "middleware", "ipc", "python", "swig")
+    package_type = "shared-library"
+    settings = "os", "arch", "compiler", "build_type"
+    # The SWIG extension module loads the fastdds library dynamically at
+    # import time; linking a static fastdds into the extension is not
+    # supported upstream.
+    default_options = {
+        "fast-dds/*:shared": True,
+        "fast-cdr/*:shared": True,
+    }
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        # Fast DDS <-> Fast DDS python version pairing follows the upstream
+        # RELEASE_SUPPORT.md (e.g. the 2.4.x bindings track fast-dds 3.4.x).
+        self.requires(f"fast-dds/{self.conan_data['fastdds_versions'][self.version]}")
+
+    def validate(self):
+        check_min_cppstd(self, 11)
+        if not self.dependencies["fast-dds"].options.shared:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires fast-dds to be built as a shared library"
+            )
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.24 <5]")
+        self.tool_requires("swig/4.1.0")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        # The SWIG moduleimport preamble references $<TARGET_FILE_NAME:fastdds>,
+        # which cannot be evaluated when fastdds is an imported target coming
+        # from CMakeDeps. Strip the preamble; the loader finds fastdds through
+        # the environment instead.
+        replace_in_file(
+            self,
+            os.path.join(self.source_folder, "fastdds_python", "src", "swig", "fastdds.i"),
+            "moduleimport=\"if __import__('os').name == 'nt': import win32api; win32api.LoadLibrary('$<TARGET_FILE_NAME:fastdds>')",
+            'moduleimport="',
+        )
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure(build_script_folder="fastdds_python")
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        self._relocate_python_module()
+
+    def _relocate_python_module(self):
+        # Upstream installs the module into the build interpreter's purelib
+        # layout relative to the prefix (lib/pythonX.Y/site-packages, or
+        # local/lib/pythonX.Y/dist-packages on Debian-patched interpreters).
+        # Relocate it to a stable path so package_info() does not depend on
+        # the build machine's Python layout.
+        target_root = os.path.join(self.package_folder, "lib", "python")
+        for root, _, files in os.walk(self.package_folder):
+            if os.path.basename(root) == "fastdds" and "__init__.py" in files:
+                origin_parent = os.path.dirname(root)
+                if os.path.normpath(origin_parent) == os.path.normpath(target_root):
+                    return
+                os.makedirs(target_root, exist_ok=True)
+                shutil.move(root, os.path.join(target_root, "fastdds"))
+                # prune the emptied original directory chain
+                while (
+                    os.path.normpath(origin_parent) != os.path.normpath(self.package_folder)
+                    and not os.listdir(origin_parent)
+                ):
+                    os.rmdir(origin_parent)
+                    origin_parent = os.path.dirname(origin_parent)
+                return
+        raise ConanException("fastdds python module not found in the package folder")
+
+    def package_info(self):
+        self.cpp_info.includedirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.bindirs = []
+        self.runenv_info.prepend_path(
+            "PYTHONPATH", os.path.join(self.package_folder, "lib", "python")
+        )

--- a/recipes/fast-dds-python/all/test_package/conanfile.py
+++ b/recipes/fast-dds-python/all/test_package/conanfile.py
@@ -1,0 +1,23 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.layout import basic_layout
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        basic_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def test(self):
+        if can_run(self):
+            python = "python" if self.settings.os == "Windows" else "python3"
+            test_script = os.path.join(self.source_folder, "test.py")
+            self.run(f'{python} "{test_script}"', env="conanrun")

--- a/recipes/fast-dds-python/all/test_package/test.py
+++ b/recipes/fast-dds-python/all/test_package/test.py
@@ -1,0 +1,13 @@
+"""Smoke test for the fastdds python bindings: exercises the SWIG module
+beyond import, without opening any network resources (no participant is
+created)."""
+
+import fastdds
+
+factory = fastdds.DomainParticipantFactory.get_instance()
+assert factory is not None
+
+qos = fastdds.DomainParticipantQos()
+assert qos.name() is not None
+
+print("fastdds python bindings OK")

--- a/recipes/fast-dds-python/config.yml
+++ b/recipes/fast-dds-python/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.4.1":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe: **fast-dds-python/2.4.1** (new recipe)

#### Motivation
Python bindings for eProsima Fast DDS — the companion package to the existing `fast-dds` and `fast-dds-gen` recipes. Upstream: https://github.com/eProsima/Fast-DDS-python. There is currently no way to consume these bindings through Conan; we have been maintaining this recipe in-house and would like to contribute it.

#### Details
Design decisions, flagged for maintainer input since there is little precedent for Python-module packages in CCI:

1. **Artifact**: a SWIG-generated extension module plus its `__init__.py`, importable as `fastdds`. Built against the build machine's Python 3 (found by CMake's `FindPython3`), same approach as `opengv`'s optional bindings.
2. **Install layout**: upstream computes its install destination from the build interpreter's `sysconfig` purelib layout (2.4.1 pins the `posix_prefix` scheme on non-Windows; older releases inherited distribution-dependent layouts such as Debian's `local/lib/pythonX.Y/dist-packages`). The recipe relocates the module to a stable `lib/python/` inside the package regardless, and exposes it via `runenv_info` `PYTHONPATH` (the `opengv` pattern).
3. **`fast-dds` must be shared**: the extension loads `fastdds` dynamically at import time; a static fastdds inside the extension is not supported upstream. Enforced via `default_options` on the dependency plus a `validate()` check.
4. **SWIG interface fix**: the upstream `moduleimport` preamble references `$<TARGET_FILE_NAME:fastdds>`, which is never expanded when `fastdds` is a CMakeDeps imported target; the recipe strips it with `replace_in_file` (loader path comes from the run environment instead).
5. **Version pairing**: the fast-dds <-> fast-dds-python compatibility matrix comes from the upstream [RELEASE_SUPPORT.md](https://github.com/eProsima/Fast-DDS-python/blob/main/RELEASE_SUPPORT.md) (2.4.x tracks fast-dds 3.4.x; the newest 2.6.x tracks fast-dds 3.6.x, which is not yet on ConanCenter). The pairing is encoded as a `fastdds_versions` map in `conandata.yml` — the same pattern the `fast-dds-gen` recipe uses — consumed by `requirements()`, so adding a future version is a pure conandata change. 2.4.1 is the newest release of the 2.4.x line.
6. **Test package**: runs a small `test.py` that goes beyond a bare import — it obtains the `DomainParticipantFactory` singleton and constructs/queries a `DomainParticipantQos` — without creating a participant, so no sockets or network resources are involved.

Depends on the `fast-dds/3.4.3` version-add PR: #30572 (this recipe requires `fast-dds/3.4.3`).

Tested locally with Conan 2.24.0 on Linux/gcc14: `conan create` builds 2.4.1 against `fast-dds/3.4.3` and the test package passes.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan
