### PR TITLE
Add patch to allow building in debug mode on most recent MSVC

### DIFF
--- a/recipes/soplex/all/conandata.yml
+++ b/recipes/soplex/all/conandata.yml
@@ -35,3 +35,7 @@ sources:
   "6.0.3":
     url: "https://github.com/scipopt/soplex/archive/refs/tags/release-603.tar.gz"
     sha256: "2bdf9adc9ac6ad48f98056679b7b852e626ac4aaaf277e7d4ce17794ed1097be"
+patches:
+  "8.0.2":
+    - patch_file: "patches/format_msvc_stdext.patch"
+      patch_description: "Remove usage of stdext when building with MSVC 1915 or higher, see https://github.com/scipopt/soplex/issues/52"

--- a/recipes/soplex/all/conandata.yml
+++ b/recipes/soplex/all/conandata.yml
@@ -2,40 +2,6 @@ sources:
   "8.0.2":
     url: "https://github.com/scipopt/soplex/archive/refs/tags/v8.0.2.tar.gz"
     sha256: "9304fd377e506b380c6b234f6aec221bfc8754541e9ad5f5584f5fbb786a8392"
-  "8.0.1":
-    url: "https://github.com/scipopt/soplex/archive/refs/tags/v8.0.1.tar.gz"
-    sha256: "f989f650e0d489f4e84037af2a50b1d0928f62ab79179ef566111d9197c2b6c8"
-  "8.0.0":
-    url: "https://github.com/scipopt/soplex/archive/refs/tags/v8.0.0.tar.gz"
-    sha256: "59828f88843ff5fd0adddbecf39a84c8a883b47dc26527bc4dedd2a4b98af07c"
-  "7.1.6":
-    url: "https://github.com/scipopt/soplex/archive/refs/tags/release-716.tar.gz"
-    sha256: "f031d60e7ad9a575393b04083c2914fb71a9886ba70ae77931c5a46c76b85ae4"
-  "7.1.5":
-    url: "https://github.com/scipopt/soplex/archive/refs/tags/release-715.tar.gz"
-    sha256: "e6e3998c0215120e452c4298d29bfad71c9dfb7f904a01f04c7919086248c130"
-  "7.1.2":
-    url: "https://github.com/scipopt/soplex/archive/refs/tags/release-712.tar.gz"
-    sha256: "a1a7d7f7e30d1db65548b32f75d6f2ed9bd0bf289f639eb4481d3d141c67a332"
-  "7.1.1":
-    url: "https://github.com/scipopt/soplex/archive/refs/tags/release-711.tar.gz"
-    sha256: "75752dca395e219e350f3b462f1f4c08e9d3c2deb2782414862f546a9489cdeb"
-  "7.1.0":
-    url: "https://github.com/scipopt/soplex/archive/refs/tags/release-710.tar.gz"
-    sha256: "ec177fdb688346287d5f211dd7ec4a0195c8ec9b3a5314d38aca383b6fa1418e"
-  "7.0.1":
-    url: "https://github.com/scipopt/soplex/archive/refs/tags/release-701.tar.gz"
-    sha256: "80cce994dcbe45fd52b60e31a3aeb5d2c60a7ddbaae495e0ce6bf58481675696"
-  "7.0.0":
-    url: "https://github.com/scipopt/soplex/archive/refs/tags/release-700.tar.gz"
-    sha256: "ab1906d3afb1793a6f129a5baef9dd8eee929ee945aade427cb9f0b17888239c"
-  "6.0.4":
-    url: "https://github.com/scipopt/soplex/archive/refs/tags/release-604.tar.gz"
-    sha256: "691f5b593cb85c2586522d5de5a5a7692958d22ff1ddffb4fc395f4696590b6f"
-  "6.0.3":
-    url: "https://github.com/scipopt/soplex/archive/refs/tags/release-603.tar.gz"
-    sha256: "2bdf9adc9ac6ad48f98056679b7b852e626ac4aaaf277e7d4ce17794ed1097be"
 patches:
   "8.0.2":
     - patch_file: "patches/format_msvc_stdext.patch"
