### PR TITLE
flecs: add 4.1.6

### DIFF
--- a/recipes/flecs/all/conandata.yml
+++ b/recipes/flecs/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.1.6":
+    url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v4.1.6.tar.gz"
+    sha256: "29ccf56961b7ffbd38cce2227a06c0722c7df464422e86619a65ee37bb31bae7"
   "4.1.5":
     url: "https://github.com/SanderMertens/flecs/archive/refs/tags/v4.1.5.tar.gz"
     sha256: "8b94f56dfdda0b3c86110f651a4e0ec1c59030db43bb4810ae296a0630682ab9"

--- a/recipes/flecs/config.yml
+++ b/recipes/flecs/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.1.6":
+    folder: all
   "4.1.5":
     folder: all
   "4.1.4":


### PR DESCRIPTION
### Summary
Changes to recipe:  **flecs/4.1.6**

#### Motivation
This PR add the version 4.1.6 with new [entity range API](https://www.flecs.dev/flecs/md_docs_2EntitiesComponents.html#ranges), which is the latest stable version for flecs, as of today.

#### Details
Add URL for flecs 4.1.6.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan