### PR TITLE
hwloc: Add version 2.14.0

### DIFF
--- a/recipes/hwloc/all/conandata.yml
+++ b/recipes/hwloc/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "2.14.0":
+    url: "https://download.open-mpi.org/release/hwloc/v2.14/hwloc-2.14.0.tar.bz2"
+    sha256: "966b9bb3e9f29f8d65ce8d106779e457f40e246a645e584b100772a42f9ae94b"
   "2.12.2":
     url: "https://download.open-mpi.org/release/hwloc/v2.12/hwloc-2.12.2.tar.bz2"
     sha256: "563e61d70febb514138af0fac36b97621e01a4aacbca07b86e7bd95b85055ba0"

--- a/recipes/hwloc/all/conanfile.py
+++ b/recipes/hwloc/all/conanfile.py
@@ -4,6 +4,7 @@ from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rm, rmdir
 from conan.tools.gnu import Autotools, AutotoolsToolchain, PkgConfigDeps
 from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=2.1"
@@ -58,13 +59,19 @@ class HwlocConan(ConanFile):
             deps.generate()
             tc = CMakeToolchain(self)
             tc.cache_variables["HWLOC_ENABLE_TESTING"] = 'OFF'
+            tc.cache_variables["HWLOC_ENABLE_PLUGINS"] = 'OFF'
             tc.cache_variables["HWLOC_SKIP_LSTOPO"] = 'ON'
             tc.cache_variables["HWLOC_SKIP_TOOLS"] = 'ON'
             tc.cache_variables["HWLOC_SKIP_INCLUDES"] = 'OFF'
+            tc.cache_variables["HWLOC_WITH_LIBXML2"] = self.options.with_libxml2
             tc.cache_variables["HWLOC_WITH_OPENCL"] = 'OFF'
             tc.cache_variables["HWLOC_WITH_CUDA"] = 'OFF'
-            tc.cache_variables["HWLOC_BUILD_SHARED_LIBS"] = True
-            tc.cache_variables["HWLOC_WITH_LIBXML2"] = self.options.with_libxml2
+
+            if Version(self.version) >= "2.13.0":
+                tc.cache_variables["BUILD_SHARED_LIBS"] = self.options.shared
+            else:
+                tc.cache_variables["HWLOC_BUILD_SHARED_LIBS"] = True
+
             tc.generate()
         else:
             deps = PkgConfigDeps(self)

--- a/recipes/hwloc/all/conanfile.py
+++ b/recipes/hwloc/all/conanfile.py
@@ -67,9 +67,7 @@ class HwlocConan(ConanFile):
             tc.cache_variables["HWLOC_WITH_OPENCL"] = 'OFF'
             tc.cache_variables["HWLOC_WITH_CUDA"] = 'OFF'
 
-            if Version(self.version) >= "2.13.0":
-                tc.cache_variables["BUILD_SHARED_LIBS"] = self.options.shared
-            else:
+            if Version(self.version) < "2.13.0":
                 tc.cache_variables["HWLOC_BUILD_SHARED_LIBS"] = True
 
             tc.generate()

--- a/recipes/hwloc/config.yml
+++ b/recipes/hwloc/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "2.14.0":
+    folder: all
   "2.12.2":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **hwloc/2.14.0**

#### Motivation
Update hwloc to the latest release.

#### Details
Starting with [hwloc version 2.13](https://raw.githubusercontent.com/open-mpi/hwloc/v2.14/NEWS):
"HWLOC_BUILD_SHARED_LIBS is removed in favor of BUILD_SHARED_LIBS."


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] ~~If this is a bug fix, please link related issue or provide bug details~~
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
