### PR TITLE
wirestead: add new recipe

### DIFF
--- a/recipes/wirestead/all/conandata.yml
+++ b/recipes/wirestead/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.9.0":
+    url: "https://github.com/wirestead/wirestead/archive/refs/tags/v0.9.0.tar.gz"
+    sha256: "110a44774356b8c3b2a4a15ecb526ca63917855003be0ae85fca2e244cbef144"

--- a/recipes/wirestead/all/conandata.yml
+++ b/recipes/wirestead/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.9.1":
+    url: "https://github.com/wirestead/wirestead/archive/refs/tags/v0.9.1.tar.gz"
+    sha256: "e4521aee0f6d1c573ea209813eead8ee2d0429a68321badfe1adf033b144b6cf"
   "0.9.0":
     url: "https://github.com/wirestead/wirestead/archive/refs/tags/v0.9.0.tar.gz"
     sha256: "110a44774356b8c3b2a4a15ecb526ca63917855003be0ae85fca2e244cbef144"

--- a/recipes/wirestead/all/conandata.yml
+++ b/recipes/wirestead/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "0.9.3":
-    url: "https://github.com/wirestead/wirestead/archive/refs/tags/v0.9.3.tar.gz"
-    sha256: "3be2dbce8dcb9dd5a1af72fc2fa3c546943c47ffb7bb94298f252af5442de45e"
+  "0.9.4":
+    url: "https://github.com/wirestead/wirestead/archive/refs/tags/v0.9.4.tar.gz"
+    sha256: "aca184518a5d0856b8839dedc5719e6778cd2e8cffdcd73bd9ca810d185e48aa"

--- a/recipes/wirestead/all/conandata.yml
+++ b/recipes/wirestead/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "0.9.5":
-    url: "https://github.com/wirestead/wirestead/archive/refs/tags/v0.9.5.tar.gz"
-    sha256: "12feca1d71124e474244f11740f23ad21a6d4ca633372573a31ee6cd97dccda2"
+  "0.9.6":
+    url: "https://github.com/wirestead/wirestead/archive/refs/tags/v0.9.6.tar.gz"
+    sha256: "886f1f84dfb24b0493fad2c59a07aeddafe854bb2294f73d33b463a6496053e9"

--- a/recipes/wirestead/all/conandata.yml
+++ b/recipes/wirestead/all/conandata.yml
@@ -1,7 +1,4 @@
 sources:
-  "0.9.1":
-    url: "https://github.com/wirestead/wirestead/archive/refs/tags/v0.9.1.tar.gz"
-    sha256: "e4521aee0f6d1c573ea209813eead8ee2d0429a68321badfe1adf033b144b6cf"
-  "0.9.0":
-    url: "https://github.com/wirestead/wirestead/archive/refs/tags/v0.9.0.tar.gz"
-    sha256: "110a44774356b8c3b2a4a15ecb526ca63917855003be0ae85fca2e244cbef144"
+  "0.9.3":
+    url: "https://github.com/wirestead/wirestead/archive/refs/tags/v0.9.3.tar.gz"
+    sha256: "3be2dbce8dcb9dd5a1af72fc2fa3c546943c47ffb7bb94298f252af5442de45e"

--- a/recipes/wirestead/all/conandata.yml
+++ b/recipes/wirestead/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "0.9.4":
-    url: "https://github.com/wirestead/wirestead/archive/refs/tags/v0.9.4.tar.gz"
-    sha256: "aca184518a5d0856b8839dedc5719e6778cd2e8cffdcd73bd9ca810d185e48aa"
+  "0.9.5":
+    url: "https://github.com/wirestead/wirestead/archive/refs/tags/v0.9.5.tar.gz"
+    sha256: "12feca1d71124e474244f11740f23ad21a6d4ca633372573a31ee6cd97dccda2"

