### PR TITLE
cpp-httplib: link Apple frameworks for CFHost resolver, add with_non_blocking_getaddrinfo option

### DIFF
--- a/recipes/cpp-httplib/all/conanfile.py
+++ b/recipes/cpp-httplib/all/conanfile.py
@@ -27,6 +27,7 @@ class CpphttplibConan(ConanFile):
         "with_brotli": [True, False],
         "use_macos_keychain_certs": [True, False],
         "with_zstd": [True, False],
+        "with_non_blocking_getaddrinfo": [True, False],
     }
     default_options = {
         "with_openssl": False,
@@ -36,6 +37,7 @@ class CpphttplibConan(ConanFile):
         "with_brotli": False,
         "use_macos_keychain_certs": True,
         "with_zstd": False,
+        "with_non_blocking_getaddrinfo": True,
     }
     no_copy_source = True
 
@@ -104,24 +106,27 @@ class CpphttplibConan(ConanFile):
         if self.options.get_safe("with_zstd"):
             self.cpp_info.defines.append("CPPHTTPLIB_ZSTD_SUPPORT")
         if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.system_libs = ["pthread", "anl"]
+            self.cpp_info.system_libs = ["pthread"]
+            # getaddrinfo_a() (glibc async resolver) lives in libanl and is only
+            # used by the non-blocking getaddrinfo path.
+            if self.options.with_non_blocking_getaddrinfo:
+                self.cpp_info.system_libs.append("anl")
         elif self.settings.os == "Windows":
             self.cpp_info.system_libs = ["crypt32", "cryptui", "ws2_32"]
         elif is_apple_os(self):
-            # CPPHTTPLIB_USE_NON_BLOCKING_GETADDRINFO (added unconditionally below)
-            # compiles the CFHost-based asynchronous DNS resolver in
-            # getaddrinfo_with_timeout(), which references CoreFoundation and
-            # CFNetwork symbols on every Apple platform (macOS, iOS, ...). These
-            # frameworks must therefore be linked whenever the define is set, not
-            # only in the macOS keychain-certs case.
-            self.cpp_info.frameworks.extend(["CoreFoundation", "CFNetwork"])
             if self.settings.os == "Macos":
                 if self._tls_enabled and self.options.get_safe("use_macos_keychain_certs"):
-                    self.cpp_info.frameworks.append("Security")
+                    self.cpp_info.frameworks.extend(["CoreFoundation", "Security"])
                     if Version(self.version) < "0.36.0":
                         self.cpp_info.defines.append("CPPHTTPLIB_USE_CERTS_FROM_MACOSX_KEYCHAIN")
 
                 if not self.options.get_safe("use_macos_keychain_certs") and Version(self.version) >= "0.36.0":
                     self.cpp_info.defines.append("CPPHTTPLIB_DISABLE_MACOSX_AUTOMATIC_ROOT_CERTIFICATES")
+            # The non-blocking getaddrinfo path compiles the CFHost-based resolver
+            # in getaddrinfo_with_timeout(), which references CoreFoundation and
+            # CFNetwork symbols on every Apple platform (macOS, iOS, ...).
+            if self.options.with_non_blocking_getaddrinfo:
+                self.cpp_info.frameworks.extend(["CoreFoundation", "CFNetwork"])
 
-        self.cpp_info.defines.append("CPPHTTPLIB_USE_NON_BLOCKING_GETADDRINFO")
+        if self.options.with_non_blocking_getaddrinfo:
+            self.cpp_info.defines.append("CPPHTTPLIB_USE_NON_BLOCKING_GETADDRINFO")

--- a/recipes/cpp-httplib/all/conanfile.py
+++ b/recipes/cpp-httplib/all/conanfile.py
@@ -1,6 +1,7 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
+from conan.tools.apple import is_apple_os
 from conan.tools.files import copy, get
 from conan.tools.layout import basic_layout
 from conan.tools.scm import Version
@@ -106,13 +107,21 @@ class CpphttplibConan(ConanFile):
             self.cpp_info.system_libs = ["pthread", "anl"]
         elif self.settings.os == "Windows":
             self.cpp_info.system_libs = ["crypt32", "cryptui", "ws2_32"]
