### PR TITLE
fast_double_parser: publish versioin 0.8.1

### DIFF
--- a/recipes/fast_double_parser/all/conandata.yml
+++ b/recipes/fast_double_parser/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "0.8.0":
-    url: "https://github.com/lemire/fast_double_parser/archive/v0.8.0.tar.gz"
-    sha256: "9ad74e059cc7c3e53a3057ca97a74c88ae2a6a7d36ce470193557cbd05ee8f92"
+  "0.8.1":
+    url: "https://github.com/lemire/fast_double_parser/archive/v0.8.1.tar.gz"
+    sha256: "685c1b7b9383f5fcd96264467bb2efa0c9995d7e8afb66ed9c84663466c3cefd"
   "0.7.0":
     url: "https://github.com/lemire/fast_double_parser/archive/v0.7.0.tar.gz"
     sha256: "eb80a1d9c406bbe8cb22fffd3c007651f716abd03225009302d8aba8e9c4df77"

--- a/recipes/fast_double_parser/config.yml
+++ b/recipes/fast_double_parser/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "0.8.0":
+  "0.8.1":
     folder: all
   "0.7.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **fast_double_parser/0.8.1**

#### Motivation
- Publish versioin 0.8.1(Maintenance release)

#### Details
Tested with
```
gcc (GCC) 16.1.1 20260728
Apple clang version 21.0.0 (clang-2100.1.1.101)
MSVC 19.51.36252

conan create . --version=0.8.1 --build=missing
```

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
