### PR TITLE
double-conversion: publish version 3.4.0

### DIFF
--- a/recipes/double-conversion/all/conandata.yml
+++ b/recipes/double-conversion/all/conandata.yml
@@ -5,21 +5,3 @@ sources:
   "3.3.0":
     url: "https://github.com/google/double-conversion/archive/refs/tags/v3.3.0.tar.gz"
     sha256: "04ec44461850abbf33824da84978043b22554896b552c5fd11a9c5ae4b4d296e"
-  "3.2.1":
-    url: "https://github.com/google/double-conversion/archive/v3.2.1.tar.gz"
-    sha256: "e40d236343cad807e83d192265f139481c51fc83a1c49e406ac6ce0a0ba7cd35"
-  "3.2.0":
-    url: "https://github.com/google/double-conversion/archive/v3.2.0.tar.gz"
-    sha256: "3dbcdf186ad092a8b71228a5962009b5c96abde9a315257a3452eb988414ea3b"
-  "3.1.7":
-    url: "https://github.com/google/double-conversion/archive/v3.1.7.tar.gz"
-    sha256: "a0204d6ab48223f2c8f53a932014e7f245125e7a5267764b1fbeebe4fa0ee8b9"
-  "3.1.6":
-    url: https://github.com/google/double-conversion/archive/v3.1.6.tar.gz
-    sha256: 8a79e87d02ce1333c9d6c5e47f452596442a343d8c3e9b234e8a62fce1b1d49c
-  "3.1.5":
-    url: "https://github.com/google/double-conversion/archive/v3.1.5.tar.gz"
-    sha256: "a63ecb93182134ba4293fd5f22d6e08ca417caafa244afaa751cbfddf6415b13"
-  "3.1.4":
-    url: "https://github.com/google/double-conversion/archive/v3.1.4.tar.gz"
-    sha256: "95004b65e43fefc6100f337a25da27bb99b9ef8d4071a36a33b5e83eb1f82021"

--- a/recipes/double-conversion/all/conandata.yml
+++ b/recipes/double-conversion/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.4.0":
+    url: "https://github.com/google/double-conversion/archive/refs/tags/v3.4.0.tar.gz"
+    sha256: "42fd4d980ea86426e457b24bdfa835a6f5ad9517ddb01cdb42b99ab9c8dd5dc9"
   "3.3.0":
     url: "https://github.com/google/double-conversion/archive/refs/tags/v3.3.0.tar.gz"
     sha256: "04ec44461850abbf33824da84978043b22554896b552c5fd11a9c5ae4b4d296e"

--- a/recipes/double-conversion/all/conanfile.py
+++ b/recipes/double-conversion/all/conanfile.py
@@ -67,3 +67,5 @@ class DoubleConversionConan(ConanFile):
         self.cpp_info.set_property("cmake_target_name", "double-conversion::double-conversion")
         self.cpp_info.set_property("pkg_config_name", "double-conversion")
         self.cpp_info.libs = ["double-conversion"]
+        if Version(self.version) >= "3.4.0":
+            self.cpp_info.set_property("cmake_target_aliases", ["double-conversion"])

--- a/recipes/double-conversion/all/conanfile.py
+++ b/recipes/double-conversion/all/conanfile.py
@@ -26,14 +26,7 @@ class DoubleConversionConan(ConanFile):
         "shared": False,
         "fPIC": True,
     }
-
-    def config_options(self):
-        if self.settings.os == "Windows":
-            del self.options.fPIC
-
-    def configure(self):
-        if self.options.shared:
-            self.options.rm_safe("fPIC")
+    implements = ["auto_shared_fpic"]
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -41,13 +34,18 @@ class DoubleConversionConan(ConanFile):
     def validate(self):
         check_min_vs(self, "190")
 
+    def build_requirements(self):
+        if Version(self.version) >= "3.4.0":
+            self.tool_requires("cmake/[>=3.29]")
+
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = True
-        if Version(self.version) <= "3.3.0": # pylint: disable=conan-condition-evals-to-constant
+        if self.settings.os == "Windows" and Version(self.version) <= "3.1.5":
+            tc.cache_variables["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = True
+        if Version(self.version) <= "3.3.1": # pylint: disable=conan-condition-evals-to-constant
             tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
         tc.generate()
 
@@ -60,10 +58,12 @@ class DoubleConversionConan(ConanFile):
         copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
         cmake = CMake(self)
         cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
         rm(self, "*.pdb", os.path.join(self.package_folder, "bin"))
 
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "double-conversion")
         self.cpp_info.set_property("cmake_target_name", "double-conversion::double-conversion")
+        self.cpp_info.set_property("pkg_config_name", "double-conversion")
         self.cpp_info.libs = ["double-conversion"]

--- a/recipes/double-conversion/all/conanfile.py
+++ b/recipes/double-conversion/all/conanfile.py
@@ -65,7 +65,6 @@ class DoubleConversionConan(ConanFile):
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "double-conversion")
         self.cpp_info.set_property("cmake_target_name", "double-conversion::double-conversion")
-        self.cpp_info.set_property("pkg_config_name", "double-conversion")
         self.cpp_info.libs = ["double-conversion"]
         if Version(self.version) >= "3.4.0":
             self.cpp_info.set_property("cmake_target_aliases", ["double-conversion"])

--- a/recipes/double-conversion/all/conanfile.py
+++ b/recipes/double-conversion/all/conanfile.py
@@ -35,18 +35,14 @@ class DoubleConversionConan(ConanFile):
         check_min_vs(self, "190")
 
     def build_requirements(self):
-        if Version(self.version) >= "3.4.0":
-            self.tool_requires("cmake/[>=3.29]")
+        self.tool_requires("cmake/[>=3.29]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)
-        if self.settings.os == "Windows" and Version(self.version) <= "3.1.5":
-            tc.cache_variables["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = True
-        if Version(self.version) <= "3.3.1": # pylint: disable=conan-condition-evals-to-constant
-            tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support
+        tc.cache_variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5" # CMake 4 support for 3.3.0
         tc.generate()
 
     def build(self):
@@ -66,5 +62,4 @@ class DoubleConversionConan(ConanFile):
         self.cpp_info.set_property("cmake_file_name", "double-conversion")
         self.cpp_info.set_property("cmake_target_name", "double-conversion::double-conversion")
         self.cpp_info.libs = ["double-conversion"]
-        if Version(self.version) >= "3.4.0":
-            self.cpp_info.set_property("cmake_target_aliases", ["double-conversion"])
+        self.cpp_info.set_property("cmake_target_aliases", ["double-conversion"])

--- a/recipes/double-conversion/all/test_package/conanfile.py
+++ b/recipes/double-conversion/all/test_package/conanfile.py
@@ -1,13 +1,12 @@
 from conan import ConanFile
 from conan.tools.build import can_run
-from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
-    test_type = "explicit"
+    generators = "CMakeDeps", "CMakeToolchain"
 
     def layout(self):
         cmake_layout(self)
@@ -22,5 +21,5 @@ class TestPackageConan(ConanFile):
 
     def test(self):
         if can_run(self):
-            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
             self.run(bin_path, env="conanrun")

--- a/recipes/double-conversion/config.yml
+++ b/recipes/double-conversion/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.4.0":
+    folder: all
   "3.3.0":
     folder: all
   "3.2.1":

--- a/recipes/double-conversion/config.yml
+++ b/recipes/double-conversion/config.yml
@@ -3,15 +3,3 @@ versions:
     folder: all
   "3.3.0":
     folder: all
-  "3.2.1":
-    folder: all
-  "3.2.0":
-    folder: all
-  "3.1.7":
-    folder: all
-  "3.1.6":
-    folder: all
-  "3.1.5":
-    folder: all
-  "3.1.4":
-    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **double-conversion/***

#### Motivation
New version is available

#### Details
- Difference between 3.3.0 and 3.4.0: https://github.com/google/double-conversion/compare/v3.3.0...v3.4.0
- Added auto_shared_fpic
- 3.4.0 requires at least CMake 3.29
- CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS is already present in CMakeLists.txt since 3.1.6
- 3.4.0 adds pkgconfig support



---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
