### PR TITLE
chronicle: new recipe

### DIFF
--- a/recipes/chronicle/all/conandata.yml
+++ b/recipes/chronicle/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2.1.2":
+    url: "https://github.com/bhouvana/Chronicle/archive/refs/tags/v2.1.2.tar.gz"
+    sha256: "6a5a733dd5dafc2d070d508000946a4a7915f0f87938369a426352ad1f3d1139"

--- a/recipes/chronicle/all/conandata.yml
+++ b/recipes/chronicle/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "2.1.2":
-    url: "https://github.com/bhouvana/Chronicle/archive/refs/tags/v2.1.2.tar.gz"
-    sha256: "6a5a733dd5dafc2d070d508000946a4a7915f0f87938369a426352ad1f3d1139"
+  "2.1.3":
+    url: "https://github.com/bhouvana/Chronicle/archive/refs/tags/v2.1.3.tar.gz"
+    sha256: "4fd27b048537d42ecd63ef9f308d796901f9cf074040495b16ebfb91eef6dffd"

--- a/recipes/chronicle/all/conanfile.py
+++ b/recipes/chronicle/all/conanfile.py
@@ -1,0 +1,60 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+
+required_conan_version = ">=1.53.0"
+
+
+class ChronicleConan(ConanFile):
+    name = "chronicle"
+    description = (
+        "Time travel for runtime state: a C++23 header-only library for "
+        "recording, querying, and replaying the history of tracked "
+        "in-process state."
+    )
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/bhouvana/Chronicle"
+    topics = ("time-travel", "state-history", "debugging", "observability", "header-only")
+
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, 23)
+
+    def build(self):
+        pass
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        copy(
+            self,
+            "*.hpp",
+            src=os.path.join(self.source_folder, "include"),
+            dst=os.path.join(self.package_folder, "include"),
+        )
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.frameworkdirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.resdirs = []
+        self.cpp_info.set_property("cmake_file_name", "chronicle")
+        self.cpp_info.set_property("cmake_target_name", "chronicle::core")
+        if self.settings.os in ("Linux", "FreeBSD"):
+            self.cpp_info.system_libs.append("pthread")

--- a/recipes/chronicle/all/test_package/CMakeLists.txt
+++ b/recipes/chronicle/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.20)
+project(test_package LANGUAGES CXX)
+
+find_package(chronicle CONFIG REQUIRED)
+
+add_executable(test_package test_package.cpp)
+target_link_libraries(test_package PRIVATE chronicle::core)
+target_compile_features(test_package PRIVATE cxx_std_23)

--- a/recipes/chronicle/all/test_package/conanfile.py
+++ b/recipes/chronicle/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+
+class ChronicleTestConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(cmd, env="conanrun")

--- a/recipes/chronicle/all/test_package/test_package.cpp
+++ b/recipes/chronicle/all/test_package/test_package.cpp
@@ -1,0 +1,18 @@
+#include <chronicle/chronicle.hpp>
+#include <cstdio>
+
+int main() {
+    chronicle::Session session;
+    chronicle::tracked<int> counter{0};
+    chronicle::track(counter, session, "counter");
+
+    chronicle::set(counter, 1);
+    chronicle::set(counter, 2);
+    chronicle::set(counter, 3);
+
+    auto timeline = chronicle::history(counter);
+
+    std::printf("final value: %d\n", static_cast<int>(counter));
+    std::printf("history size: %zu\n", timeline.size());
+    return (static_cast<int>(counter) == 3 && timeline.size() == 4) ? 0 : 1;
+}

--- a/recipes/chronicle/config.yml
+++ b/recipes/chronicle/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "2.1.2":
+  "2.1.3":
     folder: all

--- a/recipes/chronicle/config.yml
+++ b/recipes/chronicle/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.1.2":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe: **chronicle/2.1.2** (new recipe)

#### Motivation
Adds a Conan recipe for [Chronicle](https://github.com/bhouvana/Chronicle), a header-only C++23 library for recording, querying, diffing, and replaying the history of runtime state.

#### Details
- Header-only (`package_type = "header-library"`), single real dependency (pthread on Linux/FreeBSD, via `system_libs`).
- `cmake_target_name` set to `chronicle::core` to match the library's documented CMake usage.
- `test_package` builds and runs a real executable exercising `tracked<int>`/`track()`/`set()`/`history()` against the packaged headers.
- Verified locally end-to-end with `conan create recipes/chronicle/all --version 2.1.2 -s compiler.cppstd=23`: source fetched from the real tagged release, package built, and `test_package` ran with correct output.

---
- [x] Read the contributing guidelines
- [x] Checked that this PR is not a duplicate
- [ ] N/A -- not a bug fix
- [x] Tested locally with at least one configuration using a recent version of Conan (2.31.1)
