### PR TITLE
tgbot: add version 1.12.2

### DIFF
--- a/recipes/tgbot/all/conandata.yml
+++ b/recipes/tgbot/all/conandata.yml
@@ -1,7 +1,4 @@
 sources:
-  "1.10":
-    url: "https://github.com/reo7sp/tgbot-cpp/archive/v1.10.tar.gz"
-    sha256: "e81b1fd79e550a759ec2abf651373bd5f452fb898a4c12dd91a223adc9c71b50"
   "1.12.2":
     url: "https://github.com/reo7sp/tgbot-cpp/archive/v1.12.2.tar.gz"
     sha256: "5bf349ac2104df70f740322404c8ca98a35d739373e0b8ee86072d206ff821f9"

--- a/recipes/tgbot/all/conandata.yml
+++ b/recipes/tgbot/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "1.10":
     url: "https://github.com/reo7sp/tgbot-cpp/archive/v1.10.tar.gz"
     sha256: "e81b1fd79e550a759ec2abf651373bd5f452fb898a4c12dd91a223adc9c71b50"
+  "1.12.2":
+    url: "https://github.com/reo7sp/tgbot-cpp/archive/v1.12.2.tar.gz"
+    sha256: "5bf349ac2104df70f740322404c8ca98a35d739373e0b8ee86072d206ff821f9"

--- a/recipes/tgbot/all/conanfile.py
+++ b/recipes/tgbot/all/conanfile.py
@@ -80,3 +80,6 @@ class TgbotConan(ConanFile):
         self.cpp_info.set_property("cmake_target_name", "TgBot::TgBot")
         if self.options.shared:
             self.cpp_info.defines.append("TGBOT_DLL")
+        if self.settings.os == "Windows":
+            self.cpp_info.system_libs.append("ws2_32")
+            self.cpp_info.defines.extend(["_WIN32_WINNT=0x0601", "WIN32_LEAN_AND_MEAN", "NOMINMAX"])

--- a/recipes/tgbot/all/conanfile.py
+++ b/recipes/tgbot/all/conanfile.py
@@ -6,7 +6,7 @@ from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get
 
-required_conan_version = ">=2"
+required_conan_version = ">=2.28"
 
 
 class TgbotConan(ConanFile):
@@ -37,9 +37,9 @@ class TgbotConan(ConanFile):
             self.options.rm_safe("fPIC")
 
     def requirements(self):
-        self.requires("boost/[>=1.83 <2]", options={"header_only": True}, transitive_headers=True)
+        self.requires("boost/1.91.0", options={"header_only": True}, transitive_headers=True)
         self.requires("libcurl/[>=7.78 <9]", transitive_headers=True, transitive_libs=True)
-        self.requires("nlohmann_json/[>=3.11 <4]", transitive_headers=True)
+        self.requires("nlohmann_json/3.12.0", transitive_headers=True)
 
     def validate(self):
         check_min_cppstd(self, 20)
@@ -76,7 +76,7 @@ class TgbotConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["TgBot"]
-        self.cpp_info.set_property("cmake_file_name", "tgbot")
-        self.cpp_info.set_property("cmake_target_name", "tgbot::tgbot")
+        self.cpp_info.set_property("cmake_file_name", "TgBot")
+        self.cpp_info.set_property("cmake_target_name", "TgBot::TgBot")
         if self.options.shared:
             self.cpp_info.defines.append("TGBOT_DLL")

--- a/recipes/tgbot/all/conanfile.py
+++ b/recipes/tgbot/all/conanfile.py
@@ -4,17 +4,17 @@ from conan import ConanFile
 from conan.tools.apple import fix_apple_shared_install_name
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, get, replace_in_file, rmdir
+from conan.tools.files import copy, get
 
 required_conan_version = ">=2"
 
 
 class TgbotConan(ConanFile):
     name = "tgbot"
-    description = "C++ library for Telegram bot API"
+    description = "C++ library for the Telegram Bot API"
     license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
-    homepage = "http://reo7sp.github.io/tgbot-cpp"
+    homepage = "https://reo7sp.github.io/tgbot-cpp"
     topics = ("telegram", "telegram-api", "telegram-bot", "bot")
 
     package_type = "library"
@@ -30,53 +30,35 @@ class TgbotConan(ConanFile):
 
     def config_options(self):
         if self.settings.os == "Windows":
-            del self.options.fPIC
+            self.options.rm_safe("fPIC")
 
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
 
-    def layout(self):
-        cmake_layout(self, src_folder="src")
-
     def requirements(self):
-        # tgbot/Api.h:#include <boost/property_tree/ptree.hpp>
-        self.requires("boost/[>=1.83.0 <1.90.0]", transitive_headers=True)
-        # tgbot/net/CurlHttpClient.h:#include <curl/curl.h>
+        self.requires("boost/[>=1.83 <2]", options={"header_only": True}, transitive_headers=True)
         self.requires("libcurl/[>=7.78 <9]", transitive_headers=True, transitive_libs=True)
-        self.requires("openssl/[>=1.1 <4]")
+        self.requires("nlohmann_json/[>=3.11 <4]", transitive_headers=True)
 
     def validate(self):
-        check_min_cppstd(self, 17)
+        check_min_cppstd(self, 20)
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
-        tc = CMakeToolchain(self)
-        tc.variables["ENABLE_TESTS"] = False
-        if not self.settings.compiler.cppstd:
-            tc.cache_variables["CMAKE_CXX_STANDARD"] = self._min_cppstd
-        tc.generate()
-        tc = CMakeDeps(self)
-        tc.generate()
+        dependencies = CMakeDeps(self)
+        dependencies.generate()
 
-    def _patch_sources(self):
-        # Don't force PIC
-        replace_in_file(
-            self,
-            os.path.join(self.source_folder, "CMakeLists.txt"),
-            "set_property(TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)",
-            "",
-        )
-        # Don't force CMAKE_CXX_STANDARD
-        replace_in_file(self,
-            os.path.join(self.source_folder, "CMakeLists.txt"),
-            "set(CMAKE_CXX_STANDARD",
-            "#")
+        toolchain = CMakeToolchain(self)
+        toolchain.variables["ENABLE_TESTS"] = False
+        toolchain.generate()
 
     def build(self):
-        self._patch_sources()
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
@@ -84,17 +66,17 @@ class TgbotConan(ConanFile):
     def package(self):
         cmake = CMake(self)
         cmake.install()
-        copy(self, "LICENSE",
-             dst=os.path.join(self.package_folder, "licenses"),
-             src=self.source_folder)
+        copy(
+            self,
+            "LICENSE",
+            src=self.source_folder,
+            dst=os.path.join(self.package_folder, "licenses"),
+        )
         fix_apple_shared_install_name(self)
-        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
         self.cpp_info.libs = ["TgBot"]
-        self.cpp_info.defines = ["HAVE_CURL=1"]
-
-        if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.system_libs.append("m")
-        elif self.settings.os == "Windows":
-            self.cpp_info.system_libs.extend(["ws2_32"])
+        self.cpp_info.set_property("cmake_file_name", "tgbot")
+        self.cpp_info.set_property("cmake_target_name", "tgbot::tgbot")
+        if self.options.shared:
+            self.cpp_info.defines.append("TGBOT_DLL")

--- a/recipes/tgbot/all/test_package/CMakeLists.txt
+++ b/recipes/tgbot/all/test_package/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES CXX)
 
-find_package(tgbot REQUIRED CONFIG)
+find_package(TgBot REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE tgbot::tgbot)
+target_link_libraries(${PROJECT_NAME} PRIVATE TgBot::TgBot)

--- a/recipes/tgbot/config.yml
+++ b/recipes/tgbot/config.yml
@@ -1,3 +1,7 @@
 versions:
+  "1.10":
+    folder: pre_1.12
+  "1.11":
+    folder: pre_1.12
   "1.12.2":
     folder: all

--- a/recipes/tgbot/config.yml
+++ b/recipes/tgbot/config.yml
@@ -1,5 +1,3 @@
 versions:
-  "1.10":
-    folder: all
   "1.12.2":
     folder: all

--- a/recipes/tgbot/config.yml
+++ b/recipes/tgbot/config.yml
@@ -1,3 +1,5 @@
 versions:
   "1.10":
     folder: all
+  "1.12.2":
+    folder: all

--- a/recipes/tgbot/pre_1.12/conandata.yml
+++ b/recipes/tgbot/pre_1.12/conandata.yml
@@ -1,0 +1,7 @@
+sources:
+  "1.10":
+    url: "https://github.com/reo7sp/tgbot-cpp/archive/v1.10.tar.gz"
+    sha256: "e81b1fd79e550a759ec2abf651373bd5f452fb898a4c12dd91a223adc9c71b50"
+  "1.11":
+    url: "https://github.com/reo7sp/tgbot-cpp/archive/v1.11.tar.gz"
+    sha256: "77cc1cfa77a4de2bba34741a0d52b113573ebdb51f2ecfbf08b8b6f53ff87e26"

--- a/recipes/tgbot/pre_1.12/conanfile.py
+++ b/recipes/tgbot/pre_1.12/conanfile.py
@@ -1,0 +1,100 @@
+import os
+
+from conan import ConanFile
+from conan.tools.apple import fix_apple_shared_install_name
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, replace_in_file, rmdir
+
+required_conan_version = ">=2"
+
+
+class TgbotConan(ConanFile):
+    name = "tgbot"
+    description = "C++ library for Telegram bot API"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "http://reo7sp.github.io/tgbot-cpp"
+    topics = ("telegram", "telegram-api", "telegram-bot", "bot")
+
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        # tgbot/Api.h:#include <boost/property_tree/ptree.hpp>
+        self.requires("boost/[>=1.83.0 <1.90.0]", transitive_headers=True)
+        # tgbot/net/CurlHttpClient.h:#include <curl/curl.h>
+        self.requires("libcurl/[>=7.78 <9]", transitive_headers=True, transitive_libs=True)
+        self.requires("openssl/[>=1.1 <4]")
+
+    def validate(self):
+        check_min_cppstd(self, 17)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["ENABLE_TESTS"] = False
+        if not self.settings.compiler.cppstd:
+            tc.cache_variables["CMAKE_CXX_STANDARD"] = self._min_cppstd
+        tc.generate()
+        tc = CMakeDeps(self)
+        tc.generate()
+
+    def _patch_sources(self):
+        # Don't force PIC
+        replace_in_file(
+            self,
+            os.path.join(self.source_folder, "CMakeLists.txt"),
+            "set_property(TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)",
+            "",
+        )
+        # Don't force CMAKE_CXX_STANDARD
+        replace_in_file(self,
+            os.path.join(self.source_folder, "CMakeLists.txt"),
+            "set(CMAKE_CXX_STANDARD",
+            "#")
+
+    def build(self):
+        self._patch_sources()
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+        copy(self, "LICENSE",
+             dst=os.path.join(self.package_folder, "licenses"),
+             src=self.source_folder)
+        fix_apple_shared_install_name(self)
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["TgBot"]
+        self.cpp_info.defines = ["HAVE_CURL=1"]
+
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs.append("m")
+        elif self.settings.os == "Windows":
+            self.cpp_info.system_libs.extend(["ws2_32"])

--- a/recipes/tgbot/pre_1.12/test_package/CMakeLists.txt
+++ b/recipes/tgbot/pre_1.12/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(tgbot REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE tgbot::tgbot)

--- a/recipes/tgbot/pre_1.12/test_package/conanfile.py
+++ b/recipes/tgbot/pre_1.12/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/tgbot/pre_1.12/test_package/test_package.cpp
+++ b/recipes/tgbot/pre_1.12/test_package/test_package.cpp
@@ -1,0 +1,11 @@
+#include <cstdlib>
+#include <iostream>
+#include <tgbot/tgbot.h>
+
+int main() {
+    TgBot::CurlHttpClient curlHttpClient;
+    TgBot::Bot bot("CONAN_TG_BOT_TOKEN", curlHttpClient, "");
+    std::cout << "Bot Token: " << bot.getToken() << std::endl;
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
### Summary
Changes to recipe: **tgbot/1.12.2**

#### Motivation
Add the latest tgbot-cpp release to Conan Center. Version 1.12.2 has a substantially revised upstream build system and dependency set, so the recipe needs to be updated together with the version.

#### Details
- Add sources and checksum for version 1.12.2
- Remove legacy version 1.10 from the index; its already published binaries remain available from Conan Center
- Update dependencies to match upstream 1.12.2
- Update the required C++ standard to C++20
- Support static and shared builds
- Expose the upstream CMake package and target names: `TgBot` and `TgBot::TgBot`

#### Validation
- `conan create recipes/tgbot/all --version=1.12.2 -s compiler.cppstd=20 '--build=tgbot/*'`
- `conan create recipes/tgbot/all --version=1.12.2 -s compiler.cppstd=20 -o '*:shared=True' '--build=tgbot/*'`

Both configurations build successfully and pass `test_package` on macOS arm64 with Conan 2.31.2.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details (not applicable, this is a version update)
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
