### PR TITLE
causalontology/2.0.1: new recipe

### DIFF
--- a/recipes/causalontology/all/conandata.yml
+++ b/recipes/causalontology/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "1.0.2":
-    url: "https://github.com/ai-university-aiu/causalontology/archive/refs/tags/v1.0.2.tar.gz"
-    sha256: "531ab34e4546e0923c75c5e5e5cf02fb421408c6f22180c5f6298442db3a5c12"
+  "2.0.1":
+    url: "https://github.com/ai-university-aiu/causalontology/archive/refs/tags/v2.0.1.tar.gz"
+    sha256: "9ce51b79a5b547c4d6573fd93134baafe59b05d1f8bf517d5f7c6e2ddb08efd7"

--- a/recipes/causalontology/all/conandata.yml
+++ b/recipes/causalontology/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.0.2":
+    url: "https://github.com/ai-university-aiu/causalontology/archive/refs/tags/v1.0.2.tar.gz"
+    sha256: "531ab34e4546e0923c75c5e5e5cf02fb421408c6f22180c5f6298442db3a5c12"

--- a/recipes/causalontology/all/conanfile.py
+++ b/recipes/causalontology/all/conanfile.py
@@ -1,0 +1,61 @@
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, rmdir
+import os
+
+required_conan_version = ">=2.1"
+
+
+class CausalontologyConan(ConanFile):
+    name = "causalontology"
+    description = (
+        "The C++ binding of the Causalontology standard - reified causation "
+        "as a language-neutral standard and shared commons. Zero dependencies; "
+        "passes all 38 frozen conformance vectors."
+    )
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/ai-university-aiu/causalontology"
+    topics = ("causality", "ontology", "knowledge-representation", "json", "content-addressing")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+    implements = ["auto_shared_fpic"]
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def validate(self):
+        check_min_cppstd(self, 17)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        # The CMake project lives in the bindings/cpp subdirectory of the repository
+        cmake.configure(build_script_folder=os.path.join("bindings", "cpp"))
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["causalontology"]
+        self.cpp_info.set_property("cmake_file_name", "causalontology")
+        self.cpp_info.set_property("cmake_target_name", "causalontology::causalontology")

--- a/recipes/causalontology/all/test_package/CMakeLists.txt
+++ b/recipes/causalontology/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(causalontology REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE causalontology::causalontology)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/causalontology/all/test_package/conanfile.py
+++ b/recipes/causalontology/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/causalontology/all/test_package/test_package.cpp
+++ b/recipes/causalontology/all/test_package/test_package.cpp
@@ -1,0 +1,13 @@
+#include <causalontology/canonical.hpp>
+
+#include <iostream>
+
+int main() {
+    co::JValue occurrent = co::JValue::makeObject();
+    occurrent.set("type", co::JValue::of("occurrent"));
+    occurrent.set("label", co::JValue::of("press_button"));
+    occurrent.set("category", co::JValue::of("action"));
+    const std::string id = co::identify(occurrent);
+    std::cout << "identify(press_button) = " << id << std::endl;
+    return 0;
+}

--- a/recipes/causalontology/config.yml
+++ b/recipes/causalontology/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.0.2":
+    folder: "all"

--- a/recipes/causalontology/config.yml
+++ b/recipes/causalontology/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.0.2":
+  "2.0.1":
     folder: "all"


### PR DESCRIPTION
### Summary
Changes to recipe: **causalontology/1.0.2**

#### Motivation
New package. causalontology is the C++ binding of the Causalontology standard - reified causation as a language-neutral standard and shared commons. Pure C++17, zero dependencies; passes all 38 frozen conformance vectors. Apache-2.0. Upstream: https://github.com/ai-university-aiu/causalontology

#### Details
- Adds `recipes/causalontology/` (config.yml, conandata.yml, conanfile.py, test_package) for version 1.0.2.
- The upstream CMake project lives in the `bindings/cpp` subdirectory of the repository, so `build()` configures with `build_script_folder=os.path.join("bindings", "cpp")`.
- Standard CMake package: options `shared`/`fPIC` (default static, fPIC on), `check_min_cppstd(self, 17)`, installed `lib/cmake` removed in `package()` and the config regenerated via `package_info()` (`cmake_file_name` `causalontology`, `cmake_target_name` `causalontology::causalontology`).
- test_package builds against the packaged headers/library and computes a content-addressed identifier for a small occurrent.
- Tested locally with Conan 2.30.0, gcc 13, CMake 4.4 on Linux x86_64: `conan create recipes/causalontology/all --version=1.0.2 --build=missing` passes for both the default (static) configuration and `-o "*:shared=True"`, including the test_package run.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan
