### PR TITLE
[m4] Fixing condition for checking the compiler version

### DIFF
--- a/recipes/m4/all/conanfile.py
+++ b/recipes/m4/all/conanfile.py
@@ -59,7 +59,7 @@ class M4Conan(ConanFile):
             ])
             if self.settings.build_type in ("Debug", "RelWithDebInfo"):
                 tc.extra_ldflags.append("-PDB")
-        elif self.version == "1.4.19" and self.settings.compiler == "gcc" and Version(self.settings.compiler) >= "15":
+        elif self.version == "1.4.19" and self.settings.compiler == "gcc" and self.settings.compiler.version >= Version(15):
             # FIXME: https://savannah.gnu.org/support/?func=detailitem&item_id=111150
             # WORKAROUND: https://lists.buildroot.org/pipermail/buildroot/2025-May/777741.html
             tc.extra_cflags.append("-std=gnu17")


### PR DESCRIPTION
### Summary
Fixing condition for checking the compiler version

#### Motivation
The previous condition in ubuntu 16.04 docker container (with gcc 5.4) always returned True leading to failing of the build
