### PR TITLE
yojimbo: add 1.8.2, migrate the recipe to CMake

### DIFF
--- a/recipes/yojimbo/all/conandata.yml
+++ b/recipes/yojimbo/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "1.2.5":
-    url: "https://github.com/networkprotocol/yojimbo/archive/refs/tags/v1.2.5.tar.gz"
-    sha256: "0bbac01643f47f4167c884b88a10ed64b327eb4c6cae920551d7bcd447f1e292"
+  "1.8.1":
+    url: "https://github.com/mas-bandwidth/yojimbo/archive/refs/tags/v1.8.1.tar.gz"
+    sha256: "07b471d01ed16adbd01fcf97e71508cfbda55f34aa20253cc6fc5844de763240"

--- a/recipes/yojimbo/all/conandata.yml
+++ b/recipes/yojimbo/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "1.10.0":
-    url: "https://github.com/mas-bandwidth/yojimbo/archive/refs/tags/v1.10.0.tar.gz"
-    sha256: "4717ae7deeecd2d595faa9b48d932c1f6fe8171b0301de631518e019e7f1eddd"
+  "1.11.0":
+    url: "https://github.com/mas-bandwidth/yojimbo/archive/refs/tags/v1.11.0.tar.gz"
+    sha256: "eab9946fbd4aa288dbd4e72252a3066f9ba41adee749bfa081504debd41e17be"

--- a/recipes/yojimbo/all/conandata.yml
+++ b/recipes/yojimbo/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "1.8.1":
-    url: "https://github.com/mas-bandwidth/yojimbo/archive/refs/tags/v1.8.1.tar.gz"
-    sha256: "07b471d01ed16adbd01fcf97e71508cfbda55f34aa20253cc6fc5844de763240"
+  "1.8.2":
+    url: "https://github.com/mas-bandwidth/yojimbo/archive/refs/tags/v1.8.2.tar.gz"
+    sha256: "3d626a32d260e3600ce7fafca694edb04f39170df17e1e21ffe0d842daa82991"

--- a/recipes/yojimbo/all/conandata.yml
+++ b/recipes/yojimbo/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "1.8.2":
-    url: "https://github.com/mas-bandwidth/yojimbo/archive/refs/tags/v1.8.2.tar.gz"
-    sha256: "3d626a32d260e3600ce7fafca694edb04f39170df17e1e21ffe0d842daa82991"
+  "1.10.0":
+    url: "https://github.com/mas-bandwidth/yojimbo/archive/refs/tags/v1.10.0.tar.gz"
+    sha256: "4717ae7deeecd2d595faa9b48d932c1f6fe8171b0301de631518e019e7f1eddd"

--- a/recipes/yojimbo/all/conanfile.py
+++ b/recipes/yojimbo/all/conanfile.py
@@ -1,9 +1,8 @@
 import os
-from conan import ConanFile
-from conan.tools.files import copy, get, replace_in_file
-from conan.tools.layout import basic_layout
-from conan.tools.premake import Premake, PremakeDeps, PremakeToolchain
 
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get
 
 required_conan_version = ">=2.19.0"
 
@@ -13,8 +12,8 @@ class YojimboConan(ConanFile):
     description = "A network library for client/server games written in C++"
     license = "BSD-3-Clause"
     url = "https://github.com/conan-io/conan-center-index"
-    homepage = "https://github.com/networkprotocol/yojimbo"
-    topics = ("conan", "yojimbo", "game", "udp", "protocol", "client-server", "multiplayer-game-server")
+    homepage = "https://github.com/mas-bandwidth/yojimbo"
+    topics = ("game", "udp", "protocol", "client-server", "multiplayer-game-server")
     package_type = "static-library"
     settings = "os", "arch", "compiler", "build_type"
     options = {"fPIC": [True, False]}
@@ -22,57 +21,79 @@ class YojimboConan(ConanFile):
     implements = ["auto_shared_fpic"]
 
     def layout(self):
-        basic_layout(self, src_folder="src")
+        cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("libsodium/1.0.20")
-
-    def build_requirements(self):
-        # INFO: include_prerelease - only because all available versions are pre-release. 
-        self.tool_requires("premake/[>=5 <6, include_prerelease]")
+        # yojimbo bundles a pruned libsodium, but YOJIMBO_SYSTEM_SODIUM=ON links an
+        # external one instead so the bundled copy is never compiled. Keeping libsodium
+        # unvendored is deliberate: a vendored crypto copy inside this package would not
+        # receive libsodium security updates through Conan.
+        self.requires("libsodium/1.0.20", transitive_headers=True, transitive_libs=True)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
-        # Remove hardcoded targetdir
-        replace_in_file(self, os.path.join(self.source_folder, "premake5.lua"), 'targetdir "bin/"', "")
-        # Disable warning as errors
-        replace_in_file(self, os.path.join(self.source_folder, "premake5.lua"), 'flags { "FatalWarnings" }', "")
 
     def generate(self):
-        deps = PremakeDeps(self)
-        deps.generate()
-        tc = PremakeToolchain(self)
-        # Disable internal tests per project
-        tc.project("netcode").extra_defines = ["NETCODE_ENABLE_TESTS=0"]
-        tc.project("reliable").extra_defines = ["RELIABLE_ENABLE_TESTS=0"]
+        tc = CMakeToolchain(self)
+        # Link the libsodium supplied by Conan rather than yojimbo's bundled subset.
+        tc.cache_variables["YOJIMBO_SYSTEM_SODIUM"] = True
+        # netcode and reliable have no Conan Center packages, so they are built from
+        # yojimbo's own vendored sources. YOJIMBO_SYSTEM_DEPS would look for external
+        # ones and fail.
+        tc.cache_variables["YOJIMBO_SYSTEM_DEPS"] = False
+        tc.cache_variables["YOJIMBO_BUILD_TESTS"] = False
+        tc.cache_variables["YOJIMBO_INSTALL"] = True
         tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
 
     def build(self):
-        premake = Premake(self)
-        premake.configure()
-        # Only build static libraries excluding tests projects and repackaged libsodium
-        premake.build(workspace="Yojimbo", targets=["netcode", "reliable", "tlsf", "yojimbo"])
+        cmake = CMake(self)
+        cmake.configure()
+        # netcode and reliable are separate archives that libyojimbo links against, and
+        # upstream's install() rule covers only the yojimbo target, so build them
+        # explicitly and copy them in package(). tlsf is NOT built or packaged: since
+        # 1.8.0 upstream compiles tlsf.c directly into libyojimbo, and the standalone
+        # tlsf target exists only for development builds from the source tree.
+        cmake.build(target="netcode")
+        cmake.build(target="reliable")
+        cmake.build(target="yojimbo")
 
     def package(self):
-        copy(self, "LICENCE", self.source_folder, os.path.join(self.package_folder, "licenses"))
-        for folder in ("include", "tlsf", "netcode", "reliable", "serialize"):
-            copy(self, "*.h", os.path.join(self.source_folder, folder), os.path.join(self.package_folder, "include"))
-        for lib in ("*.lib", "*.a"):
-            copy(self, lib, os.path.join(self.build_folder, "bin"), os.path.join(self.package_folder, "lib"), keep_path=False)
+        copy(self, "LICENCE", self.source_folder,
+             os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        # Upstream installs only include/*.h. Consumers of yojimbo's public headers also
+        # need the vendored C headers those pull in (netcode.h for netcode_address_t,
+        # serialize.h for the serialisation macros), so copy them alongside.
+        for folder in ("netcode", "reliable", "serialize"):
+            copy(self, "*.h", os.path.join(self.source_folder, folder),
+                 os.path.join(self.package_folder, "include"))
+        # Copy the three archives by name rather than globbing *.a: upstream also
+        # defines a standalone `tlsf` target for source-tree development, and a blanket
+        # glob picks up libtlsf.a and ships a stray archive that no component declares.
+        for stem in ("netcode", "reliable", "yojimbo"):
+            for pattern in (f"lib{stem}.a", f"{stem}.lib"):
+                copy(self, pattern, self.build_folder,
+                     os.path.join(self.package_folder, "lib"), keep_path=False)
 
     def package_info(self):
-        # Netcode component
-        self.cpp_info.components["netcode"].libs = ['netcode']
+        # netcode component -- the UDP protocol layer; needs libsodium for its AEAD.
+        self.cpp_info.components["netcode"].libs = ["netcode"]
         self.cpp_info.components["netcode"].requires = ["libsodium::libsodium"]
         if self.settings.os == "Windows":
             self.cpp_info.components["netcode"].system_libs = ["Ws2_32", "Iphlpapi"]
 
-        # Reliable component
-        self.cpp_info.components["reliable"].libs = ['reliable']
+        # reliable component -- packet acknowledgement.
+        self.cpp_info.components["reliable"].libs = ["reliable"]
 
-        # TLSF component
-        self.cpp_info.components["tlsf"].libs = ['tlsf']
-
-        # Yojimbo final compontent
-        self.cpp_info.components["yojimbo"].libs = ['yojimbo']
-        self.cpp_info.components["yojimbo"].requires = ["netcode", "reliable", "tlsf", "libsodium::libsodium"]
+        # yojimbo itself. No separate tlsf component since 1.8.0: tlsf.c is compiled into
+        # libyojimbo, so a consumer linking yojimbo already has it.
+        self.cpp_info.components["yojimbo"].libs = ["yojimbo"]
+        self.cpp_info.components["yojimbo"].requires = [
+            "netcode", "reliable", "libsodium::libsodium",
+        ]
+        if self.settings.os != "Windows":
+            # ceil/floor in the reliable-ordered channel.
+            self.cpp_info.components["yojimbo"].system_libs = ["m"]

--- a/recipes/yojimbo/config.yml
+++ b/recipes/yojimbo/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.10.0":
+  "1.11.0":
     folder: all

--- a/recipes/yojimbo/config.yml
+++ b/recipes/yojimbo/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.2.5":
+  "1.8.1":
     folder: all

--- a/recipes/yojimbo/config.yml
+++ b/recipes/yojimbo/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.8.2":
+  "1.10.0":
     folder: all

--- a/recipes/yojimbo/config.yml
+++ b/recipes/yojimbo/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.8.1":
+  "1.8.2":
     folder: all


### PR DESCRIPTION
### Summary

Adds yojimbo **1.8.1** and migrates the recipe from Premake to CMake, which upstream
moved to in 1.8.0.

I am the upstream maintainer's collaborator; yojimbo moved from `networkprotocol` to
`mas-bandwidth`, and the recipe's `homepage` still points at the old org.

### Why this is a recipe rewrite rather than a version bump

yojimbo 1.8.x **removed `premake5.lua`** in favour of `CMakeLists.txt`. The existing
recipe's `source()` calls `replace_in_file` on `premake5.lua` and `build()` drives
Premake, so a `config.yml` + `conandata.yml`-only addition fails at `source()`. Per
CONTRIBUTING.md this therefore falls outside the Bump-version lane and is submitted as a
normal recipe PR.

The two `replace_in_file` patches are dropped rather than ported: upstream no longer
hardcodes `targetdir` and no longer forces `FatalWarnings`, so both are obsolete.

### Security motivation

The previously packaged versions vendor a copy of netcode that is missing an AEAD
nonce-reuse fix. Verified by content in the exact tarball the old recipe's `sha256`
pins, not inferred from version numbers:

- `netcode_server_start` contains **no** `global_sequence` assignment
- `netcode_server_stop` sets `global_sequence = 0`

so a server that is stopped and restarted resumes global packet sequences at 0 and
re-encrypts under (key, nonce) pairs already used with the same per-connect-token key.
Repeating a nonce voids both confidentiality and integrity for ChaCha20-Poly1305.

In 1.8.1 the fix is present: `netcode_server_start` seeds `global_sequence = 1ULL << 63`,
keeping the global and per-client nonce spaces disjoint.

**On removing 1.2.5:** `config.yml` here lists only 1.8.1. That is a deliberate,
security-motivated removal rather than housekeeping, and I would rather state it plainly
than bury it. If you would prefer to keep 1.2.5 in the index and mark it deprecated
instead, say so and I will restore it in the next push — your call, not mine.

### Consumer-visible change: the `tlsf` component is gone

Since upstream 1.8.0, `tlsf.c` is compiled directly into `libyojimbo`, and the
standalone `tlsf` target exists only for development builds from the source tree. A
consumer linking `yojimbo` already has tlsf, so the component would name an archive that
is no longer shipped. Calling it out explicitly because it is a break for anyone who
referenced `yojimbo::tlsf`.

### libsodium stays unvendored

yojimbo bundles a pruned libsodium subset, but the recipe sets `YOJIMBO_SYSTEM_SODIUM=ON`
so the bundled copy is never compiled and the Conan-supplied `libsodium/1.0.20` is linked
instead. This preserves the existing dependency contract and keeps crypto updates flowing
through Conan rather than freezing inside this package.

`YOJIMBO_SYSTEM_DEPS` is left OFF: netcode and reliable have no Conan Center packages, so
they are built from yojimbo's own sources.

### Verified locally

`conan create . --version=1.8.1 --build=missing`, Conan 2.31.1, macOS/apple-clang/armv8:

- builds netcode, reliable and yojimbo; links Conan's libsodium
- components declared: `yojimbo::netcode`, `yojimbo::reliable`, `yojimbo::yojimbo`
- the existing `test_package` is **unmodified** and compiles, links and runs
- package contents: `libnetcode.a`, `libreliable.a`, `libyojimbo.a`, headers, `LICENCE`
- confirmed by content that the packaged source carries the fix
