### PR TITLE
grpc: Fix MSVC compilation issue in version 1.82.0

### DIFF
--- a/recipes/grpc/all/conandata.yml
+++ b/recipes/grpc/all/conandata.yml
@@ -9,5 +9,7 @@ sources:
     url: "https://github.com/grpc/grpc/archive/v1.54.3.tar.gz"
     sha256: "17e4e1b100657b88027721220cbfb694d86c4b807e9257eaf2fb2d273b41b1b1"
 patches:
+  "1.82.0":
+    - patch_file: "patches/v1.82.0/fix-msvc-auto-return-type-template-arg.patch"
   "1.54.3":
     - patch_file: "patches/v1.50.x/002-CMake-Add-gRPC_USE_SYSTEMD-option-34384.patch"

--- a/recipes/grpc/all/patches/v1.82.0/fix-msvc-auto-return-type-template-arg.patch
+++ b/recipes/grpc/all/patches/v1.82.0/fix-msvc-auto-return-type-template-arg.patch
@@ -1,0 +1,114 @@
+Temporary patch for issue https://github.com/grpc/grpc/issues/41436
+diff --git a/src/core/call/call_filters.h b/src/core/call/call_filters.h
+index 4ec8ac8473..95be3e008c 100644
+--- a/src/core/call/call_filters.h
++++ b/src/core/call/call_filters.h
+@@ -1627,17 +1627,26 @@ constexpr bool MethodHasChannelAccess<R (T::*)(A, C)> = true;
+ template <typename... Ts>
+ constexpr bool AnyMethodHasChannelAccess = (MethodHasChannelAccess<Ts> || ...);
+ 
++// Helper for CallHasChannelAccess() that accepts method pointers as function
++// arguments to avoid MSVC C3539 errors when methods have deduced return types
++// (e.g. for FusedFilter types whose Call methods have auto return types).
++template <typename T1, typename T2, typename T3, typename T4, typename T5,
++          typename T6>
++inline constexpr bool CallHasChannelAccessHelper(T1, T2, T3, T4, T5, T6) {
++  return AnyMethodHasChannelAccess<T1, T2, T3, T4, T5, T6>;
++}
++
+ // Composite for a given channel type to determine if any of its interceptors
+ // fall into this category: later code should use this.
+ template <typename Derived>
+ inline constexpr bool CallHasChannelAccess() {
+-  return AnyMethodHasChannelAccess<
+-      decltype(&Derived::Call::OnClientInitialMetadata),
+-      decltype(&Derived::Call::OnClientToServerMessage),
+-      decltype(&Derived::Call::OnServerInitialMetadata),
+-      decltype(&Derived::Call::OnServerToClientMessage),
+-      decltype(&Derived::Call::OnServerTrailingMetadata),
+-      decltype(&Derived::Call::OnFinalize)>;
++  return CallHasChannelAccessHelper(
++      &Derived::Call::OnClientInitialMetadata,
++      &Derived::Call::OnClientToServerMessage,
++      &Derived::Call::OnServerInitialMetadata,
++      &Derived::Call::OnServerToClientMessage,
++      &Derived::Call::OnServerTrailingMetadata,
++      &Derived::Call::OnFinalize);
+ }
+ }  // namespace filters_detail
+ 
+diff --git a/src/core/lib/channel/promise_based_filter.h b/src/core/lib/channel/promise_based_filter.h
+index 15fa55a4e7..178c12af8e 100644
+--- a/src/core/lib/channel/promise_based_filter.h
++++ b/src/core/lib/channel/promise_based_filter.h
+@@ -1122,6 +1122,37 @@ MakeFilterCall(Derived* derived) {
+   return GetContext<Arena>()->ManagedNew<FilterCallData<Derived>>(derived);
+ }
+ 
++// Helper functions for ImplementChannelFilter::MakeCallPromise() that accept
++// method pointers as function arguments to avoid MSVC C3539 errors when
++// methods have deduced return types (e.g. for FusedFilter types).
++template <typename HookFn, typename HalfCloseFn, typename Derived>
++inline void RunInterceptClientToServerMessage(HookFn, HalfCloseFn,
++                                               FilterCallData<Derived>* call,
++                                               const CallArgs& call_args) {
++  InterceptClientToServerMessage<HookFn, HalfCloseFn, Derived>::Run(call,
++                                                                     call_args);
++}
++
++template <typename MethodFn, typename Derived>
++inline void RunInterceptServerInitialMetadata(MethodFn,
++                                              FilterCallData<Derived>* call,
++                                              const CallArgs& call_args) {
++  InterceptServerInitialMetadata<Derived, MethodFn>::Run(call, call_args);
++}
++
++template <typename MethodFn, typename Derived>
++inline void RunInterceptServerToClientMessage(MethodFn,
++                                              FilterCallData<Derived>* call,
++                                              const CallArgs& call_args) {
++  InterceptServerToClientMessage<Derived, MethodFn>::Run(call, call_args);
++}
++
++template <typename MethodFn, typename Derived>
++inline void RunInterceptFinalize(MethodFn, Derived* channel,
++                                 typename Derived::Call* call) {
++  InterceptFinalize<Derived, MethodFn>::Run(channel, call);
++}
++
+ }  // namespace promise_filter_detail
+ 
+ // Base class for promise-based channel filters.
+@@ -1192,22 +1223,16 @@ class ImplementChannelFilter : public ChannelFilter,
+       CallArgs call_args, NextPromiseFactory next_promise_factory) final {
+     auto* call = promise_filter_detail::MakeFilterCall<Derived>(
+         static_cast<Derived*>(this));
+-    promise_filter_detail::InterceptClientToServerMessage<
+-        decltype(&Derived::Call::OnClientToServerMessage),
+-        decltype(&Derived::Call::OnClientToServerHalfClose),
+-        Derived>::Run(call, call_args);
+-    promise_filter_detail::InterceptServerInitialMetadata<
+-        Derived,
+-        decltype(&Derived::Call::OnServerInitialMetadata)>::Run(call,
+-                                                                call_args);
+-    promise_filter_detail::InterceptServerToClientMessage<
+-        Derived,
+-        decltype(&Derived::Call::OnServerToClientMessage)>::Run(call,
+-                                                                call_args);
+-    promise_filter_detail::
+-        InterceptFinalize<Derived, decltype(&Derived::Call::OnFinalize)>::Run(
+-            static_cast<Derived*>(this),
+-            static_cast<typename Derived::Call*>(&call->call));
++    promise_filter_detail::RunInterceptClientToServerMessage(
++        &Derived::Call::OnClientToServerMessage,
++        &Derived::Call::OnClientToServerHalfClose, call, call_args);
++    promise_filter_detail::RunInterceptServerInitialMetadata(
++        &Derived::Call::OnServerInitialMetadata, call, call_args);
++    promise_filter_detail::RunInterceptServerToClientMessage(
++        &Derived::Call::OnServerToClientMessage, call, call_args);
++    promise_filter_detail::RunInterceptFinalize(
++        &Derived::Call::OnFinalize, static_cast<Derived*>(this),
++        static_cast<typename Derived::Call*>(&call->call));
+     return promise_filter_detail::MapResult(
+         &Derived::Call::OnServerTrailingMetadata,
+         promise_filter_detail::RaceAsyncCompletion<


### PR DESCRIPTION
### Summary
Changes to recipe:  **grpc/1.82.0**

#### Motivation
Grpc compilation fails on Windows with the issue https://github.com/grpc/grpc/issues/41436

#### Details
Added patch that fixes compilation of grpc using C++ standard 20 and above on Windows. The issue was opened for grpc v1.76.0, but is still present in version 1.82.0.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
