### PR TITLE
st_tree: add versions 1.4.0 and 1.3.0

### DIFF
--- a/recipes/st_tree/all/conandata.yml
+++ b/recipes/st_tree/all/conandata.yml
@@ -1,4 +1,10 @@
 sources:
+  "1.4.0":
+    url: "https://github.com/erikerlandson/st_tree/archive/refs/tags/version_1.4.0.tar.gz"
+    sha256: "fca5c74921ddd27ccf068f8ac74acbf7584054a67c33a6f11380b2e99efcf419"
+  "1.3.0":
+    url: "https://github.com/erikerlandson/st_tree/archive/refs/tags/version_1.3.0.tar.gz"
+    sha256: "c45933efc7ac839dd6191b5becfed4b8a88fa0a29bfbce8c2603695ebea6f5d0"
   "1.2.2":
     url: "https://github.com/erikerlandson/st_tree/archive/version_1.2.2.tar.gz"
     sha256: "7accf5e257407512c2025e074c9d990ebb1bf4beff22b4204b432e9b6c2b5e49"

--- a/recipes/st_tree/all/conandata.yml
+++ b/recipes/st_tree/all/conandata.yml
@@ -2,9 +2,6 @@ sources:
   "1.4.0":
     url: "https://github.com/erikerlandson/st_tree/archive/refs/tags/version_1.4.0.tar.gz"
     sha256: "fca5c74921ddd27ccf068f8ac74acbf7584054a67c33a6f11380b2e99efcf419"
-  "1.3.0":
-    url: "https://github.com/erikerlandson/st_tree/archive/refs/tags/version_1.3.0.tar.gz"
-    sha256: "c45933efc7ac839dd6191b5becfed4b8a88fa0a29bfbce8c2603695ebea6f5d0"
   "1.2.2":
     url: "https://github.com/erikerlandson/st_tree/archive/version_1.2.2.tar.gz"
     sha256: "7accf5e257407512c2025e074c9d990ebb1bf4beff22b4204b432e9b6c2b5e49"

--- a/recipes/st_tree/config.yml
+++ b/recipes/st_tree/config.yml
@@ -1,8 +1,6 @@
 versions:
   "1.4.0":
     folder: all
-  "1.3.0":
-    folder: all
   "1.2.2":
     folder: all
   "1.2.1":

--- a/recipes/st_tree/config.yml
+++ b/recipes/st_tree/config.yml
@@ -1,4 +1,8 @@
 versions:
+  "1.4.0":
+    folder: all
+  "1.3.0":
+    folder: all
   "1.2.2":
     folder: all
   "1.2.1":


### PR DESCRIPTION
### Summary
Changes to recipe:  st_tree[1.4.0/1.3.0]

#### Motivation
Have the latest versions of the library

#### Details
1.3.0 -> 1.4.0 breadth method introduced
1.2.2 -> 1.3.0 Minor fixes


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan