### PR TITLE
Fixed using of easylogging++ with perfomance feature

### DIFF
--- a/recipes/easyloggingpp/all/conanfile.py
+++ b/recipes/easyloggingpp/all/conanfile.py
@@ -24,7 +24,7 @@ class EasyloggingppConan(ConanFile):
         "enable_thread_safe": [True, False],
         "enable_debug_errors": [True, False],
         "enable_default_logfile": [True, False],
-        "enable_perfomance_tracking": [True, False],
+        "enable_performance_tracking": [True, False],
         "disable_logs": [True, False],
         "disable_debug_logs": [True, False],
         "disable_info_logs": [True, False],

--- a/recipes/easyloggingpp/all/conanfile.py
+++ b/recipes/easyloggingpp/all/conanfile.py
@@ -24,6 +24,7 @@ class EasyloggingppConan(ConanFile):
         "enable_thread_safe": [True, False],
         "enable_debug_errors": [True, False],
         "enable_default_logfile": [True, False],
+        "enable_perfomance_tracking": [True, False],
         "disable_logs": [True, False],
         "disable_debug_logs": [True, False],
         "disable_info_logs": [True, False],
@@ -40,6 +41,7 @@ class EasyloggingppConan(ConanFile):
         "enable_thread_safe": False,
         "enable_debug_errors": False,
         "enable_default_logfile": True,
+        "enable_performance_tracking": False,
         "disable_logs": False,
         "disable_debug_logs": False,
         "disable_info_logs": False,
@@ -75,6 +77,8 @@ class EasyloggingppConan(ConanFile):
             defines.append("ELPP_DEBUG_ERRORS")
         if not self.options.enable_default_logfile:
             defines.append("ELPP_NO_DEFAULT_LOG_FILE")
+        if self.options.enable_performance_tracking:
+            defines.append("ELPP_FEATURE_PERFORMANCE_TRACKING")
         if self.options.disable_logs:
             defines.append("ELPP_DISABLE_LOGS")
         if self.options.disable_debug_logs:


### PR DESCRIPTION
If macro ELPP_FEATURE_PERFORMANCE_TRACKING is not defined then PerformanceTracker class is not compiled to the library


### Summary
Changes to recipe:  easyloggingpp/9.97.1

#### Motivation
Easylogging++ library has compile time features. If we need to use perfomance tracking feature then define ELPP_FEATURE_PERFORMANCE_TRACKING should be set during library compilation.
```
#if defined(ELPP_FEATURE_ALL) || defined(ELPP_FEATURE_PERFORMANCE_TRACKING)

PerformanceTracker::PerformanceTracker(const std::string& blockName,
```
This PR adds enable_perfomance_tracking option to enable performance tracking feature.

Link to the bug https://github.com/conan-io/conan-center-index/issues/30585

#### Details
Option added to the conanfile.py and set ELPP_FEATURE_PERFORMANCE_TRACKING when it set to True.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan
