### PR TITLE
rsync/3.2.7: honor $(STRIP) in install-strip for cross-compilation

### DIFF
--- a/recipes/rsync/all/conandata.yml
+++ b/recipes/rsync/all/conandata.yml
@@ -2,3 +2,9 @@ sources:
   "3.2.7":
     url: "https://download.samba.org/pub/rsync/src/rsync-3.2.7.tar.gz"
     sha256: "4e7d9d3f6ed10878c58c5fb724a67dacf4b6aac7340b13e488fb2dc41346f2bb"
+patches:
+  "3.2.7":
+    - patch_file: "patches/0001-install-strip-honor-strip-program.patch"
+      patch_description: "install-strip: strip with --strip-program=$(STRIP) so cross-compiled binaries use the cross strip instead of the host strip"
+      patch_type: "portability"
+      patch_source: "https://github.com/RsyncProject/rsync/pull/1024"

--- a/recipes/rsync/all/conandata.yml
+++ b/recipes/rsync/all/conandata.yml
@@ -5,6 +5,6 @@ sources:
 patches:
   "3.2.7":
     - patch_file: "patches/0001-install-strip-honor-strip-program.patch"
-      patch_description: "install-strip: strip with --strip-program=$(STRIP) so cross-compiled binaries use the cross strip instead of the host strip"
+      patch_description: "install-strip: install then strip the binary with $(STRIP) (honoring the toolchain strip, defaulting to strip) so cross-compiled binaries use the cross strip instead of the host strip"
       patch_type: "portability"
       patch_source: "https://github.com/RsyncProject/rsync/pull/1024"

--- a/recipes/rsync/all/conanfile.py
+++ b/recipes/rsync/all/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.gnu import Autotools, AutotoolsToolchain, AutotoolsDeps
-from conan.tools.files import copy, get, rmdir
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
 from conan.tools.layout import basic_layout
 from conan.tools.apple import is_apple_os
 import os
@@ -36,6 +36,9 @@ class RsyncConan(ConanFile):
     }
     languages = "C"
 
+    def export_sources(self):
+        export_conandata_patches(self)
+
     def configure(self):
         self.settings.rm_safe("compiler.libcxx")
         self.settings.rm_safe("compiler.cppstd")
@@ -45,6 +48,7 @@ class RsyncConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
 
     def package_id(self):
         del self.info.settings.compiler

--- a/recipes/rsync/all/patches/0001-install-strip-honor-strip-program.patch
+++ b/recipes/rsync/all/patches/0001-install-strip-honor-strip-program.patch
@@ -1,0 +1,10 @@
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -100,6 +100,6 @@
+ install-all: install install-ssl-daemon
+ 
+ install-strip:
+-	$(MAKE) INSTALL_STRIP='-s' install
++	$(MAKE) INSTALL_STRIP='-s --strip-program=$(or $(STRIP),strip)' install
+ 
+ rsync$(EXEEXT): $(OBJS)

--- a/recipes/rsync/all/patches/0001-install-strip-honor-strip-program.patch
+++ b/recipes/rsync/all/patches/0001-install-strip-honor-strip-program.patch
@@ -1,10 +1,20 @@
 --- a/Makefile.in
 +++ b/Makefile.in
-@@ -100,6 +100,6 @@
+@@ -21,6 +21,7 @@
+ 
+ INSTALLCMD=@INSTALL@
+ INSTALLMAN=@INSTALL@
++STRIP ?= strip
+ 
+ srcdir=@srcdir@
+ MKDIR_P=@MKDIR_P@
+@@ -100,7 +101,8 @@
  install-all: install install-ssl-daemon
  
  install-strip:
 -	$(MAKE) INSTALL_STRIP='-s' install
-+	$(MAKE) INSTALL_STRIP='-s --strip-program=$(or $(STRIP),strip)' install
++	$(MAKE) install
++	$(STRIP) $(DESTDIR)$(bindir)/rsync$(EXEEXT)
  
  rsync$(EXEEXT): $(OBJS)
+ 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(OBJS) $(LIBS)


### PR DESCRIPTION
### Summary
Changes to recipe:  **rsync/3.2.7**

#### Motivation
rsync's `install-strip` target hard-codes `install -s`, which strips using the build host's strip and ignores the `STRIP` variable (rsync 3.2.7 has no `AC_CHECK_TOOL([STRIP])`).
When cross-compiling with `tools.build:install_strip=True` this runs the host strip against a target-architecture binary and fails.

#### Details
Patch `install-strip` to run `make install` then `$(STRIP)` on the installed binary, matching the merged upstream fix, and add `STRIP ?= strip` to `Makefile.in` so the strip comes from the toolchain/profile when set, defaulting to plain `strip` for native builds.

Upstream defines `STRIP` via `AC_CHECK_TOOL`/`@STRIP@`, which requires `configure.sh` to be regenerated; released tarballs ship it pre-generated and the recipe does not run autoconf, so the definition goes directly in `Makefile.in`.

Merged upstream: https://github.com/RsyncProject/rsync/pull/1024 → [`a49f085`](https://github.com/RsyncProject/rsync/commit/a49f085a4fad61ba9dc4afc925a603888c4c3123). Not yet in a release: 3.5.0 was tagged 2026-08-13, the fix merged 2026-08-16.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details: https://github.com/RsyncProject/rsync/pull/1024
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
