### PR TITLE
openimageio: Add version 3.1.16.0

### DIFF
--- a/recipes/openimageio/all/conandata.yml
+++ b/recipes/openimageio/all/conandata.yml
@@ -1,12 +1,12 @@
 sources:
-  "3.1.15.0":
-    url: "https://github.com/AcademySoftwareFoundation/OpenImageIO/releases/download/v3.1.15.0/OpenImageIO-3.1.15.0.tar.gz"
-    sha256: "2c17eb34aa9d645629caf26a1c90e14556ae558f429e1ff6f0e41fbe4c80d42e"
+  "3.1.16.0":
+    url: "https://github.com/AcademySoftwareFoundation/OpenImageIO/archive/refs/tags/v3.1.16.0.tar.gz"
+    sha256: "5af7221be05bbe69d7ec4eb74b5656c6d15b8d1a332410d6af937b1df48647c0"
   "2.5.19.1":
     url: "https://github.com/AcademySoftwareFoundation/OpenImageIO/archive/refs/tags/v2.5.19.1.tar.gz"
     sha256: "adb73f270f2eaae81c3c7cde311239944ae9faf6d206552da4ee12d746628b26"
 patches:
-  "3.1.15.0":
-    - patch_file: "patches/3.1.13.1-conan-fixes.patch"
+  "3.1.16.0":
+    - patch_file: "patches/3.1.16.0-conan-fixes.patch"
   "2.5.19.1":
     - patch_file: "patches/2.5.19.1-conan-fixes.patch"

--- a/recipes/openimageio/all/patches/3.1.16.0-conan-fixes.patch
+++ b/recipes/openimageio/all/patches/3.1.16.0-conan-fixes.patch
@@ -1,5 +1,5 @@
 diff --git CMakeLists.txt CMakeLists.txt
-index 81565b47a..8df414e47 100644
+index ec78441d2..de4513baf 100644
 --- CMakeLists.txt
 +++ CMakeLists.txt
 @@ -293,7 +293,7 @@ if (OIIO_BUILD_TOOLS AND NOT BUILD_OIIOUTIL_ONLY)
@@ -12,10 +12,10 @@ index 81565b47a..8df414e47 100644
  endif ()
  
 diff --git src/cmake/externalpackages.cmake src/cmake/externalpackages.cmake
-index f10cfc852..ec8989f81 100644
+index 425404cfd..31bc0ddff 100644
 --- src/cmake/externalpackages.cmake
 +++ src/cmake/externalpackages.cmake
-@@ -238,7 +238,7 @@ checked_find_package (fmt REQUIRED
+@@ -240,7 +240,7 @@ checked_find_package (fmt REQUIRED
                        VERSION_MIN 7.0
                        BUILD_LOCAL missing
                       )

--- a/recipes/openimageio/config.yml
+++ b/recipes/openimageio/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "3.1.15.0":
+  "3.1.16.0":
     folder: all
   "2.5.19.1":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **openimageio/3.1.16.0**

#### Motivation
Monthly update with a ton of fixes. Small file reading etc. bugfixes here and there, several CVE.

#### Details
* https://github.com/AcademySoftwareFoundation/OpenImageIO/releases/tag/v3.1.16.0
* https://github.com/AcademySoftwareFoundation/OpenImageIO/compare/v3.1.15.0...v3.1.16.0

The diff is quite large, but mainly test/fuzz engine. Small number of code changes and relatively small cmake changes. Nothing that looked problematic to me.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