-      patch_description: "Remove usage of stdext when building with MSVC 1915 or higher, see https://github.com/scipopt/soplex/issues/52"

--- a/recipes/soplex/all/conanfile.py
+++ b/recipes/soplex/all/conanfile.py
@@ -3,7 +3,7 @@ from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import collect_libs, copy, get
+from conan.tools.files import collect_libs, copy, get, apply_conandata_patches, export_conandata_patches
 from conan.tools.scm import Version
 from os.path import join
 
@@ -75,6 +75,9 @@ class SoPlexConan(ConanFile):
         if self.options.with_boost:
             self.requires("boost/1.84.0", transitive_headers=True)  # also update Boost_VERSION_MACRO below!
 
+    def export_sources(self):
+        export_conandata_patches(self)
+
     def validate(self):
         if self.settings.compiler.cppstd:
             check_min_cppstd(self, self._min_cppstd)
@@ -89,6 +92,7 @@ class SoPlexConan(ConanFile):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
+        apply_conandata_patches(self)
         tc = CMakeToolchain(self)
         tc.variables["MPFR"] = False
         tc.variables["GMP"] = self.options.with_gmp

--- a/recipes/soplex/all/conanfile.py
+++ b/recipes/soplex/all/conanfile.py
@@ -1,13 +1,12 @@
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import collect_libs, copy, get, apply_conandata_patches, export_conandata_patches
-from conan.tools.scm import Version
-from os.path import join
+from conan.tools.files import (collect_libs, copy, get, apply_conandata_patches,
+                               export_conandata_patches, replace_in_file)
+import os
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2"
 
 
 class SoPlexConan(ConanFile):
@@ -31,20 +30,6 @@ class SoPlexConan(ConanFile):
         "with_boost": True,
         "with_gmp": True,
     }
-
-    @property
-    def _min_cppstd(self):
-        return 14
-
-    @property
-    def _compilers_minimum_version(self):
-        return {
-            "gcc": "5",
-            "clang": "4",
-            "apple-clang": "7",
-            "msvc": "191",
-            "Visual Studio": "15",
-        }
 
     def _determine_lib_name(self):
         if self.options.shared:
@@ -79,17 +64,11 @@ class SoPlexConan(ConanFile):
         export_conandata_patches(self)
 
     def validate(self):
