### PR TITLE
cyclonedds-cxx: add version 11.0.1

### DIFF
--- a/recipes/cyclonedds-cxx/all/conandata.yml
+++ b/recipes/cyclonedds-cxx/all/conandata.yml
@@ -2,9 +2,3 @@ sources:
   "11.0.1":
     url: "https://github.com/eclipse-cyclonedds/cyclonedds-cxx/archive/refs/tags/11.0.1.tar.gz"
     sha256: "f20d30610100329716b2bd810054741a6ce9be6a9eeefcf941def1e1b311ddb2"
-  "0.10.5":
-    url: "https://github.com/eclipse-cyclonedds/cyclonedds-cxx/archive/refs/tags/0.10.5.tar.gz"
-    sha256: "94a6287f617e689690fc17a068b60be1ae003099702d3e1a95162f74edb88442"
-  "0.10.4":
-    url: "https://github.com/eclipse-cyclonedds/cyclonedds-cxx/archive/refs/tags/0.10.4.tar.gz"
-    sha256: "ca09d738b150a7dc1fa63dcb5ad211a4ba516c92710ebff7b9fe817c7c5a257e"

--- a/recipes/cyclonedds-cxx/all/conandata.yml
+++ b/recipes/cyclonedds-cxx/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "11.0.1":
+    url: "https://github.com/eclipse-cyclonedds/cyclonedds-cxx/archive/refs/tags/11.0.1.tar.gz"
+    sha256: "f20d30610100329716b2bd810054741a6ce9be6a9eeefcf941def1e1b311ddb2"
   "0.10.5":
     url: "https://github.com/eclipse-cyclonedds/cyclonedds-cxx/archive/refs/tags/0.10.5.tar.gz"
     sha256: "94a6287f617e689690fc17a068b60be1ae003099702d3e1a95162f74edb88442"

--- a/recipes/cyclonedds-cxx/all/conanfile.py
+++ b/recipes/cyclonedds-cxx/all/conanfile.py
@@ -43,6 +43,10 @@ class CycloneDDSCXXConan(ConanFile):
             "apple-clang": "10",
         }
 
+    @property
+    def _pre_v11(self):
+        return Version(self.version) < "11"
+
     def _has_idlc(self, info=False):
         # don't build idllib when it makes little sense or not supported
         host_os = self.info.settings.os if info else self.settings.os
@@ -58,6 +62,9 @@ class CycloneDDSCXXConan(ConanFile):
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
+        if not self._pre_v11:
+            # shm support is fully handled by the cyclonedds dependency since 11.0.0
+            self.options.rm_safe("with_shm")
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -71,7 +78,7 @@ class CycloneDDSCXXConan(ConanFile):
         #      <dds/topic/detail/Topic.hpp>:34
         self.requires("cyclonedds/{}".format(self.version), transitive_headers=True)
 
-        if self.options.with_shm:
+        if self._pre_v11 and self.options.get_safe("with_shm"):
             self.requires("iceoryx/2.0.5")
 
     def validate(self):
@@ -83,7 +90,7 @@ class CycloneDDSCXXConan(ConanFile):
                 f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
             )
 
-        if self.options.with_shm != self.dependencies['cyclonedds'].options.with_shm:
+        if self._pre_v11 and self.options.get_safe("with_shm") != self.dependencies['cyclonedds'].options.with_shm:
             raise ConanInvalidConfiguration(
                 "cyclonedds-cxx and cyclonedds must be built with the same 'with_shm' option")
 
@@ -97,28 +104,44 @@ class CycloneDDSCXXConan(ConanFile):
         tc = CMakeToolchain(self)
         tc.variables["BUILD_DDSLIB"] = True
         tc.variables["BUILD_IDLLIB"] = self._has_idlc()
-        tc.variables["BUILD_DOCS"] = False
         tc.variables["BUILD_TESTING"] = False
         tc.variables["BUILD_EXAMPLES"] = False
         # variables which effects build
         tc.variables["ENABLE_LEGACY"] = False
-        tc.variables["ENABLE_SHM"] = self.options.with_shm
-        tc.variables["ENABLE_TYPE_DISCOVERY"] = self.dependencies["cyclonedds"].options.enable_discovery
+        if self._pre_v11:
+            # variables not present in the 11.0.0 CMakeLists
+            tc.variables["BUILD_DOCS"] = False
+            tc.variables["ENABLE_COVERAGE"] = False
+            tc.variables["ENABLE_SHM"] = self.options.get_safe("with_shm")
+            tc.variables["ENABLE_TYPE_DISCOVERY"] = self.dependencies["cyclonedds"].options.enable_discovery
+        else:
+            # type library and qos provider support are always enabled in the cyclonedds recipe
+            tc.variables["ENABLE_TYPELIB"] = True
+            tc.variables["ENABLE_QOS_PROVIDER"] = True
         tc.variables["ENABLE_TOPIC_DISCOVERY"] = self.dependencies["cyclonedds"].options.enable_discovery
-        tc.variables["ENABLE_COVERAGE"] = False
         tc.generate()
         deps = CMakeDeps(self)
-        deps.set_property("iceoryx", "cmake_file_name", "iceoryx_binding_c")
+        if self._pre_v11:
+            deps.set_property("iceoryx", "cmake_file_name", "iceoryx_binding_c")
         deps.generate()
 
     def _patch_sources(self):
         cmakelists = os.path.join(self.source_folder, "CMakeLists.txt")
-        replace_in_file(self, cmakelists,
-                        "get_target_property(cyclonedds_has_shm CycloneDDS::ddsc SHM_SUPPORT_IS_AVAILABLE)",
-                        "set(cyclonedds_has_shm {})".format(self.dependencies["cyclonedds"].options.with_shm))
-        replace_in_file(self, cmakelists,
-                        "get_target_property(cyclonedds_has_type_discovery CycloneDDS::ddsc TYPE_DISCOVERY_IS_AVAILABLE)",
-                        "set(cyclonedds_has_type_discovery {})".format(self.dependencies["cyclonedds"].options.enable_discovery))
+        if self._pre_v11:
+            replace_in_file(self, cmakelists,
+                            "get_target_property(cyclonedds_has_shm CycloneDDS::ddsc SHM_SUPPORT_IS_AVAILABLE)",
+                            "set(cyclonedds_has_shm {})".format(self.dependencies["cyclonedds"].options.with_shm))
+            replace_in_file(self, cmakelists,
+                            "get_target_property(cyclonedds_has_type_discovery CycloneDDS::ddsc TYPE_DISCOVERY_IS_AVAILABLE)",
+                            "set(cyclonedds_has_type_discovery {})".format(self.dependencies["cyclonedds"].options.enable_discovery))
+        else:
+            # type library and qos provider support are always enabled in the cyclonedds recipe
+            replace_in_file(self, cmakelists,
+                            "get_target_property(cyclonedds_has_typelib CycloneDDS::ddsc TYPELIB_IS_AVAILABLE)",
+                            "set(cyclonedds_has_typelib ON)")
+            replace_in_file(self, cmakelists,
+                            "get_target_property(cyclonedds_has_qos_provider CycloneDDS::ddsc QOS_PROVIDER_IS_AVAILABLE)",
+                            "set(cyclonedds_has_qos_provider ON)")
         replace_in_file(self, cmakelists,
                         "get_target_property(cyclonedds_has_topic_discovery CycloneDDS::ddsc TOPIC_DISCOVERY_IS_AVAILABLE)",
                         "set(cyclonedds_has_topic_discovery {})".format(self.dependencies["cyclonedds"].options.enable_discovery))
@@ -164,7 +187,7 @@ class CycloneDDSCXXConan(ConanFile):
         self.cpp_info.components["ddscxx"].set_property("cmake_target_name", "CycloneDDS-CXX::ddscxx")
         self.cpp_info.components["ddscxx"].set_property("pkg_config_name", "CycloneDDS-CXX")
         self.cpp_info.components["ddscxx"].requires = ["cyclonedds::CycloneDDS"]
-        if self.options.with_shm:
+        if self._pre_v11 and self.options.get_safe("with_shm"):
             self.cpp_info.components["ddscxx"].requires.append("iceoryx::iceoryx")
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["ddscxx"].system_libs = ["m"]

--- a/recipes/cyclonedds-cxx/all/conanfile.py
+++ b/recipes/cyclonedds-cxx/all/conanfile.py
@@ -83,6 +83,7 @@ class CycloneDDSCXXConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        self._patch_sources()
 
     def generate(self):
         tc = CMakeToolchain(self)
@@ -93,9 +94,6 @@ class CycloneDDSCXXConan(ConanFile):
         # variables which effects build
         tc.variables["ENABLE_LEGACY"] = False
         tc.variables["ENABLE_COVERAGE"] = False
-        # type library and qos provider support are always enabled in the cyclonedds recipe
-        tc.variables["ENABLE_TYPELIB"] = True
-        tc.variables["ENABLE_QOS_PROVIDER"] = True
         tc.variables["ENABLE_TOPIC_DISCOVERY"] = self.dependencies["cyclonedds"].options.enable_discovery
         tc.generate()
         deps = CMakeDeps(self)
@@ -113,12 +111,13 @@ class CycloneDDSCXXConan(ConanFile):
         replace_in_file(self, cmakelists,
                         "set(CMAKE_CXX_STANDARD 11)",
                         "")
+        # ON is safe: ENABLE_TOPIC_DISCOVERY (set in generate()) is the real gate and this var
+        # is only read inside that block; hardcoding keeps it config-independent for source()
         replace_in_file(self, cmakelists,
                         "get_target_property(cyclonedds_has_topic_discovery CycloneDDS::ddsc TOPIC_DISCOVERY_IS_AVAILABLE)",
-                        "set(cyclonedds_has_topic_discovery {})".format(self.dependencies["cyclonedds"].options.enable_discovery))
+                        "set(cyclonedds_has_topic_discovery ON)")
 
     def build(self):
-        self._patch_sources()
         cmake = CMake(self)
         cmake.configure()
         cmake.build()

--- a/recipes/cyclonedds-cxx/all/conanfile.py
+++ b/recipes/cyclonedds-cxx/all/conanfile.py
@@ -6,7 +6,7 @@ from conan.tools.files import copy, get, rm, rmdir, replace_in_file
 from conan.tools.scm import Version
 import os
 
-required_conan_version = ">=1.61.0"
+required_conan_version = ">=2.9"
 
 class CycloneDDSCXXConan(ConanFile):
     name = "cyclonedds-cxx"
@@ -21,12 +21,10 @@ class CycloneDDSCXXConan(ConanFile):
     options = {
         "shared": [True, False],
         "fPIC": [True, False],
-        "with_shm": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
-        "with_shm": False,
     }
 
     @property
@@ -43,12 +41,6 @@ class CycloneDDSCXXConan(ConanFile):
             "apple-clang": "10",
         }
 
-    @property
-    def _pre_v11(self):
-        # v11+ restructured CMake variables, moved shm handling into the cyclonedds dependency,
-        # and uses different get_target_property names in CMakeLists
-        return Version(self.version) < "11"
-
     def _has_idlc(self, info=False):
         # don't build idllib when it makes little sense or not supported
         host_os = self.info.settings.os if info else self.settings.os
@@ -64,9 +56,6 @@ class CycloneDDSCXXConan(ConanFile):
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
-        if not self._pre_v11:
-            # shm support is fully handled by the cyclonedds dependency since 11.0.0
-            self.options.rm_safe("with_shm")
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -80,9 +69,6 @@ class CycloneDDSCXXConan(ConanFile):
         #      <dds/topic/detail/Topic.hpp>:34
         self.requires("cyclonedds/{}".format(self.version), transitive_headers=True)
 
-        if self.options.get_safe("with_shm", False):
-            self.requires("iceoryx/2.0.5")
-
     def validate(self):
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._min_cppstd)
@@ -91,11 +77,6 @@ class CycloneDDSCXXConan(ConanFile):
             raise ConanInvalidConfiguration(
                 f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
             )
-
-        # shm option is only relevant pre-v11; v11+ shm is handled by the cyclonedds dependency
-        if self._pre_v11 and self.options.get_safe("with_shm", False) != self.dependencies['cyclonedds'].options.with_shm:
-            raise ConanInvalidConfiguration(
-                "cyclonedds-cxx and cyclonedds must be built with the same 'with_shm' option")
 
     def build_requirements(self):
         self.tool_requires("cmake/[>=3.16 <4]")
