### PR TITLE
xkbcommon: set pkg_config_name to something other than "none"

### DIFF
--- a/recipes/xkbcommon/all/conanfile.py
+++ b/recipes/xkbcommon/all/conanfile.py
@@ -132,4 +132,4 @@ class XkbcommonConan(ConanFile):
             self.cpp_info.components["xkbcli-interactive-wayland"].includedirs = []
             self.cpp_info.components["xkbcli-interactive-wayland"].requires = ["wayland::wayland-client"]
 
-        self.cpp_info.set_property("pkg_config_name", "none")
+        self.cpp_info.set_property("pkg_config_name", "xkbcommon_all_do_not_use")


### PR DESCRIPTION
Closes: https://github.com/conan-io/conan-center-index/issues/30526
Related to: https://github.com/conan-io/conan-center-index/pull/29379, https://github.com/conan-io/conan/pull/18439

If any dependency requires `xkbcommon::xkbcommon` and uses PkgConfigDeps as a generator downstream, it'll raise an error because that transitive requirement will require a non-existing `none.pc`. Maybe all the recipes doing that should require the `xkbcommon::libxkbcommon`, but let's keep it as it was till we have a better solution for this.