### PR TITLE
metall: update to 0.34

### DIFF
--- a/recipes/metall/all/conandata.yml
+++ b/recipes/metall/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.34":
+    url: "https://github.com/LLNL/metall/archive/refs/tags/v0.34.tar.gz"
+    sha256: "977d08798fbaad405c3793f402b89507c49d9f6e12669719504bbd8dcc145c13"
   "0.32":
     url: "https://github.com/LLNL/metall/archive/refs/tags/v0.32.tar.gz"
     sha256: "2d373689c56fb41c5e995d786a76845f396099cc5f8bcba0c45a0179a621e235"

--- a/recipes/metall/all/conanfile.py
+++ b/recipes/metall/all/conanfile.py
@@ -25,7 +25,9 @@ class MetallConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("boost/[>=1.81 <2]")
+        # boost 1.91 changed the signature of boost::interprocess named_proxy::construct_n,
+        # metall calls it with the signature of boost 1.90 and older
+        self.requires("boost/[>=1.81 <1.91]")
 
     def package_id(self):
         self.info.clear()

--- a/recipes/metall/config.yml
+++ b/recipes/metall/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "0.34":
+    folder: all
   "0.32":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **metall/0.34**

#### Motivation
New upstream release

#### Details
This is a version bump. Testing the build locally surfaced an incompatibility with a recent change in boost 1.91. Therefore, the boost version is restricted to <= 1.90. Otherwise, this is just a version bump. 


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] <del>If this is a bug fix, please link related issue or provide bug details</del>
- [x] Tested locally with at least one configuration using a recent version of Conan
