### PR TITLE
trantor: add version 1.5.28

### DIFF
--- a/recipes/trantor/all/conandata.yml
+++ b/recipes/trantor/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.5.28":
+    url: "https://github.com/an-tao/trantor/archive/v1.5.28.tar.gz"
+    sha256: "8e3e493427a1704ee0d8cacb65e61b544d4b3a7159f5a4e55517272e1fb25c8f"
   "1.5.26":
     url: "https://github.com/an-tao/trantor/archive/v1.5.26.tar.gz"
     sha256: "e47092938aaf53d51c8bc72d8f54ebdcf537e6e4ac9c8276f3539413d6dfeddf"

--- a/recipes/trantor/config.yml
+++ b/recipes/trantor/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.5.28":
+    folder: "all"
   "1.5.26":
     folder: "all"


### PR DESCRIPTION
### Summary
Changes to recipe:  **trantor/1.5.28**

#### Motivation
The upstream released version 1.5.28, which includes fixes for OpenSSL 4 support (#30589).

#### Details
Added trantor version 1.5.28. 

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
