### PR TITLE
fast-dds-gen: unique package_id; fix test_package requires context

### DIFF
--- a/recipes/fast-dds-gen/all/conanfile.py
+++ b/recipes/fast-dds-gen/all/conanfile.py
@@ -14,7 +14,6 @@ class FastDdsGenConan(ConanFile):
     homepage = "https://github.com/eProsima/Fast-DDS-Gen"
     url = "https://github.com/conan-io/conan-center-index"
     topics = ("idl", "code-generation", "fastdds")
-
     package_type = "application"
     settings = "os", "arch"
 
@@ -26,6 +25,9 @@ class FastDdsGenConan(ConanFile):
 
     def requirements(self):
         self.requires("openjdk/19.0.2")
+
+    def package_id(self):
+        self.info.clear()
 
     def build_requirements(self):
         self.tool_requires("openjdk/<host_version>")

--- a/recipes/fast-dds-gen/all/test_package/conanfile.py
+++ b/recipes/fast-dds-gen/all/test_package/conanfile.py
@@ -5,8 +5,8 @@ from conan.tools.build import can_run
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
 
-    def build_requirements(self):
-        self.tool_requires(self.tested_reference_str)
+    def requirements(self):
+        self.requires(self.tested_reference_str, run=True)
 
     def test(self):
         if can_run(self):

--- a/recipes/fast-dds-gen/all/test_package/conanfile.py
+++ b/recipes/fast-dds-gen/all/test_package/conanfile.py
@@ -4,10 +4,11 @@ from conan.tools.build import can_run
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
+    generators = "VirtualRunEnv"
 
     def requirements(self):
         self.requires(self.tested_reference_str, run=True)
 
     def test(self):
         if can_run(self):
-            self.run("fastddsgen -version")
+            self.run("fastddsgen -version", env="conanrun")


### PR DESCRIPTION
### Summary
Changes to recipe:  **fast-dds-gen/***

#### Motivation
* test_package was not requiring the correct package_id when cross-building context
* Checked upstream (scripts/ in Fast-DDS-Gen v4.2.0): it contains _fastddsgen_ (unix), _fastddsgen.bat_ (windows), and _fastddsgen.in_. `package()` copies all of them unconditionally (`copy(self, "*", src=.../scripts, ...)`) — there's no if `self.settings.os == "Windows"`  branch. So the package for a Windows target and a Linux target contains the exact same files.
