### PR TITLE
libtiff: add version 4.7.2 (#30576)

### DIFF
--- a/recipes/libtiff/all/conandata.yml
+++ b/recipes/libtiff/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.7.2":
+    url: "https://download.osgeo.org/libtiff/tiff-4.7.2.tar.xz"
+    sha256: "4996f0c4f93094719b1ca5c6279b20e588773ba8a247533e486416fb662ddb88"
   "4.7.1":
     url: "https://download.osgeo.org/libtiff/tiff-4.7.1.tar.xz"
     sha256: "b92017489bdc1db3a4c97191aa4b75366673cb746de0dce5d7a749d5954681ba"
@@ -9,6 +12,10 @@ sources:
     url: "https://download.osgeo.org/libtiff/tiff-4.6.0.tar.gz"
     sha256: "88b3979e6d5c7e32b50d7ec72fb15af724f6ab2cbf7e10880c360a77e4b5d99a"
 patches:
+  "4.7.2":
+    - patch_file: "patches/4.7.2-0001-cmake-dependencies.patch"
+      patch_description: "CMake: robust handling of dependencies"
+      patch_type: "conan"
   "4.7.1":
     - patch_file: "patches/4.7.1-0001-cmake-dependencies.patch"
       patch_description: "CMake: robust handling of dependencies"

--- a/recipes/libtiff/all/patches/4.7.2-0001-cmake-dependencies.patch
+++ b/recipes/libtiff/all/patches/4.7.2-0001-cmake-dependencies.patch
@@ -1,0 +1,68 @@
+diff --git a/cmake/JBIGCodec.cmake b/cmake/JBIGCodec.cmake
+index a435002..4cb0155 100644
+--- a/cmake/JBIGCodec.cmake
++++ b/cmake/JBIGCodec.cmake
+@@ -34,7 +34,7 @@ if(JBIG_FOUND)
+     set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES} ${JBIG_INCLUDE_DIRS})
+     set(CMAKE_REQUIRED_LIBRARIES_SAVE ${CMAKE_REQUIRED_LIBRARIES})
+     set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} ${JBIG_LIBRARIES})
+-    check_symbol_exists(jbg_newlen "jbig.h" HAVE_JBG_NEWLEN)
++    set(HAVE_JBG_NEWLEN TRUE)
+     set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES_SAVE})
+     set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES_SAVE})
+ endif()
+diff --git a/cmake/JPEGCodec.cmake b/cmake/JPEGCodec.cmake
+index 2a26c43..63d6c04 100644
+--- a/cmake/JPEGCodec.cmake
++++ b/cmake/JPEGCodec.cmake
+@@ -94,36 +94,6 @@ endif()
+ if (JPEG_SUPPORT)
+     # Check for jpeg12_read_scanlines() which has been added in libjpeg-turbo 3.0
+     # for dual 8/12 bit mode.
+-    include(CheckSymbolExists)
+-    include(CMakePushCheckState)
+-    cmake_push_check_state(RESET)
+-
+-    # Set up includes and libraries for the check
+-    # For targets, we need to explicitly get the include directories
+-    if(TARGET ${JPEG_LIBRARIES})
+-        # It's an imported target - extract properties
+-        get_target_property(_jpeg_includes ${JPEG_LIBRARIES} INTERFACE_INCLUDE_DIRECTORIES)
+-        if(_jpeg_includes)
+-            set(CMAKE_REQUIRED_INCLUDES "${_jpeg_includes}")
+-        endif()
+-        unset(_jpeg_includes)
+-    elseif(JPEG_INCLUDE_DIRS)
+-        # It's a plain library - use the provided includes
+-        set(CMAKE_REQUIRED_INCLUDES "${JPEG_INCLUDE_DIRS}")
+-    endif()
+-
+-    set(CMAKE_REQUIRED_LIBRARIES "${JPEG_LIBRARIES}")
+-
+-    # Check if the jpeg12_read_scanlines symbol exists in jpeglib.h
+-    # This is more reliable than trying to compile code that calls it
+-    check_symbol_exists(jpeg_read_scanlines "stdio.h;jpeglib.h" HAVE_JPEGTURBO_DUAL_MODE_8)
+-    check_symbol_exists(jpeg12_read_scanlines "stdio.h;jpeglib.h" HAVE_JPEGTURBO_DUAL_MODE_12)
+-    set(HAVE_JPEGTURBO_DUAL_MODE_8_12 OFF)
+-    if (HAVE_JPEGTURBO_DUAL_MODE_8 AND HAVE_JPEGTURBO_DUAL_MODE_12)
+-        set(HAVE_JPEGTURBO_DUAL_MODE_8_12 ON)
+-    endif()
+-
+-    cmake_pop_check_state()
+ endif()
+ 
+ if (NOT HAVE_JPEGTURBO_DUAL_MODE_8_12)
+diff --git a/cmake/LZMACodec.cmake b/cmake/LZMACodec.cmake
+index c51afe8..53ef874 100644
+--- a/cmake/LZMACodec.cmake
++++ b/cmake/LZMACodec.cmake
+@@ -28,7 +28,7 @@
+ set(LZMA_SUPPORT FALSE)
+ find_package(liblzma)
+ 
+-option(lzma "use liblzma (required for LZMA2 compression)" ${LIBLZMA_FOUND})
+-if (lzma AND LIBLZMA_FOUND)
++option(lzma "use liblzma (required for LZMA2 compression)" ${liblzma_FOUND})
++if (lzma AND liblzma_FOUND)
+     set(LZMA_SUPPORT TRUE)
+ endif()

--- a/recipes/libtiff/config.yml
+++ b/recipes/libtiff/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.7.2":
+    folder: all
   "4.7.1":
     folder: all
   "4.7.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **libtiff/4.7.2**, closes #30576

#### Motivation

New version comes with several bugfixes.

#### Details
Added 4.7.2 in `conandata.yml` and in `config.yml`. Had to recreate the patch that allows injecting the option for jpeg-turbo as this was reworked upstream in [this merge request](https://gitlab.com/libtiff/libtiff/-/merge_requests/806/diffs). I tested the build on MacOS with default options and with `-o "libtiff/*:jpeg=libjpeg-turbo"`. Both compiled successfully. 

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
