### PR TITLE
scip, scippp: Stop publishing revs for older versions; Minor clean up

### DIFF
--- a/recipes/scip/all/conandata.yml
+++ b/recipes/scip/all/conandata.yml
@@ -2,18 +2,6 @@ sources:
   "10.0.2":
     url: "https://github.com/scipopt/scip/releases/download/v10.0.2/scip-10.0.2.tgz"
     sha256: "7544647007c9a63a770a71f5884a50ac81da37372bb6958d08588870bd58a50b"
-  "10.0.0":
-    url: "https://github.com/scipopt/scip/releases/download/v10.0.0/scip-10.0.0.tgz"
-    sha256: "b91d2ed32c422a13c502c37cf296eb9550e55d6bd311e61bfa6dfb9811b03d87"
-  "9.2.3":
-    url: "https://github.com/scipopt/scip/archive/refs/tags/v923.tar.gz"
-    sha256: "876227c75475a295e586871996281582d10cfdebf5792c10183e1c336a197d11"
-  "9.0.1":
-    url: "https://github.com/scipopt/scip/archive/refs/tags/v901.tar.gz"
-    sha256: "08ad3e7ad6f84f457d95bb70ab21fa7fc648dd43103099359ef8a8f30fcce32e"
-  "8.0.4":
-    url: "https://github.com/scipopt/scip/archive/refs/tags/v804.tar.gz"
-    sha256: "48be3f568763e3fc209803e9426389df107491371cfcce38f73dcc99ede69a51"
 patches:
   "10.0.2":
     - patch_file: "patches/0002-bigobj-spx-msvc-debug.patch"
@@ -23,19 +11,3 @@ version_mappings:
     soplex: "8.0.2"
     default_sym: "snauty"
     default_tpi: "tny"
-  "10.0.0":
-    soplex: "8.0.0"
-    default_sym: "snauty"
-    default_tpi: "tny"
-  "9.2.3":
-    soplex: "7.1.5"
-    default_sym: "snauty"
-    default_tpi: False
-  "9.0.1":
-    soplex: "7.0.1"
-    default_sym: "bliss"
-    default_tpi: False
-  "8.0.4":
-    soplex: "6.0.4"
-    default_sym: "bliss"
-    default_tpi: False

--- a/recipes/scip/all/conanfile.py
+++ b/recipes/scip/all/conanfile.py
@@ -5,10 +5,9 @@ from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.files import apply_conandata_patches, export_conandata_patches, copy, get
 from conan.tools.microsoft import check_min_vs, is_msvc
-from conan.tools.scm import Version
 from os.path import join
 
-required_conan_version = ">=1.53.0"
+required_conan_version = ">=2"
 
 
 class SCIPConan(ConanFile):
@@ -33,31 +32,12 @@ class SCIPConan(ConanFile):
         "with_gmp": True
     }
 
-    @property
-    def _min_cppstd(self):
-        return 14
-
-    @property
-    def _compilers_minimum_version(self):
-        return {
-            "gcc": "5",
-            "clang": "4",
-            "apple-clang": "7",
-        }
-
     def export_sources(self):
         export_conandata_patches(self)
 
     def validate(self):
-        if self.settings.compiler.cppstd:
-            check_min_cppstd(self, self._min_cppstd)
+        check_min_cppstd(self, 14)
         check_min_vs(self, 191)
-        if not is_msvc(self):
-            minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
-            if minimum_version and Version(self.settings.compiler.version) < minimum_version:
-                raise ConanInvalidConfiguration(
-                    f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
-                )
         if is_msvc(self) and self.options.shared:
             raise ConanInvalidConfiguration(f"{self.ref} can not be built as shared on Visual Studio and msvc.")
         if self.options.shared and self.options.with_sym == "bliss":
@@ -67,25 +47,17 @@ class SCIPConan(ConanFile):
             raise ConanInvalidConfiguration("Bliss does not support libc++.")
         if self.dependencies["soplex"].options.with_gmp and not self.options.with_gmp:
             raise ConanInvalidConfiguration("The options 'with_gmp' should be aligned with 'soplex:with_gmp' too.")
-        if (Version(self.version) >= "9.0.1" and Version(self.version) < "10.0.2") and is_msvc(self) and self.settings.build_type == "Debug":
-            # lpi_spx2.cpp : error C1128: number of sections exceeded object file format limit: compile with /bigobj
-            raise ConanInvalidConfiguration(f"{self.ref} can not be build in Debug with MSVC.")
-        if Version(self.version) < "10.0.0" and self.options.with_sym == "dejavu":
-            raise ConanInvalidConfiguration(f"Value 'dejavu' for option 'with_sym' is supported only for version >= 10.")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def requirements(self):
-        def _mapping_requires(dep, **kwargs):
-            required_version = self.conan_data["version_mappings"][self.version][dep]
-            self.requires(f"{dep}/{required_version}", **kwargs)
-
         if self.options.with_gmp:
             self.requires("gmp/6.3.0")
         if self.options.with_sym == "bliss":
             self.requires("bliss/0.77")
-        _mapping_requires("soplex")
+        required_version = self.conan_data["version_mappings"][self.version]["soplex"]
+        self.requires(f"soplex/{required_version}")
         self.requires("zlib/[>=1.2.11 <2]")
 
     def config_options(self):
@@ -117,9 +89,8 @@ class SCIPConan(ConanFile):
         tc.variables["TPI"] = self.options.with_tpi or "none"
         tc.variables["LPS"] = "spx"
         tc.variables["SYM"] = self.options.with_sym or "none"
-        if Version(self.version) >= "10.0.0":
-            tc.variables["EXACTSOLVE"] = False
-            tc.variables["MPFR"] = False
+        tc.variables["EXACTSOLVE"] = False
+        tc.variables["MPFR"] = False
         tc.variables["SOPLEX_INCLUDE_DIRS"] = self._to_cmake(self.dependencies["soplex"].cpp_info.includedirs)
         if self.options.shared:
             # CMakeLists accesses different variables for SoPlex depending on the SHARED option

--- a/recipes/scip/all/conanfile.py
+++ b/recipes/scip/all/conanfile.py
@@ -3,9 +3,10 @@ from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.files import apply_conandata_patches, export_conandata_patches, copy, get
+from conan.tools.files import (apply_conandata_patches, export_conandata_patches,
+                               replace_in_file, copy, get)
 from conan.tools.microsoft import check_min_vs, is_msvc
-from os.path import join
+import os
 
 required_conan_version = ">=2"
 
@@ -50,6 +51,7 @@ class SCIPConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"), "set(CMAKE_CXX_STANDARD", "##")
 
     def requirements(self):
         if self.options.with_gmp:
@@ -117,17 +119,17 @@ class SCIPConan(ConanFile):
         cmake.build(target="libscip")
 
     def package(self):
-        copy(self, pattern="LICENSE", src=self.source_folder, dst=join(self.package_folder, "licenses"))
+        copy(self, pattern="LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
         # cmake install is not used as this requires the command line tools to be built, which we do not do
-        copy(self, pattern="*.h", src=join(self.source_folder, "src"), dst=join(self.package_folder, "include"))
-        copy(self, pattern="*.h", src=join(self.build_folder, "scip"), dst=join(self.package_folder, "include", "scip"))
+        copy(self, pattern="*.h", src=os.path.join(self.source_folder, "src"), dst=os.path.join(self.package_folder, "include"))
+        copy(self, pattern="*.h", src=os.path.join(self.build_folder, "scip"), dst=os.path.join(self.package_folder, "include", "scip"))
         if self.options.shared:
-            copy(self, pattern="*.so*", src=join(self.build_folder, "lib"), dst=join(self.package_folder, "lib"))
-            copy(self, pattern="*.dylib*", src=join(self.build_folder, "lib"), dst=join(self.package_folder, "lib"))
+            copy(self, pattern="*.so*", src=os.path.join(self.build_folder, "lib"), dst=os.path.join(self.package_folder, "lib"))
+            copy(self, pattern="*.dylib*", src=os.path.join(self.build_folder, "lib"), dst=os.path.join(self.package_folder, "lib"))
         else:
-            copy(self, pattern="*.a", src=join(self.build_folder, "lib"), dst=join(self.package_folder, "lib"))
-            copy(self, pattern="*.lib", src=join(self.build_folder, "lib"), dst=join(self.package_folder, "lib"), keep_path=False)
-            copy(self, pattern="*.lib", src=self.build_folder, dst=join(self.package_folder, "lib"), keep_path=False)
+            copy(self, pattern="*.a", src=os.path.join(self.build_folder, "lib"), dst=os.path.join(self.package_folder, "lib"))
+            copy(self, pattern="*.lib", src=os.path.join(self.build_folder, "lib"), dst=os.path.join(self.package_folder, "lib"), keep_path=False)
+            copy(self, pattern="*.lib", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"), keep_path=False)
         fix_apple_shared_install_name(self)
 
     def package_info(self):

--- a/recipes/scip/all/test_package/CMakeLists.txt
+++ b/recipes/scip/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.15)
 project(test_package CXX)
 
 find_package(scip REQUIRED CONFIG)

--- a/recipes/scip/all/test_package/conanfile.py
+++ b/recipes/scip/all/test_package/conanfile.py
@@ -7,7 +7,6 @@ import os
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
-    test_type = "explicit"
 
     def requirements(self):
         self.requires(self.tested_reference_str)

--- a/recipes/scip/config.yml
+++ b/recipes/scip/config.yml
@@ -1,11 +1,3 @@
 versions:
   "10.0.2":
     folder: all
-  "10.0.0":
-    folder: all
-  "9.2.3":
-    folder: all
-  "9.0.1":
-    folder: all
-  "8.0.4":
-    folder: all

--- a/recipes/scippp/all/conandata.yml
+++ b/recipes/scippp/all/conandata.yml
@@ -2,21 +2,5 @@ sources:
   "1.4.0":
     url: "https://github.com/scipopt/SCIPpp/archive/refs/tags/1.4.0.tar.gz"
     sha256: "751ee71b5978cb6ce0b2d37571ccafedf4d7b0aafa0240c88133be602193c7b6"
-  "1.3.0":
-    url: "https://github.com/scipopt/SCIPpp/archive/refs/tags/1.3.0.tar.gz"
-    sha256: "a934f3386e7866ad6498b1a77316ec68658cb2b01b8fc0bb6f532678cc60f2ab"
-  "1.2.0":
-    url: "https://github.com/scipopt/SCIPpp/archive/refs/tags/1.2.0.tar.gz"
-    sha256: "8fa4b819734b9841eda1ec1c9266fb07144be490c3f24be46271c538ab18da61"
-  "1.1.0":
-    url: "https://github.com/scipopt/SCIPpp/archive/refs/tags/1.1.0.tar.gz"
-    sha256: "808b58e8ddd873ec403c021f9255004120e58d7ec6fb4b7d99ff6f21950ff8fb"
-  "1.0.2":
-    url: "https://github.com/scipopt/SCIPpp/archive/refs/tags/1.0.2.tar.gz"
-    sha256: "d51dfd0f1ca1b57619f7c82e32d5390d99d5cdaee98ae1ace99ec05a394dcee3"
 scip_mapping:
   "1.4.0": "10.0.0"
-  "1.3.0": "9.2.3"
-  "1.2.0": "9.0.1"
-  "1.1.0": "8.0.4"
-  "1.0.2": "8.0.4"

--- a/recipes/scippp/all/conandata.yml
+++ b/recipes/scippp/all/conandata.yml
@@ -2,5 +2,3 @@ sources:
   "1.4.0":
     url: "https://github.com/scipopt/SCIPpp/archive/refs/tags/1.4.0.tar.gz"
     sha256: "751ee71b5978cb6ce0b2d37571ccafedf4d7b0aafa0240c88133be602193c7b6"
-scip_mapping:
-  "1.4.0": "10.0.0"

--- a/recipes/scippp/all/conanfile.py
+++ b/recipes/scippp/all/conanfile.py
@@ -1,10 +1,8 @@
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get
-from conan.tools.microsoft import check_min_vs, is_msvc
-from conan.tools.scm import Version
+from conan.tools.microsoft import check_min_vs
 from os.path import join
 
 required_conan_version = ">=2"

--- a/recipes/scippp/all/conanfile.py
+++ b/recipes/scippp/all/conanfile.py
@@ -7,6 +7,8 @@ from conan.tools.microsoft import check_min_vs, is_msvc
 from conan.tools.scm import Version
 from os.path import join
 
+required_conan_version = ">=2"
+
 
 class ScipPlusPlus(ConanFile):
     name = "scippp"
@@ -27,38 +29,9 @@ class ScipPlusPlus(ConanFile):
         "fPIC": True
     }
 
-    @property
-    def _min_cppstd(self):
-        return 17
-
-    @property
-    def _compilers_minimum_version(self):
-        # see https://github.com/scipopt/SCIPpp/commit/faa80e753f96094004467c1daa98a7ab4d86f279
-        if Version(self.version) >= "1.1.0":
-            return {
-                "gcc": "8",
-                "clang": "7",
-                "apple-clang": "11",
-                "msvc": "192"
-            }
-        else:
-            return {
-                "gcc": "7",
-                "clang": "7",
-                "apple-clang": "10",
-                "msvc": "192"
-            }
-
     def validate(self):
-        if self.settings.compiler.cppstd:
-            check_min_cppstd(self, self._min_cppstd)
+        check_min_cppstd(self, 17)
         check_min_vs(self, 192)
-        if not is_msvc(self):
-            minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
-            if minimum_version and Version(self.settings.compiler.version) < minimum_version:
-                raise ConanInvalidConfiguration(
-                    f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
-                )
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/scippp/all/conanfile.py
+++ b/recipes/scippp/all/conanfile.py
@@ -48,8 +48,7 @@ class ScipPlusPlus(ConanFile):
             self.options.rm_safe("fPIC")
 
     def requirements(self):
-        # see https://github.com/scipopt/SCIPpp/blob/1.0.0/conanfile.py#L25
-        self.requires(f"scip/{self.conan_data['scip_mapping'][self.version]}", transitive_headers=True)
+        self.requires(f"scip/[>=10.0.0 <10.1]", transitive_headers=True)
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/recipes/scippp/all/test_package/CMakeLists.txt
+++ b/recipes/scippp/all/test_package/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
 project(test_package CXX)
-set(CMAKE_CXX_STANDARD 17)
 
 find_package(scippp REQUIRED CONFIG)
 add_executable(${PROJECT_NAME} test_package.cpp)

--- a/recipes/scippp/all/test_package/conanfile.py
+++ b/recipes/scippp/all/test_package/conanfile.py
@@ -7,7 +7,6 @@ import os
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
-    test_type = "explicit"
 
     def requirements(self):
         self.requires(self.tested_reference_str)

--- a/recipes/scippp/config.yml
+++ b/recipes/scippp/config.yml
@@ -1,11 +1,3 @@
 versions:
   "1.4.0":
     folder: all
-  "1.3.0":
-    folder: all
-  "1.2.0":
-    folder: all
-  "1.1.0":
-    folder: all
-  "1.0.2":
-    folder: all


### PR DESCRIPTION
* Stop publishing revisions for older versions (still available on the CCI)
* Minor clean up
* Using `scip` requirement as a version range