### PR TITLE
protobuf: fix issue when building with nvcc for version 6.33.5

### DIFF
--- a/recipes/protobuf/all/conandata.yml
+++ b/recipes/protobuf/all/conandata.yml
@@ -8,6 +8,9 @@ sources:
   "5.29.6":
     url: "https://github.com/protocolbuffers/protobuf/releases/download/v29.6/protobuf-29.6.tar.gz"
     sha256: "877bf9f880631aa31daf2c09896276985696728137fcd43cc534a28c5566d9ba"
+patches:
+  "6.33.5":
+    - patch_file: "patches/6.33.5-nvcc.patch"
 absl_deps:
   # reference: https://github.com/protocolbuffers/protobuf/blob/main/cmake/abseil-cpp.cmake
   "7.35.0":

--- a/recipes/protobuf/all/patches/6.33.5-nvcc.patch
+++ b/recipes/protobuf/all/patches/6.33.5-nvcc.patch
@@ -1,0 +1,32 @@
+Backport Fix for issue https://github.com/protocolbuffers/protobuf/issues/21542
+Also experienced when using nvcc (e.g. onnxruntime with CUDA)
+This is a conservative backport of:
+      https://github.com/protocolbuffers/protobuf/commit/211f52431b9ec30d4d4a1c76aafd64bd78d93c43
+Guarded by `__CUDACC__` so as to not alter behaviour for other compilers
+
+
+diff --git a/src/google/protobuf/message_lite.h b/src/google/protobuf/message_lite.h
+index 25264ef..6e0ba91 100644
+--- a/src/google/protobuf/message_lite.h
++++ b/src/google/protobuf/message_lite.h
+@@ -292,11 +292,18 @@ struct MessageTraitsImpl {
+ template <typename T>
+ using MessageTraits = decltype(MessageTraitsImpl::value<T>);
+ 
++#ifdef __CUDACC__
+ struct EnumTraitsImpl {
+-  struct Undefined;
+   template <typename T>
+-  static Undefined value;
++  static std::enable_if_t<sizeof(T) != 0> value;
+ };
++#else
++ struct EnumTraitsImpl {
++   struct Undefined;
++   template <typename T>
++   static Undefined value;
++ };
++#endif
+ template <typename T>
+ using EnumTraits = decltype(EnumTraitsImpl::value<T>);
+ 


### PR DESCRIPTION
### Summary
Fix for issue described here https://github.com/conan-io/conan-center-index/issues/30365#issuecomment-4717804329,
when protobuf/6.33.5 is a dependency of onnxruntime and CUDA supported is enabled.

* Described and reported https://github.com/protocolbuffers/protobuf/issues/21542
* Fixed in https://github.com/protocolbuffers/protobuf/commit/211f52431b9ec30d4d4a1c76aafd64bd78d93c43

no longer an issue in our 7.x releases.

