### PR TITLE
Add support for tesseract 5.5.3

### DIFF
--- a/recipes/tesseract/all/conandata.yml
+++ b/recipes/tesseract/all/conandata.yml
@@ -1,8 +1,18 @@
 sources:
+  "5.5.3":
+    url: "https://github.com/tesseract-ocr/tesseract/archive/5.5.3.tar.gz"
+    sha256: "9218e62793116d42a9f6d14cd9348518b27f382096eea3d0f2d1a24616bb5884"
   "5.5.2":
     url: "https://github.com/tesseract-ocr/tesseract/archive/5.5.2.tar.gz"
     sha256: "6235ea0dae45ea137f59c09320406f5888383741924d98855bd2ce0d16b54f21"
 patches:
+  "5.5.3":
+    - patch_file: "patches/0004-control-optimizations-5.5.3.patch"
+      patch_description: "fix condition for cpu optimizations"
+      patch_type: "portability"
+    - patch_file: "patches/0005-disable-install-pdb-5.5.3.patch"
+      patch_description: "disable installing PDB files"
+      patch_type: "portability"
   "5.5.2":
     - patch_file: "patches/0004-control-optimizations-5.5.2.patch"
       patch_description: "fix condition for cpu optimizations"

--- a/recipes/tesseract/all/patches/0004-control-optimizations-5.5.3.patch
+++ b/recipes/tesseract/all/patches/0004-control-optimizations-5.5.3.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 17cf7f6..992e5be 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -171,7 +171,7 @@ endif(ENABLE_NATIVE)
+ 
+ message(STATUS "CMAKE_SYSTEM_PROCESSOR=<${CMAKE_SYSTEM_PROCESSOR}>")
+ 
+-if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86|x86_64|AMD64|amd64|i386|i686")
++if(ENABLE_OPTIMIZATIONS AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86|x86_64|AMD64|amd64|i386|i686")
+ 
+   set(HAVE_NEON FALSE)
+   if(MSVC)

--- a/recipes/tesseract/all/patches/0005-disable-install-pdb-5.5.3.patch
+++ b/recipes/tesseract/all/patches/0005-disable-install-pdb-5.5.3.patch
@@ -1,0 +1,179 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 17cf7f6..ba4d05c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -913,7 +913,7 @@ install(
+   DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+   RENAME tesseract.pc)
+ install(TARGETS tesseract DESTINATION bin)
+-if (MSVC)
++if (0)
+   install(FILES $<TARGET_PDB_FILE:${PROJECT_NAME}> DESTINATION bin OPTIONAL)
+ endif()
+ install(
+@@ -923,7 +923,7 @@ install(
+   RUNTIME DESTINATION bin
+   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+-if (MSVC AND BUILD_SHARED_LIBS)
++if (0)
+   install(FILES $<TARGET_PDB_FILE:libtesseract> DESTINATION bin OPTIONAL)
+ endif()
+ install(
+diff --git a/src/training/CMakeLists.txt b/src/training/CMakeLists.txt
+index 354df75..19526dc 100644
+--- a/src/training/CMakeLists.txt
++++ b/src/training/CMakeLists.txt
+@@ -121,7 +121,7 @@ install(
+   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+ generate_export_header(common_training EXPORT_MACRO_NAME
+                        TESS_COMMON_TRAINING_API)
+-if (MSVC AND BUILD_SHARED_LIBS)
++if (0)
+   install(FILES $<TARGET_PDB_FILE:common_training> DESTINATION bin OPTIONAL)
+ endif()
+ project_group(common_training "Training Tools")
+@@ -139,7 +139,7 @@ if(NOT DISABLED_LEGACY_ENGINE)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib)
+-  if (MSVC)
++  if (0)
+     install(FILES $<TARGET_PDB_FILE:ambiguous_words> DESTINATION bin OPTIONAL)
+   endif()
+ endif()
+@@ -157,7 +157,7 @@ if(NOT DISABLED_LEGACY_ENGINE)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib)
+-  if (MSVC)
++  if (0)
+     install(FILES $<TARGET_PDB_FILE:classifier_tester> DESTINATION bin OPTIONAL)
+   endif()
+ endif()
+@@ -174,7 +174,7 @@ install(
+   RUNTIME DESTINATION bin
+   LIBRARY DESTINATION lib
+   ARCHIVE DESTINATION lib)
+-if (MSVC)
++if (0)
+   install(FILES $<TARGET_PDB_FILE:combine_tessdata> DESTINATION bin OPTIONAL)
+ endif()
+ 
+@@ -191,7 +191,7 @@ if(NOT DISABLED_LEGACY_ENGINE)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib)
+-  if (MSVC)
++  if (0)
+     install(FILES $<TARGET_PDB_FILE:cntraining> DESTINATION bin OPTIONAL)
+   endif()
+ endif()
+@@ -208,7 +208,7 @@ install(
+   RUNTIME DESTINATION bin
+   LIBRARY DESTINATION lib
+   ARCHIVE DESTINATION lib)
+-if (MSVC)
++if (0)
+   install(FILES $<TARGET_PDB_FILE:dawg2wordlist> DESTINATION bin OPTIONAL)
+ endif()
+ 
+@@ -225,7 +225,7 @@ if(NOT DISABLED_LEGACY_ENGINE)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib)
+-  if (MSVC)
++  if (0)
+     install(FILES $<TARGET_PDB_FILE:mftraining> DESTINATION bin OPTIONAL)
+   endif()
+ endif()
+@@ -243,7 +243,7 @@ if(NOT DISABLED_LEGACY_ENGINE)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib)
+-  if (MSVC)
++  if (0)
+      install(FILES $<TARGET_PDB_FILE:shapeclustering> DESTINATION bin OPTIONAL)
+   endif()
+ endif()
+@@ -260,7 +260,7 @@ install(
+   RUNTIME DESTINATION bin
+   LIBRARY DESTINATION lib
+   ARCHIVE DESTINATION lib)
+-if (MSVC)
++if (0)
+   install(FILES $<TARGET_PDB_FILE:wordlist2dawg> DESTINATION bin OPTIONAL)
+ endif()
+ 
+@@ -286,7 +286,7 @@ if(ICU_FOUND)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+-  if (MSVC AND BUILD_SHARED_LIBS)
++  if (0)
+     install(FILES $<TARGET_PDB_FILE:unicharset_training> DESTINATION bin OPTIONAL)
+   endif()
+   generate_export_header(unicharset_training EXPORT_MACRO_NAME
+@@ -305,7 +305,7 @@ if(ICU_FOUND)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib)
+-  if (MSVC)
++  if (0)
+     install(FILES $<TARGET_PDB_FILE:combine_lang_model> DESTINATION bin OPTIONAL)
+   endif()
+ 
+@@ -321,7 +321,7 @@ if(ICU_FOUND)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib)
+-  if (MSVC)
++  if (0)
+     install(FILES $<TARGET_PDB_FILE:lstmeval> DESTINATION bin OPTIONAL)
+   endif()
+ 
+@@ -337,7 +337,7 @@ if(ICU_FOUND)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib)
+-  if (MSVC)
++  if (0)
+     install(FILES $<TARGET_PDB_FILE:lstmtraining> DESTINATION bin OPTIONAL)
+   endif()
+ 
+@@ -353,7 +353,7 @@ if(ICU_FOUND)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib)
+-  if (MSVC)
++  if (0)
+     install(FILES $<TARGET_PDB_FILE:merge_unicharsets> DESTINATION bin OPTIONAL)
+   endif()
+ 
+@@ -369,7 +369,7 @@ if(ICU_FOUND)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib)
+-  if (MSVC)
++  if (0)
+     install(FILES $<TARGET_PDB_FILE:set_unicharset_properties> DESTINATION bin OPTIONAL)
+   endif()
+ 
+@@ -386,7 +386,7 @@ if(ICU_FOUND)
+     RUNTIME DESTINATION bin
+     LIBRARY DESTINATION lib
+     ARCHIVE DESTINATION lib)
+-  if (MSVC)
++  if (0)
+     install(FILES $<TARGET_PDB_FILE:unicharset_extractor> DESTINATION bin OPTIONAL)
+   endif()
+ 
+@@ -435,7 +435,7 @@ if(ICU_FOUND)
+       RUNTIME DESTINATION bin
+       LIBRARY DESTINATION lib
+       ARCHIVE DESTINATION lib)
+-    if (MSVC)
++    if (0)
+       install(FILES $<TARGET_PDB_FILE:text2image> DESTINATION bin OPTIONAL)
+     endif()
+   endif()

--- a/recipes/tesseract/config.yml
+++ b/recipes/tesseract/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "5.5.3":
+    folder: all
   "5.5.2":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **tesseract/5.5.3**

#### Motivation

Add support for tesseract 5.5.3 
[release notes](https://github.com/tesseract-ocr/tesseract/releases#release-5.5.3)

#### Details

New version with two new patches - tested build on mac/win/linux x86_64 and armv8 w/ conan 2.30.0

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
