### PR TITLE
soplex: unvendorize fmt and zstr; publish version 8.0.3

### DIFF
--- a/recipes/soplex/all/conandata.yml
+++ b/recipes/soplex/all/conandata.yml
@@ -2,6 +2,11 @@ sources:
   "8.0.3":
     url: "https://github.com/scipopt/soplex/archive/refs/tags/v8.0.3.tar.gz"
     sha256: "224eca4c49a2509a2a893a1d4b63e510e2ddb4ff374699cc6afc36f12af4e621"
+  "8.0.2":
+    url: "https://github.com/scipopt/soplex/archive/refs/tags/v8.0.2.tar.gz"
+    sha256: "9304fd377e506b380c6b234f6aec221bfc8754541e9ad5f5584f5fbb786a8392"
 patches:
   "8.0.3":
+    - patch_file: "patches/0001-unvendor-fmt-zstr.patch"
+  "8.0.2":
     - patch_file: "patches/0001-unvendor-fmt-zstr.patch"

--- a/recipes/soplex/all/conandata.yml
+++ b/recipes/soplex/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "8.0.2":
-    url: "https://github.com/scipopt/soplex/archive/refs/tags/v8.0.2.tar.gz"
-    sha256: "9304fd377e506b380c6b234f6aec221bfc8754541e9ad5f5584f5fbb786a8392"
+  "8.0.3":
+    url: "https://github.com/scipopt/soplex/archive/refs/tags/v8.0.3.tar.gz"
+    sha256: "224eca4c49a2509a2a893a1d4b63e510e2ddb4ff374699cc6afc36f12af4e621"
 patches:
-  "8.0.2":
+  "8.0.3":
     - patch_file: "patches/0001-unvendor-fmt-zstr.patch"

--- a/recipes/soplex/all/conandata.yml
+++ b/recipes/soplex/all/conandata.yml
@@ -2,36 +2,6 @@ sources:
   "8.0.2":
     url: "https://github.com/scipopt/soplex/archive/refs/tags/v8.0.2.tar.gz"
     sha256: "9304fd377e506b380c6b234f6aec221bfc8754541e9ad5f5584f5fbb786a8392"
-  "8.0.1":
-    url: "https://github.com/scipopt/soplex/archive/refs/tags/v8.0.1.tar.gz"
-    sha256: "f989f650e0d489f4e84037af2a50b1d0928f62ab79179ef566111d9197c2b6c8"
-  "8.0.0":
-    url: "https://github.com/scipopt/soplex/archive/refs/tags/v8.0.0.tar.gz"
-    sha256: "59828f88843ff5fd0adddbecf39a84c8a883b47dc26527bc4dedd2a4b98af07c"
-  "7.1.6":
-    url: "https://github.com/scipopt/soplex/archive/refs/tags/release-716.tar.gz"
-    sha256: "f031d60e7ad9a575393b04083c2914fb71a9886ba70ae77931c5a46c76b85ae4"
-  "7.1.5":
-    url: "https://github.com/scipopt/soplex/archive/refs/tags/release-715.tar.gz"
-    sha256: "e6e3998c0215120e452c4298d29bfad71c9dfb7f904a01f04c7919086248c130"
-  "7.1.2":
-    url: "https://github.com/scipopt/soplex/archive/refs/tags/release-712.tar.gz"
-    sha256: "a1a7d7f7e30d1db65548b32f75d6f2ed9bd0bf289f639eb4481d3d141c67a332"
-  "7.1.1":
-    url: "https://github.com/scipopt/soplex/archive/refs/tags/release-711.tar.gz"
-    sha256: "75752dca395e219e350f3b462f1f4c08e9d3c2deb2782414862f546a9489cdeb"
-  "7.1.0":
-    url: "https://github.com/scipopt/soplex/archive/refs/tags/release-710.tar.gz"
-    sha256: "ec177fdb688346287d5f211dd7ec4a0195c8ec9b3a5314d38aca383b6fa1418e"
-  "7.0.1":
-    url: "https://github.com/scipopt/soplex/archive/refs/tags/release-701.tar.gz"
-    sha256: "80cce994dcbe45fd52b60e31a3aeb5d2c60a7ddbaae495e0ce6bf58481675696"
-  "7.0.0":
-    url: "https://github.com/scipopt/soplex/archive/refs/tags/release-700.tar.gz"
-    sha256: "ab1906d3afb1793a6f129a5baef9dd8eee929ee945aade427cb9f0b17888239c"
-  "6.0.4":
-    url: "https://github.com/scipopt/soplex/archive/refs/tags/release-604.tar.gz"
-    sha256: "691f5b593cb85c2586522d5de5a5a7692958d22ff1ddffb4fc395f4696590b6f"
-  "6.0.3":
-    url: "https://github.com/scipopt/soplex/archive/refs/tags/release-603.tar.gz"
-    sha256: "2bdf9adc9ac6ad48f98056679b7b852e626ac4aaaf277e7d4ce17794ed1097be"
+patches:
+  "8.0.2":
+    - patch_file: "patches/0001-unvendor-fmt-zstr.patch"

