### PR TITLE
Add handoffkit/1.14.1

### DIFF
--- a/recipes/handoffkit/all/conandata.yml
+++ b/recipes/handoffkit/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.14.1":
+    url: "https://github.com/DaosPath/handoffkit/releases/download/v1.14.1/handoffkit-cpp-1.14.1.tar.gz"
+    sha256: "d5b2872c05b3538a576122524da6e2a452d357d0299c903586280882adce9269"

--- a/recipes/handoffkit/all/conanfile.py
+++ b/recipes/handoffkit/all/conanfile.py
@@ -1,0 +1,80 @@
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, rm, rmdir
+import os
+
+required_conan_version = ">=2.0.9"
+
+
+class HandoffkitConan(ConanFile):
+    name = "handoffkit"
+    description = "Native C++20 multi-agent runtime with structured handoffs"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/DaosPath/handoffkit"
+    topics = ("multi-agent", "handoffs", "llm", "runtime")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+    implements = ["auto_shared_fpic"]
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        # Public headers include <nlohmann/json.hpp>
+        self.requires("nlohmann_json/3.11.3", transitive_headers=True)
+
+    def validate(self):
+        check_min_cppstd(self, 20)
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.16 <4]")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.cache_variables["HANDOFFKIT_BUILD_TESTS"] = False
+        tc.cache_variables["HANDOFFKIT_BUILD_EXAMPLES"] = False
+        tc.cache_variables["HANDOFFKIT_BUILD_CLI"] = False
+        # Package the runtime core only (no fusion demo suite / CLI catalog).
+        tc.cache_variables["HANDOFFKIT_BUILD_DEMOS"] = False
+        tc.cache_variables["HANDOFFKIT_FETCH_JSON"] = False
+        tc.cache_variables["HANDOFFKIT_WITH_HTTP"] = False
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+        rm(self, "*.pdb", self.package_folder, recursive=True)
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "handoffkit")
+        self.cpp_info.set_property("cmake_target_name", "handoffkit::handoffkit")
+        # Alias used by monorepo docs / consumer_core example
+        self.cpp_info.set_property("cmake_target_aliases", ["handoffkit::core"])
+        self.cpp_info.libs = ["handoffkit_core"]
+        self.cpp_info.requires = ["nlohmann_json::nlohmann_json"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.extend(["pthread", "dl", "m"])

--- a/recipes/handoffkit/all/test_package/CMakeLists.txt
+++ b/recipes/handoffkit/all/test_package/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(handoffkit REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+if(TARGET handoffkit::core)
+  target_link_libraries(${PROJECT_NAME} PRIVATE handoffkit::core)
+else()
+  target_link_libraries(${PROJECT_NAME} PRIVATE handoffkit::handoffkit)
+endif()
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)

--- a/recipes/handoffkit/all/test_package/conanfile.py
+++ b/recipes/handoffkit/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/handoffkit/all/test_package/test_package.cpp
+++ b/recipes/handoffkit/all/test_package/test_package.cpp
@@ -1,0 +1,24 @@
+#include <handoffkit/handoffkit_core.hpp>
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+int main() {
+    using namespace handoffkit;
+
+    EchoProvider provider("echo");
+    Agent agent("Consumer", "Uses handoffkit core", provider.as_any());
+    auto out = agent.run("Validate Conan package");
+    if (!out) {
+        std::cerr << out.error().message << "\n";
+        return EXIT_FAILURE;
+    }
+
+    const std::string ver = version();
+    if (ver.empty()) {
+        return EXIT_FAILURE;
+    }
+    std::cout << "handoffkit " << ver << " ok\n";
+    return EXIT_SUCCESS;
+}

--- a/recipes/handoffkit/config.yml
+++ b/recipes/handoffkit/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.14.1":
+    folder: all


### PR DESCRIPTION
## Package Details
* **Package name:** handoffkit
* **Package version:** 1.14.1
* **Upstream:** https://github.com/DaosPath/handoffkit
* **Source:** https://github.com/DaosPath/handoffkit/releases/download/v1.14.1/handoffkit-cpp-1.14.1.tar.gz
* **License:** MIT

## Description
Native C++20 multi-agent runtime with structured handoffs (Agent/Team/Protocol/tools, offline Echo provider).

## Recipe notes
* Builds runtime **core only** (HANDOFFKIT_BUILD_DEMOS=OFF, no CLI/examples/tests).
* Depends on nlohmann_json/3.11.3 (headers include nlohmann/json.hpp).
* Requires C++20.
* Locally verified: conan create recipes/handoffkit/all --version=1.14.1 --build=missing (Windows/GCC 13) - test_package prints handoffkit 1.14.1 ok.

## Checklist
- [x] Read contributing guidelines
- [x] Latest Conan client
- [x] Tested locally at least one configuration