### PR TITLE
opentelemetry-cpp: keep shared=False on Windows to fix static proto b…

### DIFF
--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -70,7 +70,7 @@ class OpenTelemetryCppConan(ConanFile):
             # Opentelemetry-cpp on Windows only supports static libraries,
             # upstream does not support shared builds on Windows
             self.package_type = "static-library"
-            del self.options.shared
+            self.options.shared = False
 
     def configure(self):
         if self.options.get_safe("shared"):
@@ -126,6 +126,8 @@ class OpenTelemetryCppConan(ConanFile):
         if self.options.with_otlp_grpc:
             if not self.dependencies["grpc"].options.cpp_plugin:
                 raise ConanInvalidConfiguration(f"{self.ref} requires grpc with cpp_plugin=True")
+        if self.settings.os == "Windows" and self.options.shared:
+            raise ConanInvalidConfiguration(f"{self.ref} does not support shared builds on Windows")
 
     def build_requirements(self):
         if self._needs_proto:


### PR DESCRIPTION
### Summary
Changes to recipe: **opentelemetry-cpp/all**

#### Motivation
Fixes #30554

On Windows, the `shared` option was deleted in `config_options`,
leaving `BUILD_SHARED_LIBS` undefined. Upstream
`opentelemetry-proto.cmake` (since 1.26.0) treats an undefined
`BUILD_SHARED_LIBS` as SHARED, so `opentelemetry_proto` leaked as a
DLL even when the whole graph was set to static, breaking consumers
that expect all-static libraries on Windows.

#### Details
Keep the `shared` option and force it to `False` on Windows so the
CMakeToolchain generates `BUILD_SHARED_LIBS:BOOL=OFF`. Added a
`validate()` guard rejecting `opentelemetry-cpp:shared=True` on
Windows, and a comment explaining why upstream's single-DLL build
(`OPENTELEMETRY_BUILD_DLL`) is incompatible with this recipe's
multi-component layout.

Additional context: with the recipe forced static, clang-cl + static
protobuf works, and produces CI-friendly source-based coverage reports
on Windows (`-fprofile-instr-generate` + `-fcoverage-mapping`, then
`llvm-profdata`/`llvm-cov` → HTML/LCov).

---
- [x] Read the CONTRIBUTING.md
- [x] Checked that this PR is not a duplicate: discussion 24240
- [x] If this is a bug fix, please link related issue or provide bug details (Fixes #30554)
- [x] Tested locally with at least one configuration using a recent version of Conan

---

Add a :+1: reaction to pull requests you find to help the team prioritize, thanks!