--- a/recipes/soplex/all/conanfile.py
+++ b/recipes/soplex/all/conanfile.py
@@ -98,6 +98,8 @@ class SoPlexConan(ConanFile):
             rm(self, "*.lib", os.path.join(self.package_folder, "lib"), excludes=excludes)
             rm(self, "*.a", os.path.join(self.package_folder, "lib"), excludes=excludes)
 
+        rm(self, "soplex.exe" if self.settings.os == "Windows" else "soplex",
+           os.path.join(self.package_folder, "bin"))
         rmdir(self, os.path.join(self.package_folder, "share"))
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
         fix_apple_shared_install_name(self)

--- a/recipes/soplex/all/conanfile.py
+++ b/recipes/soplex/all/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import get, rm, rmdir, apply_conandata_patches, export_conandata_patches, copy
 import os
 
-required_conan_version = ">=2"
+required_conan_version = ">=2.4"
 
 
 class SoPlexConan(ConanFile):
@@ -94,8 +94,9 @@ class SoPlexConan(ConanFile):
             rm(self, "*.so*", os.path.join(self.package_folder, "lib"))
             rm(self, "*.dylib*", os.path.join(self.package_folder, "lib"))
             rm(self, "*.dll*", os.path.join(self.package_folder, "bin"))
-            if not self.options.get_safe("fPIC"):
-                rm(self, "*soplex-pic.*", os.path.join(self.package_folder, "lib"))
+            excludes = ["libsoplex-pic.*"] if self.options.get_safe("fPIC") else ["libsoplex.*"]
+            rm(self, "*.lib", os.path.join(self.package_folder, "lib"), excludes=excludes)
+            rm(self, "*.a", os.path.join(self.package_folder, "lib"), excludes=excludes)
 
         rmdir(self, os.path.join(self.package_folder, "share"))
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))

--- a/recipes/soplex/all/conanfile.py
+++ b/recipes/soplex/all/conanfile.py
@@ -3,11 +3,12 @@ from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import collect_libs, copy, get
+from conan.tools.files import collect_libs, copy, get, rm, rmdir, apply_conandata_patches, export_conandata_patches
 from conan.tools.scm import Version
+import os
 from os.path import join
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2"
 
 
 class SoPlexConan(ConanFile):
@@ -32,27 +33,8 @@ class SoPlexConan(ConanFile):
         "with_gmp": True,
     }
 
-    @property
-    def _min_cppstd(self):
-        return 14
-
-    @property
-    def _compilers_minimum_version(self):
-        return {
-            "gcc": "5",
-            "clang": "4",
-            "apple-clang": "7",
-            "msvc": "191",
-            "Visual Studio": "15",
-        }
-
-    def _determine_lib_name(self):
-        if self.options.shared:
-            return "soplexshared"
-        elif self.options.get_safe("fPIC"):
-            return "soplex-pic"
-        else:
-            return "soplex"
+    def export_sources(self):
+        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -74,19 +56,16 @@ class SoPlexConan(ConanFile):
             self.requires("gmp/6.3.0", transitive_headers=True, transitive_libs=True)
         if self.options.with_boost:
             self.requires("boost/1.84.0", transitive_headers=True)  # also update Boost_VERSION_MACRO below!
