### PR TITLE
chess-engine/1.0.0: new recipe

### DIFF
--- a/recipes/chess-engine/all/conandata.yml
+++ b/recipes/chess-engine/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.0.0":
+    url: "https://github.com/ByteMe6/chess-engine/archive/refs/tags/v1.0.0.tar.gz"
+    sha256: "860a8455095e97393a7244074e5358a3d0904e5502a8bff86d59638307d8f295"

--- a/recipes/chess-engine/all/conanfile.py
+++ b/recipes/chess-engine/all/conanfile.py
@@ -1,0 +1,41 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+
+required_conan_version = ">=1.52.0"
+
+
+class ChessEngineConan(ConanFile):
+    name = "chess-engine"
+    description = "Minimal header-only chess engine in C++17 - move generation, validation and ASCII board rendering. STL only."
+    license = "GPL-3.0-only"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/ByteMe6/chess-engine"
+    topics = ("chess", "board-game", "fen", "header-only")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, 17)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        copy(self, "chessEngine.hpp", os.path.join(self.source_folder, "src"), os.path.join(self.package_folder, "include"))
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/chess-engine/all/test_package/CMakeLists.txt
+++ b/recipes/chess-engine/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(chess-engine REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE chess-engine::chess-engine)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/chess-engine/all/test_package/conanfile.py
+++ b/recipes/chess-engine/all/test_package/conanfile.py
@@ -1,0 +1,27 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/chess-engine/all/test_package/test_package.cpp
+++ b/recipes/chess-engine/all/test_package/test_package.cpp
@@ -1,0 +1,8 @@
+#include <chessEngine.hpp>
+
+int main() {
+    Board board("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+    board.makeMove("e2", "e4");
+    std::cout << board.toFen() << std::endl;
+    return 0;
+}

--- a/recipes/chess-engine/config.yml
+++ b/recipes/chess-engine/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.0.0":
+    folder: all


### PR DESCRIPTION
Specify library name and version: **chess-engine/1.0.0**

New recipe for [chess-engine](https://github.com/ByteMe6/chess-engine) — a minimal header-only chess engine in C++17: move generation, validation, check/mate/stalemate, castling, en passant, promotion, draw rules, FEN import/export and ASCII board rendering. No dependencies beyond the STL.

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've followed the [PR guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/developing_recipes_locally.md).
