### PR TITLE
quill: add version 12.1.0

### DIFF
--- a/recipes/quill/all/conandata.yml
+++ b/recipes/quill/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "12.1.0":
+    url: "https://github.com/odygrd/quill/releases/download/v12.1.0/quill-12.1.0.zip"
+    sha256: "7981344e651f8b27116783f0968d10b6da7c282800b669d9c20fcdb907e21343"
   "12.0.0":
     url: "https://github.com/odygrd/quill/releases/download/v12.0.0/quill-12.0.0.zip"
     sha256: "74b56d9def77cb449275a35a99ba02171b6abef8e5151777ee2bb23c6576c203"

--- a/recipes/quill/config.yml
+++ b/recipes/quill/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "12.1.0":
+    folder: "all"
   "12.0.0":
     folder: "all"
   "11.1.0":


### PR DESCRIPTION
Summary
Add [Quill ](https://github.com/odygrd/quill)version 12.1.0

Motivation
Version bump with maintenance and bug fixes

Details
config.yml and conandata.yml point to the latest version

Changelog
https://github.com/odygrd/quill/blob/master/CHANGELOG.md#v1210

https://github.com/odygrd/quill/releases

https://github.com/odygrd/quill/compare/v12.0.0...v12.1.0