### PR TITLE
kubernetes: Add version 0.14.0

### DIFF
--- a/recipes/kubernetes/all/conandata.yml
+++ b/recipes/kubernetes/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.14.0":
+    url: "https://github.com/kubernetes-client/c/archive/refs/tags/v0.14.0.tar.gz"
+    sha256: "52216183b540cd10cfe33da326c7a529c127e9bca3cc512533059374591cbdc4"
   "0.13.0":
     url: "https://github.com/kubernetes-client/c/archive/refs/tags/v0.13.0.tar.gz"
     sha256: "4421066f4563a734f8ad33313f90d43fe82fd2533e9081fceca5e58790958c8e"

--- a/recipes/kubernetes/all/conanfile.py
+++ b/recipes/kubernetes/all/conanfile.py
@@ -21,9 +21,9 @@ class kubernetesRecipe(ConanFile):
     # Binary configuration
     settings = "os", "compiler", "build_type", "arch"
     options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = {"shared": True, "fPIC": True}
+    default_options = {"shared": False, "fPIC": True}
 
-    implements = ["auto_shared_fpic", "auto_language"]
+    implements = ["auto_shared_fpic"]
     languages = "C"
 
     def source(self):

--- a/recipes/kubernetes/all/conanfile.py
+++ b/recipes/kubernetes/all/conanfile.py
@@ -46,8 +46,6 @@ class kubernetesRecipe(ConanFile):
         deps = CMakeDeps(self)
         deps.generate()
         tc = CMakeToolchain(self)
-        tc.cache_variables["BUILD_STATIC_LIBS"] = not self.options.shared
-        tc.cache_variables["BUILD_SHARED_LIBS"] = self.options.shared
         tc.generate()
 
     def build(self):

--- a/recipes/kubernetes/all/conanfile.py
+++ b/recipes/kubernetes/all/conanfile.py
@@ -46,6 +46,8 @@ class kubernetesRecipe(ConanFile):
         deps = CMakeDeps(self)
         deps.generate()
         tc = CMakeToolchain(self)
+        tc.cache_variables["BUILD_STATIC_LIBS"] = not self.options.shared
+        tc.cache_variables["BUILD_SHARED_LIBS"] = self.options.shared
         tc.generate()
 
     def build(self):

--- a/recipes/kubernetes/config.yml
+++ b/recipes/kubernetes/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.14.0":
+    folder: "all"
   "0.13.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **kubernetes/0.14.0**

#### Motivation
Latest version if kubernetes c client was missing and also static build flag of the library was not honored in the recipe.

#### Details
Added version 0.14.0 of the kubernetes c client and fixed compile options when `shared` Conan option was set to False.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