-        if self.settings.compiler.cppstd:
-            check_min_cppstd(self, self._min_cppstd)
-
-        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
-        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
-            raise ConanInvalidConfiguration(
-                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
-            )
+        check_min_cppstd(self, 14)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"), "set(CMAKE_CXX_STANDARD", "##")
 
     def generate(self):
         apply_conandata_patches(self)
@@ -111,21 +90,25 @@ class SoPlexConan(ConanFile):
         cmake.build(target=f"lib{self._determine_lib_name()}")
 
     def package(self):
-        copy(self, pattern="LICENSE", src=self.source_folder, dst=join(self.package_folder, "licenses"))
-        copy(self, pattern="soplex.h", src=join(self.source_folder, "src"), dst=join(self.package_folder, "include"))
-        copy(self, pattern="soplex.hpp", src=join(self.source_folder, "src"), dst=join(self.package_folder, "include"))
-        copy(self, pattern="soplex_interface.h", src=join(self.source_folder, "src"), dst=join(self.package_folder, "include"))
-        copy(self, pattern="*.h", src=join(self.source_folder, "src", "soplex"), dst=join(self.package_folder, "include", "soplex"))
-        copy(self, pattern="*.hpp", src=join(self.source_folder, "src", "soplex"), dst=join(self.package_folder, "include", "soplex"))
-        copy(self, pattern="*.h", src=join(self.build_folder, "soplex"), dst=join(self.package_folder, "include", "soplex"))
-        copy(self, pattern="*.lib", src=join(self.build_folder, "lib"), dst=join(self.package_folder, "lib"), keep_path=False)
+        src_folder = os.path.join(self.source_folder, "src")
+        include_folder = os.path.join(self.package_folder, "include")
+        build_lib_folder = os.path.join(self.build_folder, "lib")
+        pkg_lib_folder = os.path.join(self.package_folder, "lib")
+        copy(self, pattern="LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, pattern="soplex.h", src=src_folder, dst=include_folder)
+        copy(self, pattern="soplex.hpp", src=src_folder, dst=include_folder)
+        copy(self, pattern="soplex_interface.h", src=src_folder, dst=include_folder)
+        copy(self, pattern="*.h", src=os.path.join(src_folder, "soplex"), dst=os.path.join(include_folder, "soplex"))
+        copy(self, pattern="*.hpp", src=os.path.join(src_folder, "soplex"), dst=os.path.join(include_folder, "soplex"))
+        copy(self, pattern="*.h", src=os.path.join(self.build_folder, "soplex"), dst=os.path.join(include_folder, "soplex"))
+        copy(self, pattern="*.lib", src=build_lib_folder, dst=pkg_lib_folder, keep_path=False)
         if self.options.shared:
-            copy(self, pattern="*.so*", src=join(self.build_folder, "lib"), dst=join(self.package_folder, "lib"), keep_path=False)
-            copy(self, pattern="*.dylib*", src=join(self.build_folder, "lib"), dst=join(self.package_folder, "lib"), keep_path=False)
-            copy(self, pattern="*.dll", src=join(self.build_folder, "bin"), dst=join(self.package_folder, "bin"), keep_path=False)
-            copy(self, pattern="*.dll.a", src=join(self.build_folder, "lib"), dst=join(self.package_folder, "lib"), keep_path=False)
+            copy(self, pattern="*.so*", src=build_lib_folder, dst=pkg_lib_folder, keep_path=False)
+            copy(self, pattern="*.dylib*", src=build_lib_folder, dst=pkg_lib_folder, keep_path=False)
+            copy(self, pattern="*.dll", src=os.path.join(self.build_folder, "bin"), dst=os.path.join(self.package_folder, "bin"), keep_path=False)
+            copy(self, pattern="*.dll.a", src=build_lib_folder, dst=pkg_lib_folder, keep_path=False)
         else:
-            copy(self, pattern="*.a", src=join(self.build_folder, "lib"), dst=join(self.package_folder, "lib"), keep_path=False)
+            copy(self, pattern="*.a", src=build_lib_folder, dst=pkg_lib_folder, keep_path=False)
         fix_apple_shared_install_name(self)
 
     def package_info(self):

--- a/recipes/soplex/all/conanfile.py
+++ b/recipes/soplex/all/conanfile.py
@@ -69,9 +69,9 @@ class SoPlexConan(ConanFile):
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
         replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"), "set(CMAKE_CXX_STANDARD", "##")
+        apply_conandata_patches(self)
 
     def generate(self):
-        apply_conandata_patches(self)
         tc = CMakeToolchain(self)
         tc.variables["MPFR"] = False
         tc.variables["GMP"] = self.options.with_gmp

--- a/recipes/soplex/all/patches/format_msvc_stdext.patch
+++ b/recipes/soplex/all/patches/format_msvc_stdext.patch
@@ -1,0 +1,13 @@
+diff --git a/src/soplex/external/fmt/format.h b/src/soplex/external/fmt/format.h
+index a51ba231..3b7b4db8 100644
+--- a/src/soplex/external/fmt/format.h
++++ b/src/soplex/external/fmt/format.h
+@@ -354,7 +354,7 @@ inline typename Container::value_type* get_data(Container& c) {
+   return c.data();
+ }
+
+-#if defined(_SECURE_SCL) && _SECURE_SCL
++#if defined(_SECURE_SCL) && (!defined(_MSC_VER) || _MSC_VER < 1915)
+ // Make a checked iterator to avoid MSVC warnings.
+ template <typename T> using checked_ptr = stdext::checked_array_iterator<T*>;
+ template <typename T> checked_ptr<T> make_checked(T* p, size_t size) {

--- a/recipes/soplex/all/patches/format_msvc_stdext.patch
+++ b/recipes/soplex/all/patches/format_msvc_stdext.patch
@@ -7,7 +7,7 @@ index a51ba231..3b7b4db8 100644
  }
 
 -#if defined(_SECURE_SCL) && _SECURE_SCL
-+#if defined(_SECURE_SCL) && (!defined(_MSC_VER) || _MSC_VER < 1915)
++#if defined(_SECURE_SCL) && (!defined(_MSC_VER) || _MSC_VER < 1951)
  // Make a checked iterator to avoid MSVC warnings.
  template <typename T> using checked_ptr = stdext::checked_array_iterator<T*>;
  template <typename T> checked_ptr<T> make_checked(T* p, size_t size) {

--- a/recipes/soplex/all/patches/format_msvc_stdext.patch
+++ b/recipes/soplex/all/patches/format_msvc_stdext.patch
@@ -1,13 +1,19 @@
+From 74c544ecc3e665f996e7ee76ed3468bc175773bf Mon Sep 17 00:00:00 2001
+Date: Fri, 17 Jul 2026 16:26:52 +0200
+Subject: [PATCH] Fix windows array
+
+---
 diff --git a/src/soplex/external/fmt/format.h b/src/soplex/external/fmt/format.h
-index a51ba231..3b7b4db8 100644
+index a51ba231..6ab0a651 100644
 --- a/src/soplex/external/fmt/format.h
 +++ b/src/soplex/external/fmt/format.h
-@@ -354,7 +354,7 @@ inline typename Container::value_type* get_data(Container& c) {
+@@ -354,7 +354,8 @@ inline typename Container::value_type* get_data(Container& c) {
    return c.data();
  }
-
+ 
 -#if defined(_SECURE_SCL) && _SECURE_SCL
-+#if defined(_SECURE_SCL) && (!defined(_MSC_VER) || _MSC_VER < 1951)
++// stdext::checked_array_iterator removed with MSVC 14.51
++#if defined(_SECURE_SCL) && _SECURE_SCL && (!defined(_MSC_VER) || _MSC_VER < 1951)
  // Make a checked iterator to avoid MSVC warnings.
  template <typename T> using checked_ptr = stdext::checked_array_iterator<T*>;
  template <typename T> checked_ptr<T> make_checked(T* p, size_t size) {

--- a/recipes/soplex/all/test_package/CMakeLists.txt
+++ b/recipes/soplex/all/test_package/CMakeLists.txt
@@ -1,17 +1,7 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.15)
 project(test_package CXX)
-set(CMAKE_CXX_STANDARD 14)
 
 find_package(soplex REQUIRED CONFIG)
-# work around v1 legacy generators always having namespaces
-if(TARGET soplex::soplex)
-   add_library(soplex INTERFACE IMPORTED)
-   set_target_properties(soplex PROPERTIES INTERFACE_LINK_LIBRARIES soplex::soplex)
-endif()
-
-if (MSVC)
-   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
-endif ()
 
 add_executable(${PROJECT_NAME} main.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE soplex)

--- a/recipes/soplex/all/test_package/conanfile.py
+++ b/recipes/soplex/all/test_package/conanfile.py
@@ -7,7 +7,6 @@ import os
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
-    test_type = "explicit"
 
     def requirements(self):
         self.requires(self.tested_reference_str)

--- a/recipes/soplex/config.yml
+++ b/recipes/soplex/config.yml
@@ -1,25 +1,3 @@
 versions:
   "8.0.2":
     folder: all
-  "8.0.1":
-    folder: all
-  "8.0.0":
-    folder: all
-  "7.1.6":
-    folder: all
-  "7.1.5":
-    folder: all
-  "7.1.2":
-    folder: all
-  "7.1.1":
-    folder: all
-  "7.1.0":
-    folder: all
-  "7.0.1":
-    folder: all
-  "7.0.0":
-    folder: all
-  "6.0.4":
-    folder: all
-  "6.0.3":
-    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **soplex/8.0.2**

#### Motivation
Building in debug mode with most recent version of MSVC fails.

#### Details
soplex includes a copy of fmt, therein `stdext` is used, this was removed in the most recent version of MSVC. see upstream: https://github.com/scipopt/soplex/issues/52

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
