### PR TITLE
android-ndk/r27d

### DIFF
--- a/recipes/android-ndk/all/conandata.yml
+++ b/recipes/android-ndk/all/conandata.yml
@@ -38,6 +38,19 @@ sources:
       "x86_64":
         url: "https://dl.google.com/android/repository/android-ndk-r28b-darwin.zip"
         sha256: "76d33f698302dce31f59b86e9ed82e87b530f10cc52cbaeb44207473689be309"
+  "r27d":
+    "Windows":
+      "x86_64":
+        url: "https://dl.google.com/android/repository/android-ndk-r27d-windows.zip"
+        sha256: "82094f53e66a76b6a9ec4fc35a5076091a92de3b91d13c5d4a7cfdb226304c59"
+    "Linux":
+      "x86_64":
+        url: "https://dl.google.com/android/repository/android-ndk-r27d-linux.zip"
+        sha256: "601246087a682d1944e1e16dd85bc6e49560fe8b6d61255be2829178c8ed15d9"
+    "Macos":
+      "x86_64":
+        url: "https://dl.google.com/android/repository/android-ndk-r27d-darwin.zip"
+        sha256: "e69092f9d2bfa5d1199039980a14eb91c03cc971ab5c6968fc08a8e6b84e7bb7"
   "r27c":
     "Windows":
       "x86_64":

--- a/recipes/android-ndk/config.yml
+++ b/recipes/android-ndk/config.yml
@@ -5,6 +5,8 @@ versions:
     folder: all
   "r28b":
     folder: all
+  "r27d":
+    folder: all
   "r27c":
     folder: all
   "r27":


### PR DESCRIPTION
### Summary
Changes to recipe:  **android-ndk/r27d**

#### Motivation

This was missing from the current LTS releases 

#### Details

This just adds r27d ndk version


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
