### PR TITLE
open62541pp: bump v0.21.2

### DIFF
--- a/recipes/open62541pp/all/conandata.yml
+++ b/recipes/open62541pp/all/conandata.yml
@@ -2,6 +2,3 @@ sources:
   "0.21.2":
     url: "https://github.com/open62541pp/open62541pp/archive/refs/tags/v0.21.2.tar.gz"
     sha256: "901ea8a1c1f3acd2677fab65175f45efa10df6abcea3dcf426caae61e92e0408"
-  "0.20.0":
-    url: "https://github.com/open62541pp/open62541pp/archive/refs/tags/v0.20.0.tar.gz"
-    sha256: "5f9ddc10dcc985e02d031303209b58c4fe4bfab751f227866c1f389b5bbaca99"

--- a/recipes/open62541pp/all/conandata.yml
+++ b/recipes/open62541pp/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.21.2":
+    url: "https://github.com/open62541pp/open62541pp/archive/refs/tags/v0.21.2.tar.gz"
+    sha256: "901ea8a1c1f3acd2677fab65175f45efa10df6abcea3dcf426caae61e92e0408"
   "0.20.0":
     url: "https://github.com/open62541pp/open62541pp/archive/refs/tags/v0.20.0.tar.gz"
     sha256: "5f9ddc10dcc985e02d031303209b58c4fe4bfab751f227866c1f389b5bbaca99"

--- a/recipes/open62541pp/all/conanfile.py
+++ b/recipes/open62541pp/all/conanfile.py
@@ -3,9 +3,8 @@ import os
 from conan import ConanFile
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import get, copy, rm, rmdir, replace_in_file
+from conan.tools.files import get, copy, rm, rmdir
 from conan.tools.microsoft import is_msvc_static_runtime, is_msvc
-from conan.tools.scm import Version
 
 required_conan_version = ">=2.1"
 
@@ -22,12 +21,10 @@ class Open62541ppConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
-        "ipo": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
-        "ipo": False,
     }
 
     implements = ["auto_shared_fpic"]
@@ -43,7 +40,6 @@ class Open62541ppConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
-        self._patch_sources()
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -52,23 +48,9 @@ class Open62541ppConan(ConanFile):
         if is_msvc(self):
             tc.variables["USE_MSVC_RUNTIME_LIBRARY_DLL"] = not is_msvc_static_runtime(self)
 
-        if Version(self.version) < "0.21.0":
-            tc.variables["open62541_ipo"] = self.options.ipo
-        else:
-            tc.variables["CMAKE_INTERPROCEDURAL_OPTIMISATION"] = self.options.ipo
-
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()
-
-    def _patch_sources(self):        
-        if Version(self.version) < "0.21.0":
-            # Otherwise fails with
-            #   INTERFACE_LIBRARY targets may only have whitelisted properties.  The
-            #   property "INTERPROCEDURAL_OPTIMIZATION" is not allowed.
-            # Set this in CMakeToolchain instead
-            replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
-                            "get_target_property(open62541_ipo open62541::open62541 INTERPROCEDURAL_OPTIMIZATION)", "")
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/open62541pp/all/conanfile.py
+++ b/recipes/open62541pp/all/conanfile.py
@@ -5,6 +5,7 @@ from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import get, copy, rm, rmdir, replace_in_file
 from conan.tools.microsoft import is_msvc_static_runtime, is_msvc
+from conan.tools.scm import Version
 
 required_conan_version = ">=2.1"
 
@@ -50,18 +51,24 @@ class Open62541ppConan(ConanFile):
         tc.variables["UAPP_BUILD_DOCUMENTATION"] = False
         if is_msvc(self):
             tc.variables["USE_MSVC_RUNTIME_LIBRARY_DLL"] = not is_msvc_static_runtime(self)
-        tc.variables["open62541_ipo"] = self.options.ipo
+
+        if Version(self.version) < "0.21.0":
+            tc.variables["open62541_ipo"] = self.options.ipo
+        else:
+            tc.variables["CMAKE_INTERPROCEDURAL_OPTIMISATION"] = self.options.ipo
+
         tc.generate()
         deps = CMakeDeps(self)
         deps.generate()
 
-    def _patch_sources(self):
-        # Otherwise fails with
-        #   INTERFACE_LIBRARY targets may only have whitelisted properties.  The
-        #   property "INTERPROCEDURAL_OPTIMIZATION" is not allowed.
-        # Set this in CMakeToolchain instead
-        replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
-                        "get_target_property(open62541_ipo open62541::open62541 INTERPROCEDURAL_OPTIMIZATION)", "")
+    def _patch_sources(self):        
+        if Version(self.version) < "0.21.0":
+            # Otherwise fails with
+            #   INTERFACE_LIBRARY targets may only have whitelisted properties.  The
+            #   property "INTERPROCEDURAL_OPTIMIZATION" is not allowed.
+            # Set this in CMakeToolchain instead
+            replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
+                            "get_target_property(open62541_ipo open62541::open62541 INTERPROCEDURAL_OPTIMIZATION)", "")
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/open62541pp/all/test_package/test_package.cpp
+++ b/recipes/open62541pp/all/test_package/test_package.cpp
@@ -1,7 +1,10 @@
 #include <open62541pp/node.hpp>
 #include <open62541pp/server.hpp>
+#include <iostream>
 
 int main() {
-    opcua::Server server;
-    opcua::Node parentNode(server, opcua::ObjectId::ObjectsFolder);
+    const UA_String nativeString = opcua::detail::toNativeString("Hello World");
+    const auto nativeStr = opcua::detail::toStringView(nativeString);
+    std::cout << "open62541pp: " << nativeStr << std::endl;
+    return 0;
 }

--- a/recipes/open62541pp/config.yml
+++ b/recipes/open62541pp/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.21.2":
+    folder: all
   "0.20.0":
     folder: all

--- a/recipes/open62541pp/config.yml
+++ b/recipes/open62541pp/config.yml
@@ -1,5 +1,3 @@
 versions:
   "0.21.2":
     folder: all
-  "0.20.0":
-    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  open62541pp/0.21.2

#### Motivation
Fixes #30616

A new version was recently released, and I need a bugfix that was released in this version.

#### Details
Adds 0.21.2.

Some of the customization that was done for 0.20 is no longer necessary since 0.21.0: open62541pp made significant changes to its CMakeLists.txt to reduce its usage of global CMake settings. That renders the `_patch_source` function obsolete, and changes  how the `ipo` option is injected. I wasn't sure if the `ipo` option is still relevant with this version, so I've left it in.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
