### PR TITLE
libheif: add version 1.23.1

### DIFF
--- a/recipes/libheif/all/conandata.yml
+++ b/recipes/libheif/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.23.1":
+    url: "https://github.com/strukturag/libheif/releases/download/v1.23.1/libheif-1.23.1.tar.gz"
+    sha256: "0de0327f60fcd47de90d5654c6fe152232738d60d84fe084ec3e0f35e03b166a"
   "1.20.1":
     url: "https://github.com/strukturag/libheif/releases/download/v1.20.1/libheif-1.20.1.tar.gz"
     sha256: "55cc76b77c533151fc78ba58ef5ad18562e84da403ed749c3ae017abaf1e2090"

--- a/recipes/libheif/config.yml
+++ b/recipes/libheif/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.23.1":
+    folder: all
   "1.20.1":
     folder: all
   "1.16.2":


### PR DESCRIPTION
fixes #30700 

### Summary
Changes to recipe:  **libheif/1.23.1**

#### Motivation
All versions of libheif currently available in the upstream are outdated and contain multiple high-severity CVEs.
Publishing latest version enables consumers to avoid using vulnerable package.

#### Details
Added latest (1.23.1) version of libheif available from the official release source


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
