### PR TITLE
[opentracing-cpp] Mark recipe as deprecated

### DIFF
--- a/recipes/opentracing-cpp/all/conanfile.py
+++ b/recipes/opentracing-cpp/all/conanfile.py
@@ -29,6 +29,7 @@ class OpenTracingConan(ConanFile):
         "enable_mocktracer": False,
         "enable_dynamic_load": False,
     }
+    deprecated = "opentracing-cpp is deprecated upstream. See https://github.com/opentracing/specification/issues/163"
 
     def export_sources(self):
         export_conandata_patches(self)


### PR DESCRIPTION
#### Motivation

Related to https://github.com/conan-io/conan-center-index/pull/30689
/cc @AlphaCluster

#### Details

The upstream deprecated Opentracing cpp, and explained in the issue https://github.com/opentracing/specification/issues/163

The repository has been archived since January 2024. 


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