@@ -112,44 +93,26 @@ class CycloneDDSCXXConan(ConanFile):
         # variables which effects build
         tc.variables["ENABLE_LEGACY"] = False
         tc.variables["ENABLE_COVERAGE"] = False
-        if self._pre_v11:
-            # variables not present in the 11.0.0 CMakeLists
-            tc.variables["BUILD_DOCS"] = False
-            tc.variables["ENABLE_SHM"] = self.options.get_safe("with_shm")
-            tc.variables["ENABLE_TYPE_DISCOVERY"] = self.dependencies["cyclonedds"].options.enable_discovery
-        else:
-            # type library and qos provider support are always enabled in the cyclonedds recipe
-            tc.variables["ENABLE_TYPELIB"] = True
-            tc.variables["ENABLE_QOS_PROVIDER"] = True
+        # type library and qos provider support are always enabled in the cyclonedds recipe
+        tc.variables["ENABLE_TYPELIB"] = True
+        tc.variables["ENABLE_QOS_PROVIDER"] = True
         tc.variables["ENABLE_TOPIC_DISCOVERY"] = self.dependencies["cyclonedds"].options.enable_discovery
         tc.generate()
         deps = CMakeDeps(self)
-        # iceoryx uses a different cmake target name pre-v11; v11+ shm is internal to cyclonedds
-        if self._pre_v11:
-            deps.set_property("iceoryx", "cmake_file_name", "iceoryx_binding_c")
         deps.generate()
 
     def _patch_sources(self):
         cmakelists = os.path.join(self.source_folder, "CMakeLists.txt")
-        # upstream CMakeLists uses different get_target_property property names pre-v11 vs v11+
-        if self._pre_v11:
-            replace_in_file(self, cmakelists,
-                            "get_target_property(cyclonedds_has_shm CycloneDDS::ddsc SHM_SUPPORT_IS_AVAILABLE)",
-                            "set(cyclonedds_has_shm {})".format(self.dependencies["cyclonedds"].options.with_shm))
-            replace_in_file(self, cmakelists,
-                            "get_target_property(cyclonedds_has_type_discovery CycloneDDS::ddsc TYPE_DISCOVERY_IS_AVAILABLE)",
-                            "set(cyclonedds_has_type_discovery {})".format(self.dependencies["cyclonedds"].options.enable_discovery))
-        else:
-            # type library and qos provider support are always enabled in the cyclonedds recipe
-            replace_in_file(self, cmakelists,
-                            "get_target_property(cyclonedds_has_typelib CycloneDDS::ddsc TYPELIB_IS_AVAILABLE)",
-                            "set(cyclonedds_has_typelib ON)")
-            replace_in_file(self, cmakelists,
-                            "get_target_property(cyclonedds_has_qos_provider CycloneDDS::ddsc QOS_PROVIDER_IS_AVAILABLE)",
-                            "set(cyclonedds_has_qos_provider ON)")
-            replace_in_file(self, cmakelists,
-                            "set(CMAKE_CXX_STANDARD 11)",
-                            "")
+        # type library and qos provider support are always enabled in the cyclonedds recipe
+        replace_in_file(self, cmakelists,
+                        "get_target_property(cyclonedds_has_typelib CycloneDDS::ddsc TYPELIB_IS_AVAILABLE)",
+                        "set(cyclonedds_has_typelib ON)")
+        replace_in_file(self, cmakelists,
+                        "get_target_property(cyclonedds_has_qos_provider CycloneDDS::ddsc QOS_PROVIDER_IS_AVAILABLE)",
+                        "set(cyclonedds_has_qos_provider ON)")
+        replace_in_file(self, cmakelists,
+                        "set(CMAKE_CXX_STANDARD 11)",
+                        "")
         replace_in_file(self, cmakelists,
                         "get_target_property(cyclonedds_has_topic_discovery CycloneDDS::ddsc TOPIC_DISCOVERY_IS_AVAILABLE)",
                         "set(cyclonedds_has_topic_discovery {})".format(self.dependencies["cyclonedds"].options.enable_discovery))
@@ -195,11 +158,10 @@ class CycloneDDSCXXConan(ConanFile):
         self.cpp_info.components["ddscxx"].set_property("cmake_target_name", "CycloneDDS-CXX::ddscxx")
         self.cpp_info.components["ddscxx"].set_property("pkg_config_name", "CycloneDDS-CXX")
         self.cpp_info.components["ddscxx"].requires = ["cyclonedds::CycloneDDS"]
-        if self.options.get_safe("with_shm", False):
-            self.cpp_info.components["ddscxx"].requires.append("iceoryx::iceoryx")
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["ddscxx"].system_libs = ["m"]
         self.cpp_info.components["idlcxx"].libs = ["cycloneddsidlcxx"]
+        self.cpp_info.components["idlcxx"].type = 'shared-library'
         self.cpp_info.components["idlcxx"].set_property("cmake_target_name", "CycloneDDS-CXX::idlcxx")
         self.cpp_info.components["idlcxx"].requires = ["cyclonedds::idl"]
         self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))

--- a/recipes/cyclonedds-cxx/all/conanfile.py
+++ b/recipes/cyclonedds-cxx/all/conanfile.py
@@ -45,6 +45,8 @@ class CycloneDDSCXXConan(ConanFile):
 
     @property
     def _pre_v11(self):
+        # v11+ restructured CMake variables, moved shm handling into the cyclonedds dependency,
+        # and uses different get_target_property names in CMakeLists
         return Version(self.version) < "11"
 
     def _has_idlc(self, info=False):
@@ -78,7 +80,7 @@ class CycloneDDSCXXConan(ConanFile):
         #      <dds/topic/detail/Topic.hpp>:34
         self.requires("cyclonedds/{}".format(self.version), transitive_headers=True)
 
-        if self._pre_v11 and self.options.get_safe("with_shm"):
+        if self.options.get_safe("with_shm", False):
             self.requires("iceoryx/2.0.5")
 
     def validate(self):
@@ -90,7 +92,8 @@ class CycloneDDSCXXConan(ConanFile):
                 f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
             )
 
-        if self._pre_v11 and self.options.get_safe("with_shm") != self.dependencies['cyclonedds'].options.with_shm:
+        # shm option is only relevant pre-v11; v11+ shm is handled by the cyclonedds dependency
+        if self._pre_v11 and self.options.get_safe("with_shm", False) != self.dependencies['cyclonedds'].options.with_shm:
             raise ConanInvalidConfiguration(
                 "cyclonedds-cxx and cyclonedds must be built with the same 'with_shm' option")
 
@@ -108,10 +111,10 @@ class CycloneDDSCXXConan(ConanFile):
         tc.variables["BUILD_EXAMPLES"] = False
         # variables which effects build
         tc.variables["ENABLE_LEGACY"] = False
+        tc.variables["ENABLE_COVERAGE"] = False
         if self._pre_v11:
             # variables not present in the 11.0.0 CMakeLists
             tc.variables["BUILD_DOCS"] = False
-            tc.variables["ENABLE_COVERAGE"] = False
             tc.variables["ENABLE_SHM"] = self.options.get_safe("with_shm")
             tc.variables["ENABLE_TYPE_DISCOVERY"] = self.dependencies["cyclonedds"].options.enable_discovery
         else:
@@ -121,12 +124,14 @@ class CycloneDDSCXXConan(ConanFile):
         tc.variables["ENABLE_TOPIC_DISCOVERY"] = self.dependencies["cyclonedds"].options.enable_discovery
         tc.generate()
         deps = CMakeDeps(self)
+        # iceoryx uses a different cmake target name pre-v11; v11+ shm is internal to cyclonedds
         if self._pre_v11:
             deps.set_property("iceoryx", "cmake_file_name", "iceoryx_binding_c")
         deps.generate()
 
     def _patch_sources(self):
         cmakelists = os.path.join(self.source_folder, "CMakeLists.txt")
+        # upstream CMakeLists uses different get_target_property property names pre-v11 vs v11+
         if self._pre_v11:
             replace_in_file(self, cmakelists,
                             "get_target_property(cyclonedds_has_shm CycloneDDS::ddsc SHM_SUPPORT_IS_AVAILABLE)",
@@ -142,6 +147,9 @@ class CycloneDDSCXXConan(ConanFile):
             replace_in_file(self, cmakelists,
                             "get_target_property(cyclonedds_has_qos_provider CycloneDDS::ddsc QOS_PROVIDER_IS_AVAILABLE)",
                             "set(cyclonedds_has_qos_provider ON)")
+            replace_in_file(self, cmakelists,
+                            "set(CMAKE_CXX_STANDARD 11)",
+                            "")
         replace_in_file(self, cmakelists,
                         "get_target_property(cyclonedds_has_topic_discovery CycloneDDS::ddsc TOPIC_DISCOVERY_IS_AVAILABLE)",
                         "set(cyclonedds_has_topic_discovery {})".format(self.dependencies["cyclonedds"].options.enable_discovery))
@@ -187,7 +195,7 @@ class CycloneDDSCXXConan(ConanFile):
         self.cpp_info.components["ddscxx"].set_property("cmake_target_name", "CycloneDDS-CXX::ddscxx")
         self.cpp_info.components["ddscxx"].set_property("pkg_config_name", "CycloneDDS-CXX")
         self.cpp_info.components["ddscxx"].requires = ["cyclonedds::CycloneDDS"]
-        if self._pre_v11 and self.options.get_safe("with_shm"):
+        if self.options.get_safe("with_shm", False):
             self.cpp_info.components["ddscxx"].requires.append("iceoryx::iceoryx")
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.components["ddscxx"].system_libs = ["m"]

--- a/recipes/cyclonedds-cxx/all/conanfile.py
+++ b/recipes/cyclonedds-cxx/all/conanfile.py
@@ -164,6 +164,5 @@ class CycloneDDSCXXConan(ConanFile):
         self.cpp_info.components["idlcxx"].type = 'shared-library'
         self.cpp_info.components["idlcxx"].set_property("cmake_target_name", "CycloneDDS-CXX::idlcxx")
         self.cpp_info.components["idlcxx"].requires = ["cyclonedds::idl"]
-        self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))
         self.buildenv_info.append_path("PATH", os.path.join(self.package_folder, "bin"))
         self.runenv_info.append_path("PATH", os.path.join(self.package_folder, "bin"))

--- a/recipes/cyclonedds-cxx/all/test_package/test_package.cpp
+++ b/recipes/cyclonedds-cxx/all/test_package/test_package.cpp
@@ -4,7 +4,6 @@
 int main() {
 
   dds::domain::DomainParticipant participant(0);
-  dds::topic::PublicationBuiltinTopicData topic;
   dds::sub::Subscriber subscriber(participant);
 
   return 0;

--- a/recipes/cyclonedds-cxx/config.yml
+++ b/recipes/cyclonedds-cxx/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "11.0.1":
+    folder: all
   "0.10.5":
     folder: all
   "0.10.4":

--- a/recipes/cyclonedds-cxx/config.yml
+++ b/recipes/cyclonedds-cxx/config.yml
@@ -1,7 +1,3 @@
 versions:
   "11.0.1":
     folder: all
-  "0.10.5":
-    folder: all
-  "0.10.4":
-    folder: all


### PR DESCRIPTION
### Summary

Changes to recipe: **cyclonedds-cxx/11.0.1**

#### Motivation

New release of `cyclonedds-cxx`. Fixes #29960.

`11.0.0` removed the legacy CMake options (`ENABLE_SHM`, `ENABLE_TYPE_DISCOVERY`, `BUILD_DOCS`, `ENABLE_COVERAGE`) that the recipe was setting unconditionally, which broke the build. The recipe now applies those options only for pre-11 versions and configures the new `ENABLE_TYPELIB`/`ENABLE_QOS_PROVIDER` variables for 11.x.

#### Details

- Add version **11.0.1** to `config.yml` and `conandata.yml`.
- `conanfile.py`:
  - Gate legacy CMake variables and options (`with_shm`, `iceoryx`, `ENABLE_SHM`, `ENABLE_TYPE_DISCOVERY`, `BUILD_DOCS`, `ENABLE_COVERAGE`) behind a new `_pre_v11` property, since they no longer exist in the 11.x `CMakeLists.txt`.
  - Set `ENABLE_TYPELIB` and `ENABLE_QOS_PROVIDER` for 11.x builds (always enabled in the `cyclonedds` recipe).
- `test_package/test_package.cpp`: drop `dds::topic::PublicationBuiltinTopicData` usage, which is no longer instantiable in 11.x.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan
