### PR TITLE
openimageio: Add version 3.1.15.0

### DIFF
--- a/recipes/openimageio/all/conandata.yml
+++ b/recipes/openimageio/all/conandata.yml
@@ -1,12 +1,12 @@
 sources:
-  "3.1.14.0":
-    url: "https://github.com/AcademySoftwareFoundation/OpenImageIO/releases/download/v3.1.14.0/OpenImageIO-3.1.14.0.tar.gz"
-    sha256: "ced98eff58fe27fc2fad5b789ee9cb43dda5f415700bb2f36229ad7fd32a6ea9"
+  "3.1.15.0":
+    url: "https://github.com/AcademySoftwareFoundation/OpenImageIO/releases/download/v3.1.15.0/OpenImageIO-3.1.15.0.tar.gz"
+    sha256: "2c17eb34aa9d645629caf26a1c90e14556ae558f429e1ff6f0e41fbe4c80d42e"
   "2.5.19.1":
     url: "https://github.com/AcademySoftwareFoundation/OpenImageIO/archive/refs/tags/v2.5.19.1.tar.gz"
     sha256: "adb73f270f2eaae81c3c7cde311239944ae9faf6d206552da4ee12d746628b26"
 patches:
-  "3.1.14.0":
+  "3.1.15.0":
     - patch_file: "patches/3.1.13.1-conan-fixes.patch"
   "2.5.19.1":
     - patch_file: "patches/2.5.19.1-conan-fixes.patch"

--- a/recipes/openimageio/config.yml
+++ b/recipes/openimageio/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "3.1.14.0":
+  "3.1.15.0":
     folder: all
   "2.5.19.1":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **openimageio/3.1.15.0**

#### Motivation
Monthly release with mainly fixes for different file parsers hardening against broken/malicious files.

#### Details
* https://github.com/AcademySoftwareFoundation/OpenImageIO/releases/tag/v3.1.15.0
* https://github.com/AcademySoftwareFoundation/OpenImageIO/compare/v3.1.14.0...v3.1.15.0
* I did not see any change that influences the build for us. Few cmake changes for when the vendoring is used, rest is code changes.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