--- a/recipes/wirestead/all/conanfile.py
+++ b/recipes/wirestead/all/conanfile.py
@@ -1,0 +1,123 @@
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, rmdir
+from conan.tools.scm import Version
+import os
+
+required_conan_version = ">=2.9"
+
+
+class WiresteadConan(ConanFile):
+    name = "wirestead"
+    description = "Unified, cross-platform async C++ library for Serial, TCP, UDP, and UDS communication"
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/wirestead/wirestead"
+    topics = ("async", "communication", "tcp", "udp", "serial", "uds", "networking", "cpp20")
+    settings = "os", "arch", "compiler", "build_type"
+    package_type = "library"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "enable_config": [True, False],
+        "enable_memory_tracking": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "enable_config": True,
+        "enable_memory_tracking": False,
+    }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            self.options.rm_safe("fPIC")
+
+    def configure(self):
+        if self.options.get_safe("shared"):
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def validate(self):
+        check_min_cppstd(self, 20)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def requirements(self):
+        self.requires("boost/[>=1.83.0]", transitive_headers=True, transitive_libs=True)
+        self.requires("spdlog/[>=1.9 <2]", transitive_headers=True, transitive_libs=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.cache_variables["WIRESTEAD_BUILD_SHARED"] = self.options.shared
+        tc.cache_variables["WIRESTEAD_BUILD_STATIC"] = not self.options.shared
+        tc.cache_variables["WIRESTEAD_ENABLE_INSTALL"] = True
+        tc.cache_variables["WIRESTEAD_BUILD_TESTS"] = False
+        tc.cache_variables["WIRESTEAD_BUILD_DOCS"] = False
+        tc.cache_variables["WIRESTEAD_ENABLE_PKGCONFIG"] = False
+        tc.cache_variables["WIRESTEAD_ENABLE_CONFIG"] = self.options.enable_config
+        tc.cache_variables["WIRESTEAD_ENABLE_MEMORY_TRACKING"] = self.options.enable_memory_tracking
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        if Version(self.dependencies["boost"].ref.version) >= "1.89.0":
+            deps.set_property("boost::headers", "cmake_target_aliases", ["Boost::system"])
+        deps.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+
+        copy(
+            self,
+            "LICENSE*",
+            src=self.source_folder,
+            dst=os.path.join(self.package_folder, "licenses"),
+        )
+        copy(
+            self,
+            "NOTICE",
+            src=self.source_folder,
+            dst=os.path.join(self.package_folder, "licenses"),
+        )
+
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_target_name", "wirestead::wirestead")
+        self.cpp_info.set_property("cmake_file_name", "wirestead")
+        self.cpp_info.set_property("pkg_config_name", "wirestead")
+        self.cpp_info.libs = ["wirestead"]
+
+        if self.options.enable_config:
+            self.cpp_info.defines.append("WIRESTEAD_ENABLE_CONFIG=1")
+        if self.options.enable_memory_tracking:
+            self.cpp_info.defines.append("WIRESTEAD_ENABLE_MEMORY_TRACKING=1")
+
+        if self.settings.os == "Windows":
+            self.cpp_info.system_libs.extend(["ws2_32", "mswsock", "iphlpapi"])
+            self.cpp_info.defines.extend(["WIN32_LEAN_AND_MEAN", "NOMINMAX"])
+        else:
+            self.cpp_info.system_libs.append("pthread")
+            if self.settings.os == "Macos":
+                self.cpp_info.defines.append("_DARWIN_C_SOURCE")
+            else:
+                self.cpp_info.defines.append("_POSIX_C_SOURCE=200809L")
+
+        requires = ["boost::headers", "spdlog::spdlog"]
+        if Version(self.dependencies["boost"].ref.version) < "1.89.0":
+            # boost::system is a separate component pre-1.89; from 1.89 it no
+            # longer exists and boost::headers (aliased in generate()) covers it.
+            requires.append("boost::system")
+        self.cpp_info.requires = requires

--- a/recipes/wirestead/all/conanfile.py
+++ b/recipes/wirestead/all/conanfile.py
@@ -1,4 +1,5 @@
 from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir
@@ -41,8 +42,24 @@ class WiresteadConan(ConanFile):
     def layout(self):
         cmake_layout(self, src_folder="src")
 
+    @property
+    def _minimum_compilers_version(self):
+        # Conservative floor for full, non-buggy C++20 concepts support
+        return {
+            "gcc": "11",
+            "clang": "14",
+            "apple-clang": "14",
+            "msvc": "192",
+        }
+
     def validate(self):
         check_min_cppstd(self, 20)
+        minimum_version = self._minimum_compilers_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++20 concepts support, which {self.settings.compiler} "
+                f"{self.settings.compiler.version} does not provide (minimum: {minimum_version})."
+            )
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/wirestead/all/conanfile.py
+++ b/recipes/wirestead/all/conanfile.py
@@ -44,11 +44,13 @@ class WiresteadConan(ConanFile):
 
     @property
     def _minimum_compilers_version(self):
-        # Conservative floor for full, non-buggy C++20 concepts support
+        # Binding constraint is std::source_location::current() (logger.hpp
+        # default arguments), not just concepts (builder/ibuilder.hpp) - it
+        # lands later per https://en.cppreference.com/cpp/compiler_support/20
         return {
             "gcc": "11",
-            "clang": "14",
-            "apple-clang": "14",
+            "clang": "15",
+            "apple-clang": "15",
             "msvc": "192",
         }
 

--- a/recipes/wirestead/all/test_package/CMakeLists.txt
+++ b/recipes/wirestead/all/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package)
+
+find_package(wirestead REQUIRED)
+
+add_executable(test_package test_package.cpp)
+target_link_libraries(test_package wirestead::wirestead)
+
+target_compile_features(test_package PRIVATE cxx_std_20)

--- a/recipes/wirestead/all/test_package/conanfile.py
+++ b/recipes/wirestead/all/test_package/conanfile.py
@@ -1,0 +1,28 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+import os
+
+
+class WiresteadTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def layout(self):
+        cmake_layout(self)
+
+    def test(self):
+        if can_run(self):
+            exe = "test_package.exe" if self.settings.os == "Windows" else "test_package"
+            bin_path = os.path.join(self.cpp.build.bindirs[0], exe)
+            self.run(bin_path, env="conanrun")

--- a/recipes/wirestead/all/test_package/test_package.cpp
+++ b/recipes/wirestead/all/test_package/test_package.cpp
@@ -1,0 +1,18 @@
+#include <iostream>
+#include <string>
+#include <wirestead/wirestead.hpp>
+
+int main() {
+    std::cout << "Testing wirestead package..." << std::endl;
+
+    // Exercise a compiled symbol to ensure the library links properly
+    auto& logger = wirestead::diagnostics::Logger::instance();
+    logger.set_enabled(true);
+    logger.set_console_output(false);
+    logger.set_level(wirestead::diagnostics::LogLevel::INFO);
+    logger.log(wirestead::diagnostics::LogLevel::INFO, "test_package", "basic_log", "wirestead log test");
+    logger.flush();
+
+    std::cout << "wirestead runtime test passed!" << std::endl;
+    return 0;
+}

--- a/recipes/wirestead/config.yml
+++ b/recipes/wirestead/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.9.0":
+    folder: all

--- a/recipes/wirestead/config.yml
+++ b/recipes/wirestead/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.9.1":
+    folder: all
   "0.9.0":
     folder: all

--- a/recipes/wirestead/config.yml
+++ b/recipes/wirestead/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.9.3":
+  "0.9.4":
     folder: all

--- a/recipes/wirestead/config.yml
+++ b/recipes/wirestead/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.9.4":
+  "0.9.5":
     folder: all

--- a/recipes/wirestead/config.yml
+++ b/recipes/wirestead/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.9.5":
+  "0.9.6":
     folder: all

--- a/recipes/wirestead/config.yml
+++ b/recipes/wirestead/config.yml
@@ -1,5 +1,3 @@
 versions:
-  "0.9.1":
-    folder: all
-  "0.9.0":
+  "0.9.3":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe: **wirestead/0.9.3**

fixes #30671

#### Motivation
This PR adds the `wirestead` library to Conan Center Index. `wirestead` is a cross-platform, asynchronous C++ communication library providing a unified API for Serial, TCP, UDP, and UDS transports. Publishing it on Conan Center makes it easy for downstream C++ projects to consume via `find_package(wirestead)`.

#### Details
- **Name**: wirestead
- **Version**: 0.9.3
- **License**: Apache-2.0
- **Homepage**: https://github.com/wirestead/wirestead
- **Description**: Unified, cross-platform async C++ library for Serial, TCP, UDP, and UDS communication

**Build system**: CMake, requiring C++20.

**Dependencies**:
- `boost/[>=1.83.0]` (Boost.Asio / Boost.System)
- `spdlog/[>=1.9 <2]`

**Build Options**:
- `shared` (default: False)
- `fPIC` (default: True)
- `enable_config`: enable the optional configuration-management API (default: True)
- `enable_memory_tracking`: enable memory tracking for debugging (default: False)

**Recipe notes**:
- Upstream's exported CMake config/target files and `.pc` files are removed from the package in favor of Conan-generated `CMakeDeps`/`PkgConfigDeps` equivalents, with the `WIRESTEAD_ENABLE_*` feature-flag defines and platform-specific system libs/defines re-declared in `package_info()`.
- Boost dropped `boost::system` as a standalone component starting with 1.89.0 (folded into header-only `boost::system`/`boost::headers`); the recipe handles both cases via a version check in `generate()` (CMake target alias) and `package_info()` (Conan component requirement).
- `validate()` enforces a minimum compiler version (gcc 11, clang 15, apple-clang 15, msvc 192) in addition to `check_min_cppstd(20)`. The binding constraint is `std::source_location::current()` used as a default argument in `diagnostics/logger.hpp` (concepts, used in `builder/ibuilder.hpp`, land earlier per [cppreference's C++20 compiler support table](https://en.cppreference.com/cpp/compiler_support/20)).
- Verified locally with `conan create` across static/shared builds and Boost 1.83.0, 1.89.0, and 1.91.0.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan
