### PR TITLE
minizip: add GitHub mirror for source download

### DIFF
--- a/recipes/minizip/all/conandata.yml
+++ b/recipes/minizip/all/conandata.yml
@@ -1,9 +1,13 @@
 sources:
   "1.3.2":
-    url: "https://zlib.net/fossils/zlib-1.3.2.tar.gz"
+    url:
+      - "https://zlib.net/fossils/zlib-1.3.2.tar.gz"
+      - "https://github.com/madler/zlib/releases/download/v1.3.2/zlib-1.3.2.tar.gz"
     sha256: "bb329a0a2cd0274d05519d61c667c062e06990d72e125ee2dfa8de64f0119d16"
   "1.2.13":
-    url: "https://zlib.net/fossils/zlib-1.2.13.tar.gz"
+    url:
+      - "https://zlib.net/fossils/zlib-1.2.13.tar.gz"
+      - "https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz"
     sha256: "b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30"
 patches:
   "1.2.13":


### PR DESCRIPTION
### Summary

Adds the official `madler/zlib` GitHub release assets as a mirror URL for minizip's source download (minizip is built from zlib's `contrib/minizip`, so its source *is* the zlib tarball).

### Motivation

`zlib.net` rejects requests from datacenter/CI IP ranges — GitHub Actions runners consistently get **HTTP 415** on `https://zlib.net/fossils/zlib-1.2.13.tar.gz` (it answers 200 from residential IPs). Any CI that builds `minizip/*` from source is therefore flaky or hard-broken. The `zlib` recipe already lists the GitHub release asset as its second URL for exactly this reason; this PR brings `minizip`'s conandata in line with it.

Both mirror assets verified byte-identical to the sha256 already pinned in conandata:

- `zlib-1.2.13.tar.gz` → `b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30`
- `zlib-1.3.2.tar.gz` → `bb329a0a2cd0274d05519d61c667c062e06990d72e125ee2dfa8de64f0119d16`

No recipe logic, options, or hashes change — URL list only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfZRP8RJpLQBLJqbhFC4Gb