### PR TITLE
binutils: publish version 2.46.1

### DIFF
--- a/recipes/binutils/all/conandata.yml
+++ b/recipes/binutils/all/conandata.yml
@@ -1,4 +1,10 @@
 sources:
+  "2.46.1":
+    url:
+      - "https://ftpmirror.gnu.org/gnu/binutils/binutils-2.46.1.tar.xz"
+      - "https://www.mirrorservice.org/sites/ftp.gnu.org/gnu/binutils/binutils-2.46.1.tar.xz"
+      - "https://ftp.gnu.org/gnu/binutils/binutils-2.46.1.tar.xz"
+    sha256: "e127a709cba24c76de8936cb7083dd768f28cd37eb010492e2f19b71eb1294e4"
   "2.42":
     url:
       - "https://ftpmirror.gnu.org/gnu/binutils/binutils-2.42.tar.xz"

--- a/recipes/binutils/config.yml
+++ b/recipes/binutils/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "2.46.1":
+    folder: all
   "2.42":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe: **binutils/2.46.1**

#### Motivation
`binutils/2.42` is currently the only version in the index, and it fails to build with GCC 15.

GCC 15 defaults to `-std=gnu23`, where an empty parameter list `()` means "no parameters"
rather than "unspecified parameters". `gprofng/libcollector` declares its utility function
pointers that way and then calls them with arguments, which is now a hard error:

```
In file included from .../gprofng/libcollector/collector.h:29,
                 from .../gprofng/libcollector/mmaptrace.c:38:
.../gprofng/libcollector/mmaptrace.c: In function 'init_mmap_files':
.../gprofng/libcollector/../src/collector_module.h:123:22: error: too many arguments to function '__collector_util_funcs.access'; expected 0, have 2
  123 | #define CALL_UTIL(x) __collector_util_funcs.x
      |                      ^~~~~~~~~~~~~~~~~~~~~~
.../gprofng/libcollector/mmaptrace.c:323:7: note: in expansion of macro 'CALL_UTIL'
  323 |   if (CALL_UTIL (access)(dyntext_fname, F_OK) != 0)
      |       ^~~~~~~~~
.../gprofng/libcollector/../src/collector_module.h:43:9: note: declared here
   43 |   int (*access)();
      |         ^~~~~~
```

There are 82 such errors, plus a batch of `-Wincompatible-pointer-types` errors in
`libcollector/envmgmt.c`, and the build ends at:

```
make[1]: *** [Makefile:7322: all-gprofng] Error 2
make: *** [Makefile:1032: all] Error 2
ERROR: binutils/2.42: Error in build() method, line 158
	autotools.make()
	ConanException: Error 2 while executing
```

2.46.1 has these fixed upstream and builds cleanly with the same profile, with no recipe changes needed.

#### Details
Version bump only — `config.yml` and `conandata.yml` are the only files touched, the recipe
itself is unchanged, and no existing versions are removed.

The source archive is the official GNU release. Checksum verified against
https://ftp.gnu.org/gnu/binutils/binutils-2.46.1.tar.xz:

```
e127a709cba24c76de8936cb7083dd768f28cd37eb010492e2f19b71eb1294e4  binutils-2.46.1.tar.xz
```

The same three mirrors used by the existing entries are listed, in the same order.

Tested on Linux / x86_64 / gcc 15.2.0 / Release, Conan 2.30.0.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan
