### PR TITLE
cpuinfo: publish version cci.20260612

### DIFF
--- a/recipes/cpuinfo/all/conandata.yml
+++ b/recipes/cpuinfo/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "cci.20260612":
+    url: "https://github.com/pytorch/cpuinfo/archive/4628dc060ce4e82345dc166bbac875609db4ff69.tar.gz"
+    sha256: "a550205e891f9f1982044a306cb54556347645cba129af34cd907160f83bd0f1"
   "cci.20251210":
     url: "https://github.com/pytorch/cpuinfo/archive/ff24ffee8340fbd9001cce6a9ef41cdd16aa2bd3.tar.gz"
     sha256: "59a0a35488762568c7b7575352d726cb11fee361455e451ad820bdf5a01b856e"

--- a/recipes/cpuinfo/config.yml
+++ b/recipes/cpuinfo/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "cci.20260612":
+    folder: all
   "cci.20251210":
     folder: all
   "cci.20250110":


### PR DESCRIPTION
### Summary
Changes to recipe:  **cpuinfo/cci.20260612**

#### Motivation
This version is used in onnxruntime

#### Details
This specific commit is used in v1.28.0 release of onnxruntime
https://github.com/microsoft/onnxruntime/blob/v1.28.0/cmake/deps.txt#L53

Diff with cci.20251210
https://github.com/pytorch/cpuinfo/compare/ff24ffee8340fbd9001cce6a9ef41cdd16aa2bd3...4628dc060ce4e82345dc166bbac875609db4ff69

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
