### PR TITLE
c-ares: add version 1.34.8

### DIFF
--- a/recipes/c-ares/all/conandata.yml
+++ b/recipes/c-ares/all/conandata.yml
@@ -2,10 +2,7 @@ sources:
   "1.34.8":
     url: "https://github.com/c-ares/c-ares/releases/download/v1.34.8/c-ares-1.34.8.tar.gz"
     sha256: "c222b6d681096f9444d2c4863d2c1174019e27cacca0a4a5c114d36dd7d7bf78"
-  "1.34.6":
-    url: "https://github.com/c-ares/c-ares/releases/download/v1.34.6/c-ares-1.34.6.tar.gz"
-    sha256: "912dd7cc3b3e8a79c52fd7fb9c0f4ecf0aaa73e45efda880266a2d6e26b84ef5"
-  # keep 1.25.0 for libnghttp2, trantor, libcoro
+  # keep 1.25.0 for libcoro
   "1.25.0":
     url: "https://github.com/c-ares/c-ares/releases/download/cares-1_25_0/c-ares-1.25.0.tar.gz"
     sha256: "71832b93a48f5ff579c505f4869120c14e57b783275367207f1a98314aa724e5"

--- a/recipes/c-ares/all/conandata.yml
+++ b/recipes/c-ares/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.34.8":
+    url: "https://github.com/c-ares/c-ares/releases/download/v1.34.8/c-ares-1.34.8.tar.gz"
+    sha256: "c222b6d681096f9444d2c4863d2c1174019e27cacca0a4a5c114d36dd7d7bf78"
   "1.34.6":
     url: "https://github.com/c-ares/c-ares/releases/download/v1.34.6/c-ares-1.34.6.tar.gz"
     sha256: "912dd7cc3b3e8a79c52fd7fb9c0f4ecf0aaa73e45efda880266a2d6e26b84ef5"

--- a/recipes/c-ares/config.yml
+++ b/recipes/c-ares/config.yml
@@ -1,7 +1,5 @@
 versions:
   "1.34.8":
     folder: all
-  "1.34.6":
-    folder: all
   "1.25.0":
     folder: all

--- a/recipes/c-ares/config.yml
+++ b/recipes/c-ares/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.34.8":
+    folder: all
   "1.34.6":
     folder: all
   "1.25.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **c-ares/1.34.8**

#### Motivation
The latest version was released.

#### Details
fixes #30636 

Change log: https://c-ares.org/changelog.html#c-ares-version-1348---july-7-2026
Tag: https://github.com/c-ares/c-ares/releases/tag/v1.34.8


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
