### PR TITLE
sockpp: Expose SOCKPP_BUILD_CAN as with_can option

### DIFF
--- a/recipes/sockpp/all/conanfile.py
+++ b/recipes/sockpp/all/conanfile.py
@@ -18,10 +18,12 @@ class SockppConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
+        "with_can": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
+        "with_can": False,
     }
     implements = ["auto_shared_fpic"]
     languages = "C++"
@@ -34,8 +36,11 @@ class SockppConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
+        SOCKPP_WITH_OPENSSL
+        SOCKPP_WITH_MBEDTLS
         tc.cache_variables["SOCKPP_BUILD_SHARED"] = self.options.shared
         tc.cache_variables["SOCKPP_BUILD_STATIC"] = not self.options.shared
+        tc.cache_variables["SOCKPP_BUILD_CAN"] = self.options.with_can
         tc.generate()
 
     def validate(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **sockpp/1.0.0**

#### Motivation
Allow downstream projects to request a build of sockpp with socket CAN support without resorting to buildchain hooks.

#### Details
Adds `with_can` option, defaults to false. Setting option to true will set SOCKPP_BUILD_CAN to ON, enabling CAN functionality.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
