### PR TITLE
gdbm: add 1.26 and patch 1.23 for C23/GCC 15 compatibility

### DIFF
--- a/recipes/gdbm/all/conandata.yml
+++ b/recipes/gdbm/all/conandata.yml
@@ -1,4 +1,10 @@
 sources:
+  "1.26":
+    url: [
+      "https://ftp.gnu.org/gnu/gdbm/gdbm-1.26.tar.gz",
+      "https://mirrors.tripadvisor.com/gnu/gdbm/gdbm-1.26.tar.gz",
+    ]
+    sha256: "6a24504a14de4a744103dcb936be976df6fbe88ccff26065e54c1c47946f4a5e"
   "1.23":
     url: [
       "https://ftp.gnu.org/gnu/gdbm/gdbm-1.23.tar.gz",
@@ -18,5 +24,10 @@ sources:
     ]
     sha256: "86e613527e5dba544e73208f42b78b7c022d4fa5a6d5498bf18c8d6f745b91dc"
 patches:
+  "1.23":
+    - patch_file: "patches/0002-c23-rename-bool-union-member.patch"
+      patch_description: "C23 compatibility fix"
+      patch_type: "portability"
+      patch_source: "https://git.gnu.org.ua/gdbm.git/commit/?id=734f69451392ffb6280d8a3aef51e2673c9b8554"
   "1.18.1":
     - patch_file: "patches/0001-fix-multiple-definitions.patch"

--- a/recipes/gdbm/all/patches/0002-c23-rename-bool-union-member.patch
+++ b/recipes/gdbm/all/patches/0002-c23-rename-bool-union-member.patch
@@ -1,0 +1,137 @@
+--- a/tools/var.c
++++ b/tools/var.c
+@@ -27,7 +27,7 @@
+ union value
+ {
+   char *string;
+-  int bool;
++  int b;
+   int num;
+ };
+ 
+@@ -90,7 +90,7 @@
+     .name = "confirm",
+     .type = VART_BOOL,
+     .flags = VARF_INIT,
+-    .init = { .bool = 1 }
++    .init = { .b = 1 }
+   },
+   {
+     .name = "cachesize",
+@@ -114,32 +114,32 @@
+     .name = "lock",
+     .type = VART_BOOL,
+     .flags = VARF_INIT,
+-    .init = { .bool = 1 }
++    .init = { .b = 1 }
+   },
+   {
+     .name = "mmap",
+     .type = VART_BOOL,
+     .flags = VARF_INIT,
+-    .init = { .bool = 1 }
++    .init = { .b = 1 }
+   },
+   {
+     .name = "sync",
+     .type = VART_BOOL,
+     .flags = VARF_INIT,
+-    .init = { .bool = 0 }
++    .init = { .b = 0 }
+   },
+   {
+     .name = "coalesce",
+     .type = VART_BOOL,
+     .flags = VARF_INIT,
+-    .init = { .bool = 0 },
++    .init = { .b = 0 },
+     .sethook = coalesce_sethook
+   },
+   {
+     .name = "centfree",
+     .type = VART_BOOL,
+     .flags = VARF_INIT,
+-    .init = { .bool = 0 },
++    .init = { .b = 0 },
+     .sethook = centfree_sethook
+   },
+   {
+@@ -252,21 +252,21 @@
+   for (i = 0; trueval[i]; i++)
+     if (strcasecmp (trueval[i], val) == 0)
+       {
+-	vp->bool = 1;
++	vp->b = 1;
+ 	return VAR_OK;
+       }
+   
+   for (i = 0; falseval[i]; i++)
+     if (strcasecmp (falseval[i], val) == 0)
+       {
+-	vp->bool = 0;
++	vp->b = 0;
+ 	return VAR_OK;
+       }
+   
+   n = strtoul (val, &p, 0);
+   if (*p)
+     return VAR_ERR_BADTYPE;
+-  vp->bool = !!n;
++  vp->b = !!n;
+   return VAR_OK;
+ }
+   
+@@ -286,7 +286,7 @@
+ static int
+ b2b (union value *vp, void *val, int flags)
+ {
+-  vp->bool = !!*(int*)val;
++  vp->b = !!*(int*)val;
+   return VAR_OK;
+ }
+ 
+@@ -307,7 +307,7 @@
+ static int
+ i2b (union value *vp, void *val, int flags)
+ {
+-  vp->bool = *(int*)val;
++  vp->b = *(int*)val;
+   return VAR_OK;
+ }
+ 
+@@ -414,7 +414,7 @@
+       break;
+ 
+     case VART_BOOL:
+-      *(int*)val = vp->v.bool;
++      *(int*)val = vp->v.b;
+       break;
+       
+     case VART_INT:
+@@ -461,7 +461,7 @@
+ 	      break;
+ 	      
+ 	    case VART_BOOL:
+-	      fprintf (fp, "%s%s", vp->v.bool ? "" : "no", vp->name);
++	      fprintf (fp, "%s%s", vp->v.b ? "" : "no", vp->name);
+ 	      break;
+ 	      
+ 	    case VART_STRING:
+@@ -647,7 +647,7 @@
+ {
+   if (!v)
+     return VAR_OK;
+-  return gdbmshell_setopt ("GDBM_SETCENTFREE", GDBM_SETCENTFREE, v->bool) == 0
++  return gdbmshell_setopt ("GDBM_SETCENTFREE", GDBM_SETCENTFREE, v->b) == 0
+          ? VAR_OK : VAR_ERR_GDBM;
+ }
+ 
+@@ -656,7 +656,7 @@
+ {
+   if (!v)
+     return VAR_OK;
+-  return gdbmshell_setopt ("GDBM_SETCOALESCEBLKS", GDBM_SETCOALESCEBLKS, v->bool) == 0
++  return gdbmshell_setopt ("GDBM_SETCOALESCEBLKS", GDBM_SETCOALESCEBLKS, v->b) == 0
+          ? VAR_OK : VAR_ERR_GDBM;
+ }
+ 

--- a/recipes/gdbm/config.yml
+++ b/recipes/gdbm/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.26":
+    folder: all
   "1.23":
     folder: all
   "1.19":


### PR DESCRIPTION
### Summary

Changes to recipe:  **gdbm**

#### Motivation

GCC 15 defaults to C23, where `bool` is a keyword and gdbm 1.23 fails to build. 

* https://github.com/NVIDIA/nvnmos/issues/67
* https://puszcza.gnu.org.ua/bugs/?642

#### Details

Backport the upstream fix for 1.23 and add 1.26, which includes it natively.

Thanks to @hartmutopfermann for finding the bug and suggesting the patch.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
