### PR TITLE
sioxx: add new recipe (v0.3.0)

### DIFF
--- a/recipes/sioxx/all/conandata.yml
+++ b/recipes/sioxx/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.2.0":
+    url: "https://github.com/jfayot/sioxx/archive/refs/tags/v0.2.0.tar.gz"
+    sha256: "68b5e99c5de25e9c867f10b9b21d71d9b71eac435299f4322ffb1dd88913b067"
   "0.1.1":
     url: "https://github.com/jfayot/sioxx/archive/refs/tags/v0.1.1.tar.gz"
     sha256: "feb9f7e75499dae7846193fff99f6d220d4a51d3f45138992012a84cf553dc80"

--- a/recipes/sioxx/all/conandata.yml
+++ b/recipes/sioxx/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "0.2.0":
-    url: "https://github.com/jfayot/sioxx/archive/refs/tags/v0.2.0.tar.gz"
-    sha256: "68b5e99c5de25e9c867f10b9b21d71d9b71eac435299f4322ffb1dd88913b067"
+  "0.3.0":
+    url: "https://github.com/jfayot/sioxx/archive/refs/tags/v0.3.0.tar.gz"
+    sha256: "f41e084fd16c4d59ea8669173c5276f99d2d20be9a78c097e5568fac15352fdf"

--- a/recipes/sioxx/all/conandata.yml
+++ b/recipes/sioxx/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.1.1":
+    url: "https://github.com/jfayot/sioxx/archive/refs/tags/v0.1.1.tar.gz"
+    sha256: "feb9f7e75499dae7846193fff99f6d220d4a51d3f45138992012a84cf553dc80"

--- a/recipes/sioxx/all/conandata.yml
+++ b/recipes/sioxx/all/conandata.yml
@@ -2,6 +2,3 @@ sources:
   "0.2.0":
     url: "https://github.com/jfayot/sioxx/archive/refs/tags/v0.2.0.tar.gz"
     sha256: "68b5e99c5de25e9c867f10b9b21d71d9b71eac435299f4322ffb1dd88913b067"
-  "0.1.1":
-    url: "https://github.com/jfayot/sioxx/archive/refs/tags/v0.1.1.tar.gz"
-    sha256: "feb9f7e75499dae7846193fff99f6d220d4a51d3f45138992012a84cf553dc80"

--- a/recipes/sioxx/all/conanfile.py
+++ b/recipes/sioxx/all/conanfile.py
@@ -45,7 +45,7 @@ class SioxxConan(ConanFile):
         )
 
     def build_requirements(self):
-        self.tool_requires("cmake/[>=3.28 <4]")
+        self.tool_requires("cmake/[>=3.28]")
 
     def validate(self):
         check_min_cppstd(self, 17)

--- a/recipes/sioxx/all/conanfile.py
+++ b/recipes/sioxx/all/conanfile.py
@@ -1,0 +1,98 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, rmdir
+
+
+required_conan_version = ">=2.28"
+
+
+class SioxxConan(ConanFile):
+    name = "sioxx"
+    description = "A modern C++17 Socket.IO client built on Boost.Beast"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/jfayot/sioxx"
+    topics = ("socket.io", "websocket", "boost-beast", "networking")
+    package_type = "library"
+
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "boost/*:header_only": True,
+    }
+
+    implements = ["auto_shared_fpic"]
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("boost/1.90.0", visible=False)
+        self.requires("nlohmann_json/3.12.0", transitive_headers=True)
+        self.requires(
+            "openssl/3.6.3",
+            transitive_headers=False,
+            transitive_libs=not self.options.shared,
+            visible=not self.options.shared,
+        )
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.28 <4]")
+
+    def validate(self):
+        check_min_cppstd(self, 17)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
+
+        tc = CMakeToolchain(self)
+        tc.cache_variables["BUILD_SHARED_LIBS"] = bool(self.options.shared)
+        tc.cache_variables["SIOXX_BUILD_DOCS"] = False
+        tc.cache_variables["SIOXX_BUILD_EXAMPLES"] = False
+        tc.cache_variables["SIOXX_BUILD_TESTS"] = False
+        tc.cache_variables["SIOXX_INSTALL"] = True
+        tc.cache_variables["SIOXX_USE_SYSTEM_BOOST"] = True
+        tc.cache_variables["SIOXX_USE_SYSTEM_JSON"] = True
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(
+            self,
+            "LICENSE",
+            src=self.source_folder,
+            dst=os.path.join(self.package_folder, "licenses"),
+        )
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["sioxx"]
+        self.cpp_info.set_property("cmake_file_name", "sioxx")
+        self.cpp_info.set_property("cmake_target_name", "sioxx::sioxx")
+        self.cpp_info.set_property("pkg_config_name", "sioxx")
+        self.cpp_info.requires = ["nlohmann_json::nlohmann_json"]
+
+        if not self.options.shared:
+            self.cpp_info.requires.extend(["openssl::ssl", "openssl::crypto"])
+            if self.settings.os == "Windows":
+                self.cpp_info.system_libs.extend(["ws2_32", "mswsock"])
+            elif self.settings.os in ("Linux", "FreeBSD"):
+                self.cpp_info.system_libs.append("pthread")

--- a/recipes/sioxx/all/test_package/CMakeLists.txt
+++ b/recipes/sioxx/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(sioxx REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE sioxx::sioxx)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/sioxx/all/test_package/conanfile.py
+++ b/recipes/sioxx/all/test_package/conanfile.py
@@ -1,0 +1,27 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/sioxx/all/test_package/test_package.cpp
+++ b/recipes/sioxx/all/test_package/test_package.cpp
@@ -1,0 +1,19 @@
+#include <sioxx/sioxx.hpp>
+
+int main()
+{
+    sioxx::client_options opts;
+    opts.parser = sioxx::parser_kind::msgpack;
+    opts.reconnect_attempts = 5;
+    opts.reconnect_delay = std::chrono::milliseconds(1000);
+    opts.reconnect_delay_max = std::chrono::milliseconds(30000);
+    opts.reconnect_randomization_factor = 0.5;
+
+    sioxx::client client(opts);
+
+    auto sock = client.socket("/chat");
+    sock->on("hello_world", [](const std::string &event, sioxx::message data) {});
+
+    const auto message = sioxx::make_args("conan", 2);
+    return message.size() == 2 ? 0 : 1;
+}

--- a/recipes/sioxx/config.yml
+++ b/recipes/sioxx/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.1.1":
+    folder: all

--- a/recipes/sioxx/config.yml
+++ b/recipes/sioxx/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.2.0":
+    folder: all
   "0.1.1":
     folder: all

--- a/recipes/sioxx/config.yml
+++ b/recipes/sioxx/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.2.0":
+  "0.3.0":
     folder: all

--- a/recipes/sioxx/config.yml
+++ b/recipes/sioxx/config.yml
@@ -1,5 +1,3 @@
 versions:
   "0.2.0":
     folder: all
-  "0.1.1":
-    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe: **sioxx/0.3.0**

#### Motivation
Add sioxx to Conan Center.

sioxx is a modern C++17 Socket.IO client built on Boost.Beast, with support for JSON and MessagePack payloads. Version 0.3.0 also adds authenticated HTTP proxy support.

Upstream project: https://github.com/jfayot/sioxx
Documentation: https://jfayot.github.io/sioxx/
Dev.to article: https://dev.to/jfayot/sioxx-a-modern-c-socketio-client-nlohmannjson-boostbeast-json-or-messagepack-1hj1

#### Details
This PR adds the initial Conan Center recipe for sioxx 0.3.0, including:

- Static and shared library support
- C++17 validation
- Boost 1.90.0 in header-only mode
- nlohmann_json 3.12.0 as a public header dependency
- OpenSSL 3.6.3 with appropriate static-link propagation
- CMake integration through the `sioxx::sioxx` target
- A consumer test package
- Verified source archive SHA-256 and packaged MIT license

Tested locally with Conan 2.30.0 on macOS ARM64 using both configurations:

- `shared=False`
- `shared=True`

Both configurations built, packaged, linked, and executed the test package successfully.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
