### PR TITLE
cppcheck: publish version 2.21.1

### DIFF
--- a/recipes/cppcheck/all/conandata.yml
+++ b/recipes/cppcheck/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "2.21.0":
-    url: "https://github.com/danmar/cppcheck/archive/2.21.0.tar.gz"
-    sha256: "f028ff75ca5372738f3737c8b3e8611426a6526b6aea2ef01301ab0f5902f044"
+  "2.21.1":
+    url: "https://github.com/cppcheck-opensource/cppcheck/archive/2.21.1.tar.gz"
+    sha256: "ba750bd872ad7c01f951ff2d9dc8c68ea5852654545ec7a62a4c318d690c8e22"

--- a/recipes/cppcheck/config.yml
+++ b/recipes/cppcheck/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "2.21.0":
+  "2.21.1":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **cppcheck/2.21.1**

#### Motivation
Update to the latest patch version with bug fix - fixed build on Oracle Linux 8.

#### Details
Repository URL changed from https://github.com/danmar/cppcheck/ to https://github.com/cppcheck-opensource/cppcheck, see `README.md`.
https://github.com/cppcheck-opensource/cppcheck/compare/2.21.0...2.21.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
