### PR TITLE
neargye-semver: add version 1.0.0

### DIFF
--- a/recipes/neargye-semver/all/conandata.yml
+++ b/recipes/neargye-semver/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.0":
+    url: "https://github.com/Neargye/semver/archive/refs/tags/v1.0.0.tar.gz"
+    sha256: "14fe5060fa1f039811c9969e638b1968b93265e1ecc799515c38196c8c62617b"
   "0.3.1":
     url: "https://github.com/Neargye/semver/archive/refs/tags/v0.3.1.tar.gz"
     sha256: "422b5882460a685a455fda9da53b85aa1824dcb9ba9dfbd0460ce50393f71061"

--- a/recipes/neargye-semver/all/test_package/test_package.cpp
+++ b/recipes/neargye-semver/all/test_package/test_package.cpp
@@ -2,30 +2,10 @@
 #include <semver.hpp>
 
 int main() {
-    const auto v_default = semver::from_string("0.1.0");
     const auto v1 = semver::from_string("1.4.3");
     const auto v2 = semver::from_string("1.2.4-alpha.10");
 
-    if (v_default.to_string() != "0.1.0" ||
-        v1.to_string() != "1.4.3" ||
-        v2.to_string() != "1.2.4-alpha.10" ||
-        !(v2 < v1)) {
-        return 1;
-    }
-
-#if SEMVER_VERSION_MAJOR >= 1
-    const auto v3 = semver::from_string("1.2.3-rc.1+build.42");
-    if (v3.prerelease_tag() != "rc.1" ||
-        v3.build_metadata() != "build.42" ||
-        v3.without_prerelease().to_string() != "1.2.3+build.42") {
-        return 1;
-    }
-#endif
-
     std::cout << v1 << '\n';
     std::cout << v2 << '\n';
-#if SEMVER_VERSION_MAJOR >= 1
-    std::cout << v3 << '\n';
-#endif
     return 0;
 }

--- a/recipes/neargye-semver/all/test_package/test_package.cpp
+++ b/recipes/neargye-semver/all/test_package/test_package.cpp
@@ -2,21 +2,30 @@
 #include <semver.hpp>
 
 int main() {
-    constexpr semver::version v_default;
-    std::cout << v_default << std::endl; // 0.1.0
+    const auto v_default = semver::from_string("0.1.0");
+    const auto v1 = semver::from_string("1.4.3");
+    const auto v2 = semver::from_string("1.2.4-alpha.10");
 
-    constexpr semver::version v1{1, 4, 3};
-    constexpr semver::version v2{"1.2.4-alpha.10"};
-    std::cout << v1 << std::endl; // 1.4.3
-    std::cout << v2 << std::endl; // 1.2.4-alpha.10
+    if (v_default.to_string() != "0.1.0" ||
+        v1.to_string() != "1.4.3" ||
+        v2.to_string() != "1.2.4-alpha.10" ||
+        !(v2 < v1)) {
+        return 1;
+    }
 
-    semver::version v_s;
-    v_s.from_string("1.2.3-rc.1");
-    std::string s1 = v_s.to_string();
-    std::cout << s1 << std::endl; // 1.2.3-rc.1
-    v_s.prerelease_number = 0;
-    std::string s2 = v_s.to_string();
-    std::cout << s2 << std::endl; // 1.2.3-rc
+#if SEMVER_VERSION_MAJOR >= 1
+    const auto v3 = semver::from_string("1.2.3-rc.1+build.42");
+    if (v3.prerelease_tag() != "rc.1" ||
+        v3.build_metadata() != "build.42" ||
+        v3.without_prerelease().to_string() != "1.2.3+build.42") {
+        return 1;
+    }
+#endif
 
+    std::cout << v1 << '\n';
+    std::cout << v2 << '\n';
+#if SEMVER_VERSION_MAJOR >= 1
+    std::cout << v3 << '\n';
+#endif
     return 0;
 }

--- a/recipes/neargye-semver/config.yml
+++ b/recipes/neargye-semver/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.0.0":
+    folder: all
   "0.3.1":
     folder: all
   "0.3.0":


### PR DESCRIPTION
### Summary

Changes to recipe: **neargye-semver/1.0.0**

#### Motivation

Publish the upstream stable `1.0.0` release in Conan Center.

Upstream release:
https://github.com/Neargye/semver/releases/tag/v1.0.0

#### Details

- Added the `1.0.0` source archive and SHA256.
- Registered `1.0.0` in the recipe version index.
- Updated `test_package` for the 1.0 API while preserving compatibility with 0.3.x.

Validation:

- `conan create all/conanfile.py --version=1.0.0`
- `conan create all/conanfile.py --version=0.3.1`
- `conan create all/conanfile.py --version=0.3.0`

Tested with Conan 2.30, MSVC 19.51, and C++17.

---

- [x] Read the contributing guidelines.
- [x] Checked that this PR is not a duplicate.
- [x] This is not a bug fix.
- [x] Tested locally with a recent Conan version.