### PR TITLE
apibrasil/0.0.2: add recipe

### DIFF
--- a/recipes/apibrasil/all/conandata.yml
+++ b/recipes/apibrasil/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.0.2":
+    url: "https://github.com/APIBrasil/apigratis-sdk-cpp/archive/refs/tags/v0.0.2.tar.gz"
+    sha256: "de2c3c0ecc9f8a356f3eb2fdcf4acb0d1ab13f7ef04b8e7a08f6ca1c8a384caf"

--- a/recipes/apibrasil/all/conanfile.py
+++ b/recipes/apibrasil/all/conanfile.py
@@ -1,0 +1,112 @@
+import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, rmdir
+
+required_conan_version = ">=2.1"
+
+
+class ApibrasilConan(ConanFile):
+    name = "apibrasil"
+    description = (
+        "Official C++ SDK for the APIBrasil platform - WhatsApp, SMS, "
+        "CPF/CNPJ lookups, vehicles, CEP, correios, PIX/boleto payments and more."
+    )
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/APIBrasil/apigratis-sdk-cpp"
+    topics = ("apibrasil", "whatsapp", "sms", "cpf-cnpj", "pix", "sdk")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "with_curl": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "with_curl": True,
+    }
+
+    @property
+    def _min_cppstd(self):
+        return 17
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+            # Windows ships a native WinHTTP transport, so libcurl is optional there.
+            self.options.with_curl = False
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        # nlohmann/json is exposed through the SDK's public headers.
+        self.requires("nlohmann_json/3.11.3", transitive_headers=True)
+        if self.options.with_curl:
+            self.requires("libcurl/[>=7.78.0 <9]")
+
+    def validate(self):
+        check_min_cppstd(self, self._min_cppstd)
+        if self.settings.os != "Windows" and not self.options.with_curl:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires with_curl=True on non-Windows platforms; "
+                "libcurl is the only HTTP transport there (Windows uses WinHTTP)."
+            )
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
+        tc = CMakeToolchain(self)
+        tc.variables["APIBRASIL_BUILD_EXAMPLES"] = False
+        tc.variables["APIBRASIL_BUILD_TESTS"] = False
+        tc.variables["APIBRASIL_INSTALL"] = True
+        if not self.options.with_curl:
+            # Keep CMake from picking up a system libcurl and selecting the wrong
+            # transport; without curl in the graph only WinHTTP remains.
+            tc.variables["CMAKE_DISABLE_FIND_PACKAGE_CURL"] = True
+        if self.options.get_safe("shared"):
+            # The library does not annotate its API with dllexport, so let CMake
+            # export all symbols when building a Windows DLL.
+            tc.variables["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = True
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE",
+             src=self.source_folder,
+             dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        # The project ships its own *Config.cmake; on Conan the consumer's
+        # CMakeDeps generates those, so drop the packaged ones to avoid conflicts.
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["apibrasil"]
+        self.cpp_info.set_property("cmake_file_name", "apibrasil")
+        self.cpp_info.set_property("cmake_target_name", "apibrasil::apibrasil")
+
+        self.cpp_info.requires = ["nlohmann_json::nlohmann_json"]
+        if self.options.with_curl:
+            self.cpp_info.requires.append("libcurl::libcurl")
+            self.cpp_info.defines.append("APIBRASIL_HAVE_CURL")
+        if self.settings.os == "Windows":
+            self.cpp_info.system_libs.append("winhttp")
+            self.cpp_info.defines.append("APIBRASIL_HAVE_WINHTTP")

--- a/recipes/apibrasil/all/test_package/CMakeLists.txt
+++ b/recipes/apibrasil/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(apibrasil CONFIG REQUIRED)
+
+add_executable(test_package src/test_package.cpp)
+target_link_libraries(test_package PRIVATE apibrasil::apibrasil)
+target_compile_features(test_package PRIVATE cxx_std_17)

--- a/recipes/apibrasil/all/test_package/conanfile.py
+++ b/recipes/apibrasil/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/apibrasil/all/test_package/src/test_package.cpp
+++ b/recipes/apibrasil/all/test_package/src/test_package.cpp
@@ -1,0 +1,17 @@
+// Smoke test for the apibrasil Conan package: confirms the headers are on the
+// include path and the compiled library links. It does not make network calls.
+
+#include <iostream>
+
+#include <apibrasil/apibrasil.hpp>
+
+int main() {
+    // Constructing the client forces linking against the compiled library.
+    // The default constructor only reads environment variables (no network).
+    apibrasil::ApiBrasil api;
+    (void)api;
+
+    std::cout << "APIBrasil SDK C++ " << apibrasil::kSdkVersion
+              << " - Conan package OK\n";
+    return 0;
+}

--- a/recipes/apibrasil/config.yml
+++ b/recipes/apibrasil/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.0.2":
+    folder: all


### PR DESCRIPTION
Specify library name and version: **apibrasil/0.0.2**

Adds a recipe for [apibrasil](https://github.com/APIBrasil/apigratis-sdk-cpp) — the official C++ SDK for the APIBrasil platform (WhatsApp, SMS, CPF/CNPJ lookups, vehicles, CEP, correios, PIX/boleto payments and more).

- Header + compiled library (static/shared), C++17.
- Dependencies: `nlohmann_json` (public headers) and `libcurl` (HTTP transport). On Windows the default is a native WinHTTP transport, so `libcurl` is optional there (`with_curl=False`); on other platforms `libcurl` is required.
- Validated locally with `conan create` for both `with_curl=False` (WinHTTP) and `with_curl=True` (libcurl) — `test_package` builds, links and runs.