### PR TITLE
onetbb: Add version 2023.1.0

### DIFF
--- a/recipes/onetbb/all/conandata.yml
+++ b/recipes/onetbb/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "2023.0.0":
-    url: "https://github.com/uxlfoundation/oneTBB/archive/v2023.0.0.tar.gz"
-    sha256: "f8767b971ec6aea25dde58ae0f593e94e7aa75a739a86f67967012f69e2199b1"
+  "2023.1.0":
+    url: "https://github.com/uxlfoundation/oneTBB/archive/v2023.1.0.tar.gz"
+    sha256: "191288b52e1e6b17198000b64d77d194bb65e791be46ebc606e9b091781e2070"

--- a/recipes/onetbb/all/conanfile.py
+++ b/recipes/onetbb/all/conanfile.py
@@ -6,7 +6,6 @@ from conan.tools.files import copy, get, rm, rmdir, save
 from conan.tools.microsoft import is_msvc
 from conan.tools.scm import Version
 import os
-import re
 
 required_conan_version = ">=2.0"
 

--- a/recipes/onetbb/all/conanfile.py
+++ b/recipes/onetbb/all/conanfile.py
@@ -17,13 +17,10 @@ class OneTBBConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/oneapi-src/oneTBB"
     description = (
-        "oneTBB is a flexible C++ library that simplifies the work of adding parallelism to complex applications, "
-        " even if you are not a threading expert."
-        " The library lets you easily write parallel programs that take full advantage of the multi-core performance."
-        " Such programs are portable, composable and have a future-proof scalability."
-        " oneTBB provides you with functions, interfaces, and classes to parallelize and scale the code."
-        " All you have to do is to use the templates.")
-    topics = ("parallelism", "tasks", "tbb", "tbbmalloc", "threading")
+        "oneAPI Threading Building Blocks (oneTBB) lets you easily write parallel C++"
+        " programs that take full advantage of multicore performance, that are portable, composable"
+        " and have future-proof scalability.")
+    topics = ("tbb", "threading", "parallelism", "tbbmalloc")
     package_type = "shared-library"
     settings = "os", "arch", "compiler", "build_type"
     options = {

--- a/recipes/onetbb/all/conanfile.py
+++ b/recipes/onetbb/all/conanfile.py
@@ -17,10 +17,13 @@ class OneTBBConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/oneapi-src/oneTBB"
     description = (
-        "oneAPI Threading Building Blocks (oneTBB) lets you easily write parallel C++"
-        " programs that take full advantage of multicore performance, that are portable, composable"
-        " and have future-proof scalability.")
-    topics = ("tbb", "threading", "parallelism", "tbbmalloc")
+        "oneTBB is a flexible C++ library that simplifies the work of adding parallelism to complex applications, "
+        " even if you are not a threading expert."
+        " The library lets you easily write parallel programs that take full advantage of the multi-core performance."
+        " Such programs are portable, composable and have a future-proof scalability."
+        " oneTBB provides you with functions, interfaces, and classes to parallelize and scale the code."
+        " All you have to do is to use the templates.")
+    topics = ("parallelism", "tasks", "tbb", "tbbmalloc", "threading")
     package_type = "shared-library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
@@ -59,7 +62,7 @@ class OneTBBConan(ConanFile):
 
     def requirements(self):
         if self.options.get_safe("tbbbind"):
-            self.requires("hwloc/2.12.2", options={'shared': True})
+            self.requires("hwloc/[>=2.12.2 <3]", options={'shared': True})
 
     def validate(self):
         if self.settings.compiler == "apple-clang" and Version(self.settings.compiler.version) < "11.0":

--- a/recipes/onetbb/config.yml
+++ b/recipes/onetbb/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "2023.0.0":
+  "2023.1.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **onetbb/2023.1.0**

#### Motivation
Update onetbb to the latest release.

#### Details
Due to the release of a new version of hwloc, I updated the dependency.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] ~~If this is a bug fix, please link related issue or provide bug details~~
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
