### PR TITLE
fmt: add version 12.2.0

### DIFF
--- a/recipes/fmt/all/conandata.yml
+++ b/recipes/fmt/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "12.2.0":
+    url: "https://github.com/fmtlib/fmt/releases/download/12.2.0/fmt-12.2.0.zip"
+    sha256: "a2f4a8d51178f954e4c339007f77edd76ba0cb2e36f87a48e5a5403d9be5878f"
   "12.1.0":
     url: "https://github.com/fmtlib/fmt/releases/download/12.1.0/fmt-12.1.0.zip"
     sha256: "695fd197fa5aff8fc67b5f2bbc110490a875cdf7a41686ac8512fb480fa8ada7"

--- a/recipes/fmt/all/conanfile.py
+++ b/recipes/fmt/all/conanfile.py
@@ -156,3 +156,9 @@ class FmtConan(ConanFile):
                 self.cpp_info.components["_fmt"].defines.append("FMT_SHARED")
 
         self.cpp_info.components["_fmt"].set_property("cmake_target_name", f"fmt::{target}")
+
+        if Version(self.version) >= "12.2.0" and not self.options.header_only:
+            self.cpp_info.components["fmt_c"].set_property("cmake_target_name", "fmt::fmt-c")
+            self.cpp_info.components["fmt_c"].set_property("cmake_target_aliases", ["fmt-c"])
+            self.cpp_info.components["fmt_c"].libs = ["fmt-c"]
+            self.cpp_info.components["fmt_c"].requires = ["_fmt"]

--- a/recipes/fmt/config.yml
+++ b/recipes/fmt/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "12.2.0":
+    folder: all
   "12.1.0":
     folder: all
   "12.0.0":


### PR DESCRIPTION
### Summary
Changes to recipe: **fmt/12.2.0**

#### Motivation
New upstream release: https://github.com/fmtlib/fmt/releases/tag/12.2.0

#### Details
Version bump only: new entry in conandata.yml and config.yml. The sha256
matches the digest GitHub reports for the release asset.

License note: upstream removed the optional binary-embedding exception in
12.2.0, so the license is now plain MIT - matching the recipe's existing
`license = "MIT"` attribute. No recipe changes needed.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan (2.25.0, gcc 14, Release; test_package passes)
