### PR TITLE
plotjuggler_sdk/0.20.0

### DIFF
--- a/recipes/plotjuggler_sdk/all/conandata.yml
+++ b/recipes/plotjuggler_sdk/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "0.17.0":
-    url: "https://github.com/PlotJuggler/plotjuggler_sdk/archive/refs/tags/v0.17.0.tar.gz"
-    sha256: "e1278bb33d2b9ef8ade8f2e2dfe319f0005c3ea8707685c5bc6170e008071618"
+  "0.18.0":
+    url: "https://github.com/PlotJuggler/plotjuggler_sdk/archive/refs/tags/v0.18.0.tar.gz"
+    sha256: "8041f1304f1ad7eb03c489aac3a2d2997f63d20e1c9a598647c8f220e9aa721d"

--- a/recipes/plotjuggler_sdk/all/conandata.yml
+++ b/recipes/plotjuggler_sdk/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.16.0":
+    url: "https://github.com/PlotJuggler/plotjuggler_sdk/archive/refs/tags/v0.16.0.tar.gz"
+    sha256: "9f1cd9c619c7137068c91160514879de9d5c35b53b54b645a30ab447419c5b52"

--- a/recipes/plotjuggler_sdk/all/conandata.yml
+++ b/recipes/plotjuggler_sdk/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "0.16.2":
-    url: "https://github.com/PlotJuggler/plotjuggler_sdk/archive/refs/tags/v0.16.2.tar.gz"
-    sha256: "7aeec69df940764a628375e9b51ee79a5a986154ad43c8c2e2ce9d8656a8e064"
+  "0.17.0":
+    url: "https://github.com/PlotJuggler/plotjuggler_sdk/archive/refs/tags/v0.17.0.tar.gz"
+    sha256: "e1278bb33d2b9ef8ade8f2e2dfe319f0005c3ea8707685c5bc6170e008071618"

--- a/recipes/plotjuggler_sdk/all/conandata.yml
+++ b/recipes/plotjuggler_sdk/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "0.16.1":
-    url: "https://github.com/PlotJuggler/plotjuggler_sdk/archive/refs/tags/v0.16.1.tar.gz"
-    sha256: "e41266e9d0d827941e20f4a5dfb3cfff340170d649c4fe3351e027a9e81c42bf"
+  "0.16.2":
+    url: "https://github.com/PlotJuggler/plotjuggler_sdk/archive/refs/tags/v0.16.2.tar.gz"
+    sha256: "7aeec69df940764a628375e9b51ee79a5a986154ad43c8c2e2ce9d8656a8e064"

--- a/recipes/plotjuggler_sdk/all/conandata.yml
+++ b/recipes/plotjuggler_sdk/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "0.16.0":
-    url: "https://github.com/PlotJuggler/plotjuggler_sdk/archive/refs/tags/v0.16.0.tar.gz"
-    sha256: "9f1cd9c619c7137068c91160514879de9d5c35b53b54b645a30ab447419c5b52"
+  "0.16.1":
+    url: "https://github.com/PlotJuggler/plotjuggler_sdk/archive/refs/tags/v0.16.1.tar.gz"
+    sha256: "e41266e9d0d827941e20f4a5dfb3cfff340170d649c4fe3351e027a9e81c42bf"

--- a/recipes/plotjuggler_sdk/all/conandata.yml
+++ b/recipes/plotjuggler_sdk/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "0.18.0":
-    url: "https://github.com/PlotJuggler/plotjuggler_sdk/archive/refs/tags/v0.18.0.tar.gz"
-    sha256: "8041f1304f1ad7eb03c489aac3a2d2997f63d20e1c9a598647c8f220e9aa721d"
+  "0.20.0":
+    url: "https://github.com/PlotJuggler/plotjuggler_sdk/archive/refs/tags/v0.20.0.tar.gz"
+    sha256: "2baddcbc9ed2bc61612a91ff684da6b9a5a5a52c73c4f8af8fa8cd4df1ba2907"

--- a/recipes/plotjuggler_sdk/all/conanfile.py
+++ b/recipes/plotjuggler_sdk/all/conanfile.py
@@ -1,0 +1,192 @@
+import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, rm
+from conan.tools.microsoft import is_msvc
+from conan.tools.scm import Version
+
+required_conan_version = ">=2.1"
+
+
+class PlotjugglerSdkConan(ConanFile):
+    name = "plotjuggler_sdk"
+    description = (
+        "C++20 foundation libraries for PlotJuggler: plugin SDK and plugin host loaders."
+    )
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/PlotJuggler/plotjuggler_sdk"
+    topics = ("plotjuggler", "plugin-sdk", "telemetry", "data-visualization")
+    package_type = "static-library"
+    settings = "os", "arch", "compiler", "build_type"
+
+    # The SDK ships as static archives only (host loaders + vocabulary types);
+    # there is intentionally no `shared` option. There is deliberately no `fPIC`
+    # option either: PlotJuggler plugins are shared objects and the host loaders
+    # dlopen() them, so every target hardcodes POSITION_INDEPENDENT_CODE ON
+    # upstream. Exposing fPIC would be a no-op knob (CCI requires options to have
+    # an observable effect). `with_host` lets consumers that only author plugins
+    # skip the host-side loader libraries. `assert_throws` switches PJ_ASSERT
+    # from assert() to throwing.
+    options = {
+        "with_host": [True, False],
+        "assert_throws": [True, False],
+    }
+    default_options = {
+        "with_host": True,
+        "assert_throws": False,
+    }
+
+    @property
+    def _min_cppstd(self):
+        return 20
+
+    @property
+    def _compilers_minimum_version(self):
+        # Tune these against the oldest toolchains you actually intend to
+        # support; these are conservative C++20 baselines.
+        return {
+            "gcc": "11",
+            "clang": "14",
+            "apple-clang": "14",
+            "msvc": "192",
+            "Visual Studio": "16",
+        }
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        # nlohmann_json is in PUBLIC installed headers (config_envelope.hpp,
+        # widget_data, plugin_catalog) and is find_dependency()'d by the
+        # installed CMake usage, so it must propagate to consumers.
+        self.requires("nlohmann_json/3.12.0", transitive_headers=True)
+
+        # fmt and fast_float are header-only, private implementation details:
+        # they never appear in an installed pj_base header and are never linked
+        # into the archives' public surface. Keep them invisible so they do not
+        # propagate to downstream consumers of this static-library package.
+        self.requires(
+            "fmt/12.1.0",
+            headers=True,
+            libs=False,
+            visible=False,
+            transitive_headers=False,
+            transitive_libs=False,
+        )
+        self.requires(
+            "fast_float/8.1.0",
+            headers=True,
+            libs=False,
+            visible=False,
+            transitive_headers=False,
+            transitive_libs=False,
+        )
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler))
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which needs at least "
+                f"{self.settings.compiler} {minimum_version} "
+                f"(got {self.settings.compiler.version})."
+            )
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.cache_variables["PJ_INSTALL_SDK"] = True
+        tc.cache_variables["PJ_BUILD_TESTS"] = False
+        tc.cache_variables["PJ_BUILD_PORTED_PLUGINS"] = False
+        # Never fail a third-party package build on a warning from a compiler
+        # version upstream has not pinned. Requires the PJ_WARNINGS_AS_ERRORS
+        # option (SDK >= the release that added it).
+        tc.cache_variables["PJ_WARNINGS_AS_ERRORS"] = False
+        tc.cache_variables["PJ_ASSERT_THROWS"] = bool(self.options.assert_throws)
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(
+            self,
+            "LICENSE*",
+            src=self.source_folder,
+            dst=os.path.join(self.package_folder, "licenses"),
+        )
+        cmake = CMake(self)
+        cmake.install()
+
+        # Conan Center re-derives the CMake package from package_info() below, so
+        # the project-installed find/config/targets files must be removed. Keep
+        # PjPluginManifest.cmake — it is a genuine build helper shipped as a
+        # cmake_build_module, not a generated find script.
+        cmake_dir = os.path.join(self.package_folder, "lib", "cmake", "plotjuggler_sdk")
+        rm(self, "plotjuggler_sdkConfig*.cmake", cmake_dir)
+        rm(self, "plotjuggler_sdkTargets*.cmake", cmake_dir)
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "plotjuggler_sdk")
+
+        # Ship the PjPluginManifest helper as a build module so consumers can
+        # call pj_emit_plugin_manifest() after find_package() returns.
+        self.cpp_info.set_property(
+            "cmake_build_modules",
+            [os.path.join("lib", "cmake", "plotjuggler_sdk", "PjPluginManifest.cmake")],
+        )
+
+        # --- base ---
+        base = self.cpp_info.components["base"]
+        base.set_property("cmake_target_name", "plotjuggler_sdk::base")
+        base.libs = ["pj_base"]
+        base.includedirs = ["include"]
+        # assert.hpp is a header that branches on PJ_ASSERT_THROWS at the
+        # *consumer's* compile time; upstream exports it PUBLIC on pj_base. The
+        # define must ride along or consumers get assert() while the archive was
+        # built to throw (and vice versa). Propagated to plugin_sdk/plugin_host
+        # via their `requires = ["base", ...]`.
+        if self.options.assert_throws:
+            base.defines = ["PJ_ASSERT_THROWS"]
+
+        # --- plugin_sdk (umbrella INTERFACE: pj_base + nlohmann_json) ---
+        sdk = self.cpp_info.components["plugin_sdk"]
+        sdk.set_property("cmake_target_name", "plotjuggler_sdk::plugin_sdk")
+        sdk.libs = []  # INTERFACE only
+        sdk.includedirs = ["include"]
+        sdk.requires = ["base", "nlohmann_json::nlohmann_json"]
+        # PJ_DIALOG_PLUGIN's variadic-overload macro needs conformant __VA_ARGS__
+        # expansion on MSVC. Upstream sets this as an INTERFACE option on the
+        # dialog SDK target, which is dropped when we strip the project's CMake
+        # targets — restore it here so MSVC dialog-plugin authors still compile.
+        if is_msvc(self):
+            sdk.cxxflags = ["/Zc:preprocessor"]
+
+        # --- plugin_host (umbrella linking every host-side loader) ---
+        if self.options.with_host:
+            host = self.cpp_info.components["plugin_host"]
+            host.set_property("cmake_target_name", "plotjuggler_sdk::plugin_host")
+            host.libs = [
+                "pj_data_source_host",
+                "pj_message_parser_host",
+                "pj_toolbox_host",
+                "pj_dialog_library",
+                "pj_plugin_catalog",
+                "pj_plugin_loader_detail",
+            ]
+            host.includedirs = ["include"]
+            host.requires = ["base", "nlohmann_json::nlohmann_json"]
+            if self.settings.os in ("Linux", "FreeBSD"):
+                host.system_libs = ["dl"]

--- a/recipes/plotjuggler_sdk/all/conanfile.py
+++ b/recipes/plotjuggler_sdk/all/conanfile.py
@@ -86,6 +86,11 @@ class PlotjugglerSdkConan(ConanFile):
             transitive_libs=False,
         )
 
+    def build_requirements(self):
+        # The SDK's CMakeLists requires CMake >= 3.22; some CCI build images
+        # (notably macOS) ship an older one.
+        self.tool_requires("cmake/[>=3.22]")
+
     def validate(self):
         if self.settings.compiler.cppstd:
             check_min_cppstd(self, self._min_cppstd)

--- a/recipes/plotjuggler_sdk/all/test_package/CMakeLists.txt
+++ b/recipes/plotjuggler_sdk/all/test_package/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.22)
+project(test_package LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(plotjuggler_sdk REQUIRED CONFIG)
+
+add_executable(test_package test_package.cpp)
+# plugin_sdk transitively pulls in the `base` component (libpj_base.a) and
+# nlohmann_json, exercising real linkage — not just header availability.
+target_link_libraries(test_package PRIVATE plotjuggler_sdk::plugin_sdk)
+
+# When the package was built with_host (default), also link and exercise the
+# host loaders so the plugin_host component's lib list and its `dl` syslib
+# wiring are validated. Gated so `-o with_host=False` still builds.
+if(TEST_WITH_HOST)
+  target_link_libraries(test_package PRIVATE plotjuggler_sdk::plugin_host)
+  target_compile_definitions(test_package PRIVATE PJ_TEST_WITH_HOST)
+endif()

--- a/recipes/plotjuggler_sdk/all/test_package/CMakeLists.txt
+++ b/recipes/plotjuggler_sdk/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)

--- a/recipes/plotjuggler_sdk/all/test_package/conanfile.py
+++ b/recipes/plotjuggler_sdk/all/test_package/conanfile.py
@@ -1,0 +1,36 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def generate(self):
+        # Mirror the tested package's with_host option: the plugin_host
+        # component only exists when the package was built with it, so the
+        # consumer must only link plotjuggler_sdk::plugin_host in that case.
+        with_host = bool(self.dependencies["plotjuggler_sdk"].options.with_host)
+        tc = CMakeToolchain(self)
+        tc.cache_variables["TEST_WITH_HOST"] = with_host
+        tc.generate()
+        CMakeDeps(self).generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/plotjuggler_sdk/all/test_package/test_package.cpp
+++ b/recipes/plotjuggler_sdk/all/test_package/test_package.cpp
@@ -1,0 +1,27 @@
+#include <cstdlib>
+#include <pj_base/number_parse.hpp>
+
+#ifdef PJ_TEST_WITH_HOST
+#include <pj_plugins/host/plugin_catalog.hpp>
+#endif
+
+// parseNumber<double> dispatches to PJ::detail::parseDoubleImpl, which is
+// compiled out-of-line into libpj_base.a. Calling it therefore verifies that
+// the static archive is actually linked through the plugin_sdk component, not
+// merely that the headers are on the include path.
+int main() {
+  const auto value = PJ::parseNumber<double>("1.5");
+  if (!value || *value != 1.5) {
+    return EXIT_FAILURE;
+  }
+
+#ifdef PJ_TEST_WITH_HOST
+  // Scanning a (non-existent) directory forces the plugin_host archives — and the
+  // dlopen-backed loader, hence libdl — onto the link line, validating the
+  // plugin_host component's lib list and system_libs wiring.
+  const auto scan = PJ::scanPluginDsos("/nonexistent/plotjuggler_sdk_test_package");
+  (void)scan;
+#endif
+
+  return EXIT_SUCCESS;
+}

--- a/recipes/plotjuggler_sdk/config.yml
+++ b/recipes/plotjuggler_sdk/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.16.0":
+    folder: all

--- a/recipes/plotjuggler_sdk/config.yml
+++ b/recipes/plotjuggler_sdk/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.17.0":
+  "0.18.0":
     folder: all

--- a/recipes/plotjuggler_sdk/config.yml
+++ b/recipes/plotjuggler_sdk/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.16.2":
+  "0.17.0":
     folder: all

--- a/recipes/plotjuggler_sdk/config.yml
+++ b/recipes/plotjuggler_sdk/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.16.0":
+  "0.16.1":
     folder: all

--- a/recipes/plotjuggler_sdk/config.yml
+++ b/recipes/plotjuggler_sdk/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.16.1":
+  "0.16.2":
     folder: all

--- a/recipes/plotjuggler_sdk/config.yml
+++ b/recipes/plotjuggler_sdk/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.18.0":
+  "0.20.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe: **plotjuggler_sdk/0.16.0**

#### Motivation
New recipe. `plotjuggler_sdk` is the C++20 plugin SDK for [PlotJuggler](https://github.com/facontidavide/PlotJuggler) (the time-series visualization tool): vocabulary types, the canonical builtin object codecs, the plugin C-ABI protocol headers, and the host-side plugin loaders. Publishing it on CCI lets plugin authors consume the SDK with a plain `find_package(plotjuggler_sdk)` without adding a custom remote.

#### Details
- Static library, C++20 (`validate()` enforces `compiler.cppstd >= 20` and minimum compiler versions).
- Builds from the released tag tarball; upstream gates `-Werror` behind `PJ_WARNINGS_AS_ERRORS` (OFF here) so new-compiler warnings cannot break CCI builds.
- Three CMake components: `plotjuggler_sdk::base`, `::plugin_sdk` (plugin-author umbrella), `::plugin_host` (host-side loaders, disabled with `-o with_host=False`).
- Requires `nlohmann_json`, `fmt`, `fast_float` (all from CCI).
- `test_package` consumes `plugin_sdk` and (option-gated) `plugin_host`.
- Tested locally with Conan 2.27.1 / gcc-13 / x86_64 / Release / cppstd=20: default, `-o with_host=False`, and `-o assert_throws=True` configurations.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
