### PR TITLE
reliable/1.4.0: new recipe

### DIFF
--- a/recipes/reliable/all/conandata.yml
+++ b/recipes/reliable/all/conandata.yml
@@ -1,0 +1,5 @@
+sources:
+  "1.4.0":
+    url: "https://github.com/mas-bandwidth/reliable/archive/refs/tags/v1.4.0.tar.gz"
+    sha256: "bcd4e55fc9ea3108d68a30a1a7ecdcf02d0cfe7e6144e4f1a10b06a6e37529b6"
+

--- a/recipes/reliable/all/conandata.yml
+++ b/recipes/reliable/all/conandata.yml
@@ -1,5 +1,4 @@
 sources:
-  "1.4.0":
-    url: "https://github.com/mas-bandwidth/reliable/archive/refs/tags/v1.4.0.tar.gz"
-    sha256: "bcd4e55fc9ea3108d68a30a1a7ecdcf02d0cfe7e6144e4f1a10b06a6e37529b6"
-
+  "1.4.2":
+    url: "https://github.com/mas-bandwidth/reliable/archive/refs/tags/v1.4.2.tar.gz"
+    sha256: "89232c846cfa92a9d6c3514f6ebabaf7304bd7ed7e4dfb8bb369d1cdb4a820e1"

--- a/recipes/reliable/all/conanfile.py
+++ b/recipes/reliable/all/conanfile.py
@@ -1,0 +1,68 @@
+import os
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, rmdir
+
+required_conan_version = ">=2.19.0"
+
+
+class ReliableConan(ConanFile):
+    name = "reliable"
+    description = "A simple reliability layer for UDP-based protocols: " \
+                  "packet acknowledgement and fragmentation"
+    license = "BSD-3-Clause"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/mas-bandwidth/reliable"
+    topics = ("udp", "networking", "games", "reliability")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {"shared": [True, False], "fPIC": [True, False]}
+    default_options = {"shared": False, "fPIC": True}
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        # plain C library: the C++ settings do not affect the package
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        # tests, example, soak, stats and fuzz harnesses default ON when reliable is
+        # the top-level project; none of them are part of the package.
+        tc.cache_variables["RELIABLE_BUILD_TESTS"] = False
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        # upstream spells it LICENCE
+        copy(self, "LICENCE", self.source_folder,
+             os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        # upstream installs reliable.pc; Conan generators replace it
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["reliable"]
+        # match the reliable.pc that upstream installs
+        self.cpp_info.set_property("pkg_config_name", "reliable")
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            # fabs/pow in the rtt, jitter and bandwidth statistics
+            self.cpp_info.system_libs = ["m"]
+

--- a/recipes/reliable/all/conanfile.py
+++ b/recipes/reliable/all/conanfile.py
@@ -4,7 +4,7 @@ from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir
 
-required_conan_version = ">=2.19.0"
+required_conan_version = ">=2.0"
 
 
 class ReliableConan(ConanFile):

--- a/recipes/reliable/all/test_package/CMakeLists.txt
+++ b/recipes/reliable/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES C)
+
+find_package(reliable REQUIRED CONFIG)
+
+add_executable(test_package test_package.c)
+target_link_libraries(test_package PRIVATE reliable::reliable)
+

--- a/recipes/reliable/all/test_package/conanfile.py
+++ b/recipes/reliable/all/test_package/conanfile.py
@@ -1,0 +1,27 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")
+

--- a/recipes/reliable/all/test_package/test_package.c
+++ b/recipes/reliable/all/test_package/test_package.c
@@ -1,0 +1,47 @@
+#include <reliable.h>
+
+#include <stdint.h>
+#include <stdio.h>
+
+/* reliable_endpoint_create requires non-NULL packet callbacks */
+
+static void transmit_packet(void * context, uint64_t id, uint16_t sequence, uint8_t * packet_data, int packet_bytes)
+{
+    (void) context; (void) id; (void) sequence; (void) packet_data; (void) packet_bytes;
+}
+
+static int process_packet(void * context, uint64_t id, uint16_t sequence, uint8_t * packet_data, int packet_bytes)
+{
+    (void) context; (void) id; (void) sequence; (void) packet_data; (void) packet_bytes;
+    return 1;
+}
+
+int main(void)
+{
+    struct reliable_config_t config;
+    struct reliable_endpoint_t * endpoint;
+
+    if (reliable_init() != RELIABLE_OK)
+    {
+        printf("reliable_init failed\n");
+        return 1;
+    }
+
+    reliable_default_config(&config);
+    config.transmit_packet_function = transmit_packet;
+    config.process_packet_function = process_packet;
+
+    endpoint = reliable_endpoint_create(&config, 100.0);
+    if (endpoint == NULL)
+    {
+        printf("reliable_endpoint_create failed\n");
+        return 1;
+    }
+    reliable_endpoint_destroy(endpoint);
+
+    reliable_term();
+
+    printf("reliable %s: endpoint created and destroyed\n", RELIABLE_VERSION_FULL);
+    return 0;
+}
+

--- a/recipes/reliable/all/test_package/test_package.c
+++ b/recipes/reliable/all/test_package/test_package.c
@@ -1,47 +1,14 @@
 #include <reliable.h>
-
-#include <stdint.h>
 #include <stdio.h>
-
-/* reliable_endpoint_create requires non-NULL packet callbacks */
-
-static void transmit_packet(void * context, uint64_t id, uint16_t sequence, uint8_t * packet_data, int packet_bytes)
-{
-    (void) context; (void) id; (void) sequence; (void) packet_data; (void) packet_bytes;
-}
-
-static int process_packet(void * context, uint64_t id, uint16_t sequence, uint8_t * packet_data, int packet_bytes)
-{
-    (void) context; (void) id; (void) sequence; (void) packet_data; (void) packet_bytes;
-    return 1;
-}
 
 int main(void)
 {
-    struct reliable_config_t config;
-    struct reliable_endpoint_t * endpoint;
-
     if (reliable_init() != RELIABLE_OK)
     {
         printf("reliable_init failed\n");
         return 1;
     }
-
-    reliable_default_config(&config);
-    config.transmit_packet_function = transmit_packet;
-    config.process_packet_function = process_packet;
-
-    endpoint = reliable_endpoint_create(&config, 100.0);
-    if (endpoint == NULL)
-    {
-        printf("reliable_endpoint_create failed\n");
-        return 1;
-    }
-    reliable_endpoint_destroy(endpoint);
-
     reliable_term();
-
-    printf("reliable %s: endpoint created and destroyed\n", RELIABLE_VERSION_FULL);
+    printf("reliable %s\n", RELIABLE_VERSION_FULL);
     return 0;
 }
-

--- a/recipes/reliable/config.yml
+++ b/recipes/reliable/config.yml
@@ -1,0 +1,4 @@
+versions:
+  "1.4.0":
+    folder: all
+

--- a/recipes/reliable/config.yml
+++ b/recipes/reliable/config.yml
@@ -1,4 +1,3 @@
 versions:
-  "1.4.0":
+  "1.4.2":
     folder: all
-


### PR DESCRIPTION
### Summary
Changes to recipe: **reliable/1.4.0**

#### Motivation
New recipe for [reliable](https://github.com/mas-bandwidth/reliable), a plain C reliability layer (acks, fragmentation, connection statistics) for UDP-based protocols. No dependencies. Part of the mas-bandwidth family (serialize and netcode submitted alongside); dependency of yojimbo (#30676). Submitted by the upstream author.

#### Details
CMake build, static/shared via standard options; plain-C recipe (`compiler.cppstd`/`libcxx` removed in `configure()`); upstream `reliable.pc` removed from the package, `pkg_config_name` set to match. Test package creates and destroys an endpoint. Locally verified with `conan create` (both shared and static) on macOS 15 / arm64 / apple-clang 21.