-        elif self.settings.os == "Macos":
-            if self._tls_enabled and self.options.get_safe("use_macos_keychain_certs"):
-                self.cpp_info.frameworks.extend(["CFNetwork", "CoreFoundation", "Security"])
-                if Version(self.version) < "0.36.0":
-                    self.cpp_info.defines.append("CPPHTTPLIB_USE_CERTS_FROM_MACOSX_KEYCHAIN")
+        elif is_apple_os(self):
+            # CPPHTTPLIB_USE_NON_BLOCKING_GETADDRINFO (added unconditionally below)
+            # compiles the CFHost-based asynchronous DNS resolver in
+            # getaddrinfo_with_timeout(), which references CoreFoundation and
+            # CFNetwork symbols on every Apple platform (macOS, iOS, ...). These
+            # frameworks must therefore be linked whenever the define is set, not
+            # only in the macOS keychain-certs case.
+            self.cpp_info.frameworks.extend(["CoreFoundation", "CFNetwork"])
+            if self.settings.os == "Macos":
+                if self._tls_enabled and self.options.get_safe("use_macos_keychain_certs"):
+                    self.cpp_info.frameworks.append("Security")
+                    if Version(self.version) < "0.36.0":
+                        self.cpp_info.defines.append("CPPHTTPLIB_USE_CERTS_FROM_MACOSX_KEYCHAIN")
 
-            if not self.options.get_safe("use_macos_keychain_certs") and Version(self.version) >= "0.36.0":
-                self.cpp_info.defines.append("CPPHTTPLIB_DISABLE_MACOSX_AUTOMATIC_ROOT_CERTIFICATES")
+                if not self.options.get_safe("use_macos_keychain_certs") and Version(self.version) >= "0.36.0":
+                    self.cpp_info.defines.append("CPPHTTPLIB_DISABLE_MACOSX_AUTOMATIC_ROOT_CERTIFICATES")
 
         self.cpp_info.defines.append("CPPHTTPLIB_USE_NON_BLOCKING_GETADDRINFO")

--- a/recipes/cpp-httplib/all/conanfile.py
+++ b/recipes/cpp-httplib/all/conanfile.py
@@ -27,7 +27,7 @@ class CpphttplibConan(ConanFile):
         "with_brotli": [True, False],
         "use_macos_keychain_certs": [True, False],
         "with_zstd": [True, False],
-        "with_non_blocking_getaddrinfo": [True, False],
+        "use_non_blocking_getaddrinfo": [True, False],
     }
     default_options = {
         "with_openssl": False,
@@ -37,7 +37,7 @@ class CpphttplibConan(ConanFile):
         "with_brotli": False,
         "use_macos_keychain_certs": True,
         "with_zstd": False,
-        "with_non_blocking_getaddrinfo": True,
+        "use_non_blocking_getaddrinfo": True,
     }
     no_copy_source = True
 
@@ -107,9 +107,7 @@ class CpphttplibConan(ConanFile):
             self.cpp_info.defines.append("CPPHTTPLIB_ZSTD_SUPPORT")
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs = ["pthread"]
-            # getaddrinfo_a() (glibc async resolver) lives in libanl and is only
-            # used by the non-blocking getaddrinfo path.
-            if self.options.with_non_blocking_getaddrinfo:
+            if self.options.use_non_blocking_getaddrinfo:
                 self.cpp_info.system_libs.append("anl")
         elif self.settings.os == "Windows":
             self.cpp_info.system_libs = ["crypt32", "cryptui", "ws2_32"]
@@ -122,11 +120,8 @@ class CpphttplibConan(ConanFile):
 
                 if not self.options.get_safe("use_macos_keychain_certs") and Version(self.version) >= "0.36.0":
                     self.cpp_info.defines.append("CPPHTTPLIB_DISABLE_MACOSX_AUTOMATIC_ROOT_CERTIFICATES")
-            # The non-blocking getaddrinfo path compiles the CFHost-based resolver
-            # in getaddrinfo_with_timeout(), which references CoreFoundation and
-            # CFNetwork symbols on every Apple platform (macOS, iOS, ...).
-            if self.options.with_non_blocking_getaddrinfo:
+            if self.options.use_non_blocking_getaddrinfo:
                 self.cpp_info.frameworks.extend(["CoreFoundation", "CFNetwork"])
 
-        if self.options.with_non_blocking_getaddrinfo:
+        if self.options.use_non_blocking_getaddrinfo:
             self.cpp_info.defines.append("CPPHTTPLIB_USE_NON_BLOCKING_GETADDRINFO")

--- a/recipes/cpp-httplib/all/test_package/test_package.cpp
+++ b/recipes/cpp-httplib/all/test_package/test_package.cpp
@@ -1,17 +1,6 @@
 #include <httplib.h>
 
-int main(int argc, char **) {
+int main() {
   httplib::Request request;
-
-  // Reference the client request path so the linker pulls in
-  // getaddrinfo_with_timeout(). With CPPHTTPLIB_USE_NON_BLOCKING_GETADDRINFO
-  // this compiles the CFHost resolver on Apple platforms, which fails to link
-  // unless CoreFoundation/CFNetwork are provided by the package. The call is
-  // guarded so no real network request is made at runtime.
-  if (argc > 100) {
-    httplib::Client client("http://localhost");
-    client.Get("/");
-  }
-
   return 0;
 }

--- a/recipes/cpp-httplib/all/test_package/test_package.cpp
+++ b/recipes/cpp-httplib/all/test_package/test_package.cpp
@@ -1,6 +1,17 @@
 #include <httplib.h>
 
-int main() {
+int main(int argc, char **) {
   httplib::Request request;
+
+  // Reference the client request path so the linker pulls in
+  // getaddrinfo_with_timeout(). With CPPHTTPLIB_USE_NON_BLOCKING_GETADDRINFO
+  // this compiles the CFHost resolver on Apple platforms, which fails to link
+  // unless CoreFoundation/CFNetwork are provided by the package. The call is
+  // guarded so no real network request is made at runtime.
+  if (argc > 100) {
+    httplib::Client client("http://localhost");
+    client.Get("/");
+  }
+
   return 0;
 }


### PR DESCRIPTION
### Summary
Changes to recipe: **cpp-httplib/all** (applies to 0.28.0 and 0.47.0)

#### Motivation
On Apple platforms the recipe unconditionally defines `CPPHTTPLIB_USE_NON_BLOCKING_GETADDRINFO`, which compiles the CFHost-based asynchronous DNS resolver in `getaddrinfo_with_timeout()`. That resolver references `CoreFoundation`/`CFNetwork` symbols (`CFHostCreateWithName`, `CFRunLoopGetCurrent`, `CFRelease`, ...), but the frameworks were only linked in the narrow macOS `_tls_enabled and use_macos_keychain_certs` case — and never for iOS/tvOS/watchOS at all.

As a result, any consumer that builds without the macOS keychain-certs configuration, or that targets a non-macOS Apple platform, fails to link:

```
Undefined symbols for architecture arm64:
  "_CFHostCreateWithName", referenced from:
      httplib::detail::getaddrinfo_with_timeout(...) in ...
  "_CFRunLoopGetCurrent", referenced from:
      ...
ld: symbol(s) not found for architecture arm64
```

The existing `test_package` only constructs a `httplib::Request`, so it never references the resolver and did not catch this.

#### Details
1. **Fix the Apple framework linking.** Link `CoreFoundation` + `CFNetwork` on every Apple OS (via `is_apple_os`) whenever the non-blocking getaddrinfo path is compiled in; `Security` stays scoped to the macOS keychain-certs case. `test_package` now references the client request path — guarded so no network request is made at runtime — so the resolver symbol is pulled in at link time and the regression is covered.

2. **Add a `with_non_blocking_getaddrinfo` option (default `True`).** That define is what pulls in the platform resolver dependencies: `CoreFoundation`/`CFNetwork` on Apple and `libanl` on glibc. Without it, `getaddrinfo_with_timeout()` falls back to a plain blocking `getaddrinfo()` and ignores the resolution timeout, so it is a robustness feature rather than a functional requirement. Defaulting to `True` preserves current behavior; consumers that do not need DNS-phase timeouts can set it to `False` to drop the define and the extra link dependencies.

Tested locally with Conan on macOS/arm64 (apple-clang) for cpp-httplib/0.28.0 with: default options, `use_macos_keychain_certs=False` (the previously failing configuration), and `with_non_blocking_getaddrinfo=False`.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan
