### PR TITLE
upa-url: add version 2.5.0

### DIFF
--- a/recipes/upa-url/all/conandata.yml
+++ b/recipes/upa-url/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.5.0":
+    url: "https://github.com/upa-url/upa/archive/refs/tags/v2.5.0.tar.gz"
+    sha256: "3feec2468433831e6c65e31a9fdddc9711d5464759cb54d155bf99c4efbeaa88"
   "2.4.0":
     url: "https://github.com/upa-url/upa/archive/refs/tags/v2.4.0.tar.gz"
     sha256: "97a7ddf56c8b65e8b54027d01acfb4fe7b2f0f1f16ce5023d12ce5a5539718ff"

--- a/recipes/upa-url/all/conandata.yml
+++ b/recipes/upa-url/all/conandata.yml
@@ -2,6 +2,3 @@ sources:
   "2.5.0":
     url: "https://github.com/upa-url/upa/archive/refs/tags/v2.5.0.tar.gz"
     sha256: "3feec2468433831e6c65e31a9fdddc9711d5464759cb54d155bf99c4efbeaa88"
-  "2.4.0":
-    url: "https://github.com/upa-url/upa/archive/refs/tags/v2.4.0.tar.gz"
-    sha256: "97a7ddf56c8b65e8b54027d01acfb4fe7b2f0f1f16ce5023d12ce5a5539718ff"

--- a/recipes/upa-url/all/conanfile.py
+++ b/recipes/upa-url/all/conanfile.py
@@ -48,10 +48,9 @@ class upa_urlRecipe(ConanFile):
         copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
         cmake = CMake(self)
         cmake.install()
-        # Remove unused files
+
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
-        if Version(self.version) >= "2.5.0":
-            rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "upa")

--- a/recipes/upa-url/all/conanfile.py
+++ b/recipes/upa-url/all/conanfile.py
@@ -2,6 +2,7 @@ from conan import ConanFile
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout
 from conan.tools.files import copy, get, rmdir
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=2"
@@ -14,7 +15,7 @@ class upa_urlRecipe(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/upa-url/upa"
     description = "An implementation of the WHATWG URL Standard in C++"
-    topics = ("url", "parser", "psl", "whatwg")
+    topics = ("url", "urlpattern", "parser", "psl", "whatwg")
 
     # Binary configuration
     package_type = "library"
@@ -49,6 +50,8 @@ class upa_urlRecipe(ConanFile):
         cmake.install()
         # Remove unused files
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        if Version(self.version) >= "2.5.0":
+            rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "upa")

--- a/recipes/upa-url/config.yml
+++ b/recipes/upa-url/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "2.5.0":
+    folder: all
   "2.4.0":
     folder: all

--- a/recipes/upa-url/config.yml
+++ b/recipes/upa-url/config.yml
@@ -1,5 +1,3 @@
 versions:
   "2.5.0":
     folder: all
-  "2.4.0":
-    folder: all


### PR DESCRIPTION
### Summary
Add new version: **upa-url/2.5.0**

#### Motivation
Update to the latest release of the Upa URL library.

#### Details
* The `urlpattern` topic was added because this version implements the [URL Pattern standard](https://urlpattern.spec.whatwg.org/).
* Added statement to remove the `pkgconfig` directory generated by CMake starting with this version.

More information: https://github.com/upa-url/upa/releases/tag/v2.5.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] ~~If this is a bug fix, please link related issue or provide bug details~~
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
