### PR TITLE
libattr: publish version 2.6.0

### DIFF
--- a/recipes/libattr/all/conandata.yml
+++ b/recipes/libattr/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "2.6.0":
     url: "https://download.savannah.nongnu.org/releases/attr/attr-2.6.0.tar.gz"
     sha256: "d42fa374513180bb48cb11a46696f488240e5124ff1e6ad88b0abff706985612"
+  "2.5.2":
+    url: "https://download.savannah.nongnu.org/releases/attr/attr-2.5.2.tar.gz"
+    sha256: "39bf67452fa41d0948c2197601053f48b3d78a029389734332a6309a680c6c87"

--- a/recipes/libattr/all/conandata.yml
+++ b/recipes/libattr/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "2.5.2":
-    url: "https://download.savannah.nongnu.org/releases/attr/attr-2.5.2.tar.gz"
-    sha256: "39bf67452fa41d0948c2197601053f48b3d78a029389734332a6309a680c6c87"
+  "2.6.0":
+    url: "https://download.savannah.nongnu.org/releases/attr/attr-2.6.0.tar.gz"
+    sha256: "d42fa374513180bb48cb11a46696f488240e5124ff1e6ad88b0abff706985612"

--- a/recipes/libattr/all/test_package/test_package.c
+++ b/recipes/libattr/all/test_package/test_package.c
@@ -1,12 +1,11 @@
 #include <sys/types.h>
-#include <attr/attributes.h>
+#include <sys/xattr.h>
 
 int main(int argc, char* argv[])
 {
     char value[255];
-    int len = sizeof(value);
     const char *path = "file_not_exist.txt";
     const char *attr = "attr_not_exist";
-    attr_get(path, attr, value, &len, 0);
+    getxattr(path, attr, value, sizeof(value));
     return 0;
 }

--- a/recipes/libattr/all/test_package/test_package.c
+++ b/recipes/libattr/all/test_package/test_package.c
@@ -1,11 +1,11 @@
-#include <sys/types.h>
-#include <sys/xattr.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <attr/libattr.h>
 
-int main(int argc, char* argv[])
-{
-    char value[255];
-    const char *path = "file_not_exist.txt";
-    const char *attr = "attr_not_exist";
-    getxattr(path, attr, value, sizeof(value));
-    return 0;
+
+int main(void) {
+    printf("libattr test package: attr_copy_file\n");
+    attr_copy_file("file_not_exist.txt", "attr_not_exist", NULL, NULL);
+    return EXIT_SUCCESS;
 }

--- a/recipes/libattr/config.yml
+++ b/recipes/libattr/config.yml
@@ -1,3 +1,5 @@
 versions:
   "2.6.0":
     folder: all
+  "2.5.2":
+    folder: all

--- a/recipes/libattr/config.yml
+++ b/recipes/libattr/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "2.5.2":
+  "2.6.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **libattr/2.6.0**

#### Motivation
To fix vulnerability [CVE-2026-54371](https://www.cve.org/CVERecord?id=CVE-2026-54371)

#### Details
https://lists.nongnu.org/archive/html/acl-devel/2026-06/msg00000.html

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