+        # Unvendored fmt and zstr
+        self.requires("fmt/[>=11 <13]", transitive_headers=True)
+        self.requires("zstr/[>1 <2]", transitive_headers=True)
 
     def validate(self):
-        if self.settings.compiler.cppstd:
-            check_min_cppstd(self, self._min_cppstd)
-
-        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
-        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
-            raise ConanInvalidConfiguration(
-                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
-            )
+        check_min_cppstd(self, 14)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -104,28 +83,34 @@ class SoPlexConan(ConanFile):
     def build(self):
         cmake = CMake(self)
         cmake.configure()
-        cmake.build(target=f"lib{self._determine_lib_name()}")
+        cmake.build()
 
     def package(self):
-        copy(self, pattern="LICENSE", src=self.source_folder, dst=join(self.package_folder, "licenses"))
-        copy(self, pattern="soplex.h", src=join(self.source_folder, "src"), dst=join(self.package_folder, "include"))
-        copy(self, pattern="soplex.hpp", src=join(self.source_folder, "src"), dst=join(self.package_folder, "include"))
-        copy(self, pattern="soplex_interface.h", src=join(self.source_folder, "src"), dst=join(self.package_folder, "include"))
-        copy(self, pattern="*.h", src=join(self.source_folder, "src", "soplex"), dst=join(self.package_folder, "include", "soplex"))
-        copy(self, pattern="*.hpp", src=join(self.source_folder, "src", "soplex"), dst=join(self.package_folder, "include", "soplex"))
-        copy(self, pattern="*.h", src=join(self.build_folder, "soplex"), dst=join(self.package_folder, "include", "soplex"))
-        copy(self, pattern="*.lib", src=join(self.build_folder, "lib"), dst=join(self.package_folder, "lib"), keep_path=False)
-        if self.options.shared:
-            copy(self, pattern="*.so*", src=join(self.build_folder, "lib"), dst=join(self.package_folder, "lib"), keep_path=False)
-            copy(self, pattern="*.dylib*", src=join(self.build_folder, "lib"), dst=join(self.package_folder, "lib"), keep_path=False)
-            copy(self, pattern="*.dll", src=join(self.build_folder, "bin"), dst=join(self.package_folder, "bin"), keep_path=False)
-            copy(self, pattern="*.dll.a", src=join(self.build_folder, "lib"), dst=join(self.package_folder, "lib"), keep_path=False)
+        cmake = CMake(self)
+        cmake.install()
+        if not self.options.shared:
+            rm(self, "*.so*", os.path.join(self.package_folder, "lib"))
+            rm(self, "*.dylib*", os.path.join(self.package_folder, "lib"))
+            rm(self, "*.dll*", os.path.join(self.package_folder, "lib"))
         else:
-            copy(self, pattern="*.a", src=join(self.build_folder, "lib"), dst=join(self.package_folder, "lib"), keep_path=False)
+            rm(self, "*.lib", os.path.join(self.package_folder, "lib"))
+            rm(self, "*.a", os.path.join(self.package_folder, "lib"))
+        if not self.options.get_safe("fPIC"):
+            rm(self, "soplex-pic.*", os.path.join(self.package_folder, "lib"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
         fix_apple_shared_install_name(self)
 
+    def _determine_lib_name(self):
+        if self.options.shared:
+            return "soplexshared"
+        elif self.options.get_safe("fPIC"):
+            return "soplex-pic"
+        else:
+            return "soplex"
+
     def package_info(self):
-        self.cpp_info.libs = collect_libs(self)
+        self.cpp_info.libs = [self._determine_lib_name()]
         # https://github.com/conan-io/conan-center-index/pull/16017#discussion_r1156484737
         self.cpp_info.set_property("cmake_target_name", "soplex")
         if self.settings.os in ["Linux", "FreeBSD"]:

--- a/recipes/soplex/all/conanfile.py
+++ b/recipes/soplex/all/conanfile.py
@@ -2,7 +2,7 @@ from conan import ConanFile
 from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import get, rm, rmdir, apply_conandata_patches, export_conandata_patches
+from conan.tools.files import get, rm, rmdir, apply_conandata_patches, export_conandata_patches, copy
 import os
 
 required_conan_version = ">=2"
@@ -84,17 +84,19 @@ class SoPlexConan(ConanFile):
         cmake.build()
 
     def package(self):
+        copy(self, pattern="LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
         cmake = CMake(self)
         cmake.install()
-        if not self.options.shared:
+        if self.options.shared:
+            rm(self, "*.lib", os.path.join(self.package_folder, "lib"), excludes=["libsoplexshared*"])
+            rm(self, "*.a", os.path.join(self.package_folder, "lib"))
+        else:
             rm(self, "*.so*", os.path.join(self.package_folder, "lib"))
             rm(self, "*.dylib*", os.path.join(self.package_folder, "lib"))
-            rm(self, "*.dll*", os.path.join(self.package_folder, "lib"))
-        else:
-            rm(self, "*.lib", os.path.join(self.package_folder, "lib"))
-            rm(self, "*.a", os.path.join(self.package_folder, "lib"))
-        if not self.options.get_safe("fPIC"):
-            rm(self, "soplex-pic.*", os.path.join(self.package_folder, "lib"))
+            rm(self, "*.dll*", os.path.join(self.package_folder, "bin"))
+            if not self.options.get_safe("fPIC"):
+                rm(self, "*soplex-pic.*", os.path.join(self.package_folder, "lib"))
+
         rmdir(self, os.path.join(self.package_folder, "share"))
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
         fix_apple_shared_install_name(self)

--- a/recipes/soplex/all/conanfile.py
+++ b/recipes/soplex/all/conanfile.py
@@ -1,12 +1,9 @@
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import collect_libs, copy, get, rm, rmdir, apply_conandata_patches, export_conandata_patches
-from conan.tools.scm import Version
+from conan.tools.files import get, rm, rmdir, apply_conandata_patches, export_conandata_patches
 import os
-from os.path import join
 
 required_conan_version = ">=2"
 
@@ -56,7 +53,6 @@ class SoPlexConan(ConanFile):
             self.requires("gmp/6.3.0", transitive_headers=True, transitive_libs=True)
         if self.options.with_boost:
             self.requires("boost/1.84.0", transitive_headers=True)  # also update Boost_VERSION_MACRO below!
-        # Unvendored fmt and zstr
         self.requires("fmt/[>=11 <13]", transitive_headers=True)
         self.requires("zstr/[>1 <2]", transitive_headers=True)
 
@@ -65,14 +61,16 @@ class SoPlexConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        # Vendorized fmt and zstr
+        rmdir(self, os.path.join(self.source_folder, "src", "soplex", "external"))
         apply_conandata_patches(self)
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["MPFR"] = False
-        tc.variables["GMP"] = self.options.with_gmp
-        tc.variables["BOOST"] = self.options.with_boost
-        tc.variables["Boost_VERSION_MACRO"] = "108400"
+        tc.cache_variables["MPFR"] = False
+        tc.cache_variables["GMP"] = self.options.with_gmp
+        tc.cache_variables["BOOST"] = self.options.with_boost
+        tc.cache_variables["Boost_VERSION_MACRO"] = "108400"
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
         tc.generate()
         deps = CMakeDeps(self)
@@ -101,16 +99,15 @@ class SoPlexConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
         fix_apple_shared_install_name(self)
 
-    def _determine_lib_name(self):
-        if self.options.shared:
-            return "soplexshared"
-        elif self.options.get_safe("fPIC"):
-            return "soplex-pic"
-        else:
-            return "soplex"
-
     def package_info(self):
-        self.cpp_info.libs = [self._determine_lib_name()]
+        if self.options.shared:
+            libname = "soplexshared"
+        elif self.options.get_safe("fPIC"):
+            libname = "soplex-pic"
+        else:
+            libname = "soplex"
+
+        self.cpp_info.libs = [libname]
         # https://github.com/conan-io/conan-center-index/pull/16017#discussion_r1156484737
         self.cpp_info.set_property("cmake_target_name", "soplex")
         if self.settings.os in ["Linux", "FreeBSD"]:

--- a/recipes/soplex/all/patches/0001-unvendor-fmt-zstr.patch
+++ b/recipes/soplex/all/patches/0001-unvendor-fmt-zstr.patch
@@ -1,0 +1,100 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1c00fb3..4efd50d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -144,6 +144,11 @@ if(GMP_FOUND)
+     set(libs ${libs} ${GMP_LIBRARIES})
+ endif()
+ 
++find_package(fmt CONFIG REQUIRED)
++include_directories(${fmt_INCLUDE_DIRS})
++find_package(zstr CONFIG REQUIRED)
++include_directories(${zstr_INCLUDE_DIRS})
++
+ if(QUADMATH)
+    find_package(Quadmath)
+ endif()
+@@ -254,7 +259,7 @@ set(EXTRA_CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)
+ configure_file(${PROJECT_SOURCE_DIR}/soplex-config.cmake.in "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/soplex-config.cmake" @ONLY)
+ 
+ add_subdirectory(src)
+-add_subdirectory(tests/c_interface)
+-add_subdirectory(check)
++#add_subdirectory(tests/c_interface)
++#add_subdirectory(check)
+ 
+ enable_testing()
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index f3758e1..60ea2c3 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -220,28 +220,6 @@ set_target_properties(soplex PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/$
+ install(FILES ${headers} ${PROJECT_BINARY_DIR}/soplex/config.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/soplex)
+ install(FILES soplex.h soplex.hpp soplex_interface.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+ 
+-install(FILES
+-     ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/chrono.h
+-     ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/color.h
+-     ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/compile.h
+-     ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/core.h
+-     ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/format-inl.h
+-     ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/format.h
+-     ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/locale.h
+-     ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/os.h
+-     ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/ostream.h
+-     ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/posix.h
+-     ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/printf.h
+-     ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/ranges.h
+-     DESTINATION include/soplex/external/fmt)
+-
+-# TODO this is necessary only if ZLIB_FOUND?
+-install(FILES
+-     ${PROJECT_SOURCE_DIR}/src/soplex/external/zstr/zstr.hpp
+-     ${PROJECT_SOURCE_DIR}/src/soplex/external/zstr/strict_fstream.hpp
+-     DESTINATION include/soplex/external/zstr)
+-install(FILES ${PROJECT_SOURCE_DIR}/src/soplex/external/zstr/License.txt DESTINATION ${CMAKE_INSTALL_DATADIR}/licenses/soplex/zstr)
+-
+ # install the binary and the library to appropriate lcoations and add them to an export group
+ install(TARGETS soplex libsoplex libsoplex-pic libsoplexshared EXPORT soplex-targets
+     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+@@ -255,7 +233,6 @@ endif()
+ 
+ # install license files of soplex and fmt
+ install(FILES ${PROJECT_SOURCE_DIR}/LICENSE DESTINATION ${CMAKE_INSTALL_DATADIR}/licenses/soplex)
+-install(FILES ${PROJECT_SOURCE_DIR}/src/soplex/external/fmt/LICENSE.rst DESTINATION ${CMAKE_INSTALL_DATADIR}/licenses/soplex/fmt)
+ 
+ # Add library targets to the build-tree export set
+ export(TARGETS libsoplex libsoplex-pic libsoplexshared
+diff --git a/src/soplex/fmt.hpp b/src/soplex/fmt.hpp
+index 54c7dca..b8e1d94 100644
+--- a/src/soplex/fmt.hpp
++++ b/src/soplex/fmt.hpp
+@@ -36,11 +36,11 @@
+ 
+ /* to provide backwards compatibility use fmt of PaPILO <= 2.3 due to breaking changes in fmt 7 */
+ #if !defined(SOPLEX_WITH_PAPILO) || PAPILO_VERSION_MAJOR > 2 || (PAPILO_VERSION_MAJOR == 2 && PAPILO_VERSION_MINOR > 3)
+-#include "soplex/external/fmt/format.h"
+-#include "soplex/external/fmt/ostream.h"
++#include "fmt/format.h"
++#include "fmt/ostream.h"
+ #else
+-#include "papilo/external/fmt/format.h"
+-#include "papilo/external/fmt/ostream.h"
++#include "fmt/format.h"
++#include "fmt/ostream.h"
+ #endif
+ 
+ #endif
+diff --git a/src/soplex/spxfileio.h b/src/soplex/spxfileio.h
+index 89edb9d..90bc7be 100644
+--- a/src/soplex/spxfileio.h
++++ b/src/soplex/spxfileio.h
+@@ -41,7 +41,7 @@
+  *-----------------------------------------------------------------------------
+  */
+ #ifdef SOPLEX_WITH_ZLIB
+-#include "soplex/external/zstr/zstr.hpp"
++#include "zstr.hpp"
+ #endif // WITH_GSZSTREAM
+ 
+ namespace soplex

--- a/recipes/soplex/all/patches/0001-unvendor-fmt-zstr.patch
+++ b/recipes/soplex/all/patches/0001-unvendor-fmt-zstr.patch
@@ -27,10 +27,10 @@ index 1c00fb3..712b737 100644
  
  enable_testing()
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index f3758e1..4ba0d68 100644
+index f3758e1..a06fda0 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -192,58 +192,25 @@ target_include_directories(libsoplexshared BEFORE PUBLIC
+@@ -192,70 +192,36 @@ target_include_directories(libsoplexshared BEFORE PUBLIC
  target_link_libraries(libsoplexshared libsoplex ${libs})
  set_target_properties(libsoplexshared PROPERTIES CXX_VISIBILITY_PRESET default)
  
@@ -90,7 +90,12 @@ index f3758e1..4ba0d68 100644
      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-@@ -255,7 +222,6 @@ endif()
+     INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+ 
+ if(MSVC)
+-    install(FILES $<TARGET_PDB_FILE:libsoplexshared> $<TARGET_PDB_FILE:soplex> DESTINATION ${CMAKE_INSTALL_BINDIR} OPTIONAL)
++    install(FILES $<TARGET_PDB_FILE:libsoplexshared> DESTINATION ${CMAKE_INSTALL_BINDIR} OPTIONAL)
+ endif()
  
  # install license files of soplex and fmt
  install(FILES ${PROJECT_SOURCE_DIR}/LICENSE DESTINATION ${CMAKE_INSTALL_DATADIR}/licenses/soplex)

--- a/recipes/soplex/all/patches/0001-unvendor-fmt-zstr.patch
+++ b/recipes/soplex/all/patches/0001-unvendor-fmt-zstr.patch
@@ -27,38 +27,10 @@ index 1c00fb3..712b737 100644
  
  enable_testing()
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index f3758e1..a06fda0 100644
+index f3758e1..60ea2c3 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -192,70 +192,36 @@ target_include_directories(libsoplexshared BEFORE PUBLIC
- target_link_libraries(libsoplexshared libsoplex ${libs})
- set_target_properties(libsoplexshared PROPERTIES CXX_VISIBILITY_PRESET default)
- 
--# create soplex binary using library without pic
--add_executable(soplex soplexmain.cpp)
--target_link_libraries(soplex LINK_PUBLIC libsoplex)
- 
--if(EMSCRIPTEN AND EMSCRIPTEN_HTML)
--    set_target_properties(soplex PROPERTIES LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/soplex_webdemo_shell.html)
--    set(CMAKE_EXECUTABLE_SUFFIX ".html")
--endif()
- 
- if(SANITIZE)
-     find_package(Sanitizers)
-     add_sanitizers(libsoplex)
-     add_sanitizers(libsoplex-pic)
-     add_sanitizers(libsoplexshared)
--    add_sanitizers(soplex)
-     get_target_property(CONF_SANITIZE_FLAGS libsoplex SANITIZE_FLAGS)
- endif(SANITIZE)
- 
--add_executable(example EXCLUDE_FROM_ALL example.cpp)
--target_link_libraries(example libsoplex)
- 
- # set the install rpath to the installed destination
--set_target_properties(soplex PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
- 
- # install the header files of soplex
+@@ -220,28 +220,6 @@ set_target_properties(soplex PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/$
  install(FILES ${headers} ${PROJECT_BINARY_DIR}/soplex/config.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/soplex)
  install(FILES soplex.h soplex.hpp soplex_interface.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
  
@@ -85,17 +57,9 @@ index f3758e1..a06fda0 100644
 -install(FILES ${PROJECT_SOURCE_DIR}/src/soplex/external/zstr/License.txt DESTINATION ${CMAKE_INSTALL_DATADIR}/licenses/soplex/zstr)
 -
  # install the binary and the library to appropriate lcoations and add them to an export group
--install(TARGETS soplex libsoplex libsoplex-pic libsoplexshared EXPORT soplex-targets
-+install(TARGETS libsoplex libsoplex-pic libsoplexshared EXPORT soplex-targets
+ install(TARGETS soplex libsoplex libsoplex-pic libsoplexshared EXPORT soplex-targets
      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-     INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
- 
- if(MSVC)
--    install(FILES $<TARGET_PDB_FILE:libsoplexshared> $<TARGET_PDB_FILE:soplex> DESTINATION ${CMAKE_INSTALL_BINDIR} OPTIONAL)
-+    install(FILES $<TARGET_PDB_FILE:libsoplexshared> DESTINATION ${CMAKE_INSTALL_BINDIR} OPTIONAL)
- endif()
+@@ -255,7 +233,6 @@ endif()
  
  # install license files of soplex and fmt
  install(FILES ${PROJECT_SOURCE_DIR}/LICENSE DESTINATION ${CMAKE_INSTALL_DATADIR}/licenses/soplex)

--- a/recipes/soplex/all/patches/0001-unvendor-fmt-zstr.patch
+++ b/recipes/soplex/all/patches/0001-unvendor-fmt-zstr.patch
@@ -27,10 +27,38 @@ index 1c00fb3..712b737 100644
  
  enable_testing()
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index f3758e1..60ea2c3 100644
+index f3758e1..4ba0d68 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -220,28 +220,6 @@ set_target_properties(soplex PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/$
+@@ -192,58 +192,25 @@ target_include_directories(libsoplexshared BEFORE PUBLIC
+ target_link_libraries(libsoplexshared libsoplex ${libs})
+ set_target_properties(libsoplexshared PROPERTIES CXX_VISIBILITY_PRESET default)
+ 
+-# create soplex binary using library without pic
+-add_executable(soplex soplexmain.cpp)
+-target_link_libraries(soplex LINK_PUBLIC libsoplex)
+ 
+-if(EMSCRIPTEN AND EMSCRIPTEN_HTML)
+-    set_target_properties(soplex PROPERTIES LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/soplex_webdemo_shell.html)
+-    set(CMAKE_EXECUTABLE_SUFFIX ".html")
+-endif()
+ 
+ if(SANITIZE)
+     find_package(Sanitizers)
+     add_sanitizers(libsoplex)
+     add_sanitizers(libsoplex-pic)
+     add_sanitizers(libsoplexshared)
+-    add_sanitizers(soplex)
+     get_target_property(CONF_SANITIZE_FLAGS libsoplex SANITIZE_FLAGS)
+ endif(SANITIZE)
+ 
+-add_executable(example EXCLUDE_FROM_ALL example.cpp)
+-target_link_libraries(example libsoplex)
+ 
+ # set the install rpath to the installed destination
+-set_target_properties(soplex PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+ 
+ # install the header files of soplex
  install(FILES ${headers} ${PROJECT_BINARY_DIR}/soplex/config.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/soplex)
  install(FILES soplex.h soplex.hpp soplex_interface.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
  
@@ -57,9 +85,12 @@ index f3758e1..60ea2c3 100644
 -install(FILES ${PROJECT_SOURCE_DIR}/src/soplex/external/zstr/License.txt DESTINATION ${CMAKE_INSTALL_DATADIR}/licenses/soplex/zstr)
 -
  # install the binary and the library to appropriate lcoations and add them to an export group
- install(TARGETS soplex libsoplex libsoplex-pic libsoplexshared EXPORT soplex-targets
+-install(TARGETS soplex libsoplex libsoplex-pic libsoplexshared EXPORT soplex-targets
++install(TARGETS libsoplex libsoplex-pic libsoplexshared EXPORT soplex-targets
      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-@@ -255,7 +233,6 @@ endif()
+     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+@@ -255,7 +222,6 @@ endif()
  
  # install license files of soplex and fmt
  install(FILES ${PROJECT_SOURCE_DIR}/LICENSE DESTINATION ${CMAKE_INSTALL_DATADIR}/licenses/soplex)

--- a/recipes/soplex/all/patches/0001-unvendor-fmt-zstr.patch
+++ b/recipes/soplex/all/patches/0001-unvendor-fmt-zstr.patch
@@ -1,20 +1,22 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 1c00fb3..4efd50d 100644
+index 1c00fb3..712b737 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -144,6 +144,11 @@ if(GMP_FOUND)
+@@ -144,6 +144,13 @@ if(GMP_FOUND)
      set(libs ${libs} ${GMP_LIBRARIES})
  endif()
  
 +find_package(fmt CONFIG REQUIRED)
 +include_directories(${fmt_INCLUDE_DIRS})
++set(libs ${libs} ${fmt_LIBRARIES})
 +find_package(zstr CONFIG REQUIRED)
 +include_directories(${zstr_INCLUDE_DIRS})
++set(libs ${libs} ${zstr_LIBRARIES})
 +
  if(QUADMATH)
     find_package(Quadmath)
  endif()
-@@ -254,7 +259,7 @@ set(EXTRA_CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)
+@@ -254,7 +261,7 @@ set(EXTRA_CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)
  configure_file(${PROJECT_SOURCE_DIR}/soplex-config.cmake.in "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/soplex-config.cmake" @ONLY)
  
  add_subdirectory(src)

--- a/recipes/soplex/all/test_package/CMakeLists.txt
+++ b/recipes/soplex/all/test_package/CMakeLists.txt
@@ -1,17 +1,7 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.15)
 project(test_package CXX)
-set(CMAKE_CXX_STANDARD 14)
 
 find_package(soplex REQUIRED CONFIG)
-# work around v1 legacy generators always having namespaces
-if(TARGET soplex::soplex)
-   add_library(soplex INTERFACE IMPORTED)
-   set_target_properties(soplex PROPERTIES INTERFACE_LINK_LIBRARIES soplex::soplex)
-endif()
-
-if (MSVC)
-   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
-endif ()
 
 add_executable(${PROJECT_NAME} main.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE soplex)

--- a/recipes/soplex/all/test_package/conanfile.py
+++ b/recipes/soplex/all/test_package/conanfile.py
@@ -7,7 +7,6 @@ import os
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
-    test_type = "explicit"
 
     def requirements(self):
         self.requires(self.tested_reference_str)

--- a/recipes/soplex/config.yml
+++ b/recipes/soplex/config.yml
@@ -1,3 +1,5 @@
 versions:
   "8.0.3":
     folder: all
+  "8.0.2":
+    folder: all

--- a/recipes/soplex/config.yml
+++ b/recipes/soplex/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "8.0.2":
+  "8.0.3":
     folder: all

--- a/recipes/soplex/config.yml
+++ b/recipes/soplex/config.yml
@@ -1,25 +1,3 @@
 versions:
   "8.0.2":
     folder: all
-  "8.0.1":
-    folder: all
-  "8.0.0":
-    folder: all
-  "7.1.6":
-    folder: all
-  "7.1.5":
-    folder: all
-  "7.1.2":
-    folder: all
-  "7.1.1":
-    folder: all
-  "7.1.0":
-    folder: all
-  "7.0.1":
-    folder: all
-  "7.0.0":
-    folder: all
-  "6.0.4":
-    folder: all
-  "6.0.3":
-    folder: all


### PR DESCRIPTION
* Publish version 8.0.3
* Unvendorize fmt and zstr requirements (using version ranges and a Conan patch)
* Run `cmake.install` to install all the targets (no more manual copies)
* Stop publishing revisions for older versions (still available on the conancenter remote)
  * Keep `8.0.2` (used by `or-tools`)
* Clean up and modernize recipe/test_package

Related to https://github.com/conan-io/conan-center-index/pull/30583
