### PR TITLE
cyclonedds: add option to disable/enable building QoS provider

### DIFF
--- a/recipes/cyclonedds/all/conandata.yml
+++ b/recipes/cyclonedds/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "11.0.1.1":
+    url: "https://github.com/eclipse-cyclonedds/cyclonedds/archive/11.0.1.tar.gz"
+    sha256: "c25d46075ad6b5cee564bda9e5f49509e9a6dbb1a8b858e708eb360d335cf973"
   "11.0.1":
     url: "https://github.com/eclipse-cyclonedds/cyclonedds/archive/11.0.1.tar.gz"
     sha256: "c25d46075ad6b5cee564bda9e5f49509e9a6dbb1a8b858e708eb360d335cf973"
@@ -15,6 +18,9 @@ sources:
     url: "https://github.com/eclipse-cyclonedds/cyclonedds/archive/refs/tags/0.10.2.tar.gz"
     sha256: "bc84e137e0c8a055b8cd97fbeafec94e36de1b0c2e88800896a82384fd867ae5"
 patches:
+  "11.0.1.1":
+    - patch_file: "patches/11.0.1-0001-fix-find-iceoryx.patch"
+    - patch_file: "patches/11.0.1-0002-generate-cmakedeps-compat.patch"
   "11.0.1":
     - patch_file: "patches/11.0.1-0001-fix-find-iceoryx.patch"
     - patch_file: "patches/11.0.1-0002-generate-cmakedeps-compat.patch"

--- a/recipes/cyclonedds/all/conanfile.py
+++ b/recipes/cyclonedds/all/conanfile.py
@@ -27,6 +27,7 @@ class CycloneDDSConan(ConanFile):
         "with_shm" : [True, False],
         "enable_security" : [True, False],
         "enable_discovery" : [True, False],
+        "enable_qos_provider" : [True, False],
     }
     default_options = {
         "shared": False,
@@ -35,6 +36,7 @@ class CycloneDDSConan(ConanFile):
         "with_shm": False,
         "enable_security": False,
         "enable_discovery": True,
+        "enable_qos_provider": True,
     }
 
     short_paths = True
@@ -69,6 +71,8 @@ class CycloneDDSConan(ConanFile):
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
+        if self._pre_v11:
+            del self.options.enable_qos_provider
 
     def configure(self):
         if self.options.shared:
@@ -96,7 +100,7 @@ class CycloneDDSConan(ConanFile):
             raise ConanInvalidConfiguration(
                 f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
             )
-        if Version(self.version) == "11.0.1" and not self.options.shared and self.settings.compiler == "msvc":
+        if Version(self.version) >= "11.0.1" and not self.options.shared and self.settings.compiler == "msvc":
             # FIXME: ddsc.lib(cdtors.c.obj) : error LNK2005: tls_callback_func already defined in string.c.obj
             raise ConanInvalidConfiguration("Windows static build is not support due linker error. See https://github.com/eclipse-cyclonedds/cyclonedds/issues/2422")
 
@@ -126,6 +130,8 @@ class CycloneDDSConan(ConanFile):
         tc.variables["ENABLE_SECURITY"] = self.options.enable_security
         tc.variables["ENABLE_TYPE_DISCOVERY"] = self.options.enable_discovery
         tc.variables["ENABLE_TOPIC_DISCOVERY"] = self.options.enable_discovery
+        if not self._pre_v11:
+            tc.variables["ENABLE_QOS_PROVIDER"] = self.options.enable_qos_provider
         tc.generate()
 
         cd = CMakeDeps(self)

--- a/recipes/cyclonedds/config.yml
+++ b/recipes/cyclonedds/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "11.0.1.1":
+    folder: all
   "11.0.1":
     folder: all
   "0.10.5":


### PR DESCRIPTION
### Summary
Changes to recipe:  **cyclonedds/11.0.1**

#### Motivation
The primary motivation in my case is to enable updating cyclonedds-cxx to 11.0.1. More on that below. There is also a secondary benefit; exposing a native build option to the Conan user, allowing them to build CycloneDDS without the QoS Provider enabled. The QoS Provider allows DDS Quality Of Service settings to be read from an XML file, so is a non-trivial item that some deployments may prefer to omit.

Going back to cyclonedds-cxx. cyclonedds-cxx inspects cyclonedds options to determine whether to enable various options. 11.0 adds enabling QoS provider support to the these options. The native CMake build tries to inspect underlying cyclonedds options to set its build options, and if it doesn't find one disables the corresponding cyclonedds-cxx option. The Conan packaging handles this for other options by patching the build to use the Conan cyclonedds options directly.To enable building cyclonedds-cxx with QoS Provider support, there needs to be a cyclonedds option to inspect.

#### Details
This change adds a new `enable_qos_provider` option mimicking existing security and discovery options and (provided the cyclonedds version is 11.0 or later, so the option exists) sets a toolchain variable.

---
- [ X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [ X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
