### PR TITLE
librats: add recipe (2.0.6)

### DIFF
--- a/recipes/librats/all/conandata.yml
+++ b/recipes/librats/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2.0.6":
+    url: "https://github.com/librats/librats/archive/refs/tags/2.0.6.tar.gz"
+    sha256: "3f3afd8f69b7f27774588e6df42004284830454b007e77f198f26dad4812a711"

--- a/recipes/librats/all/conanfile.py
+++ b/recipes/librats/all/conanfile.py
@@ -1,0 +1,121 @@
+import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get
+from conan.tools.scm import Version
+
+required_conan_version = ">=2.0"
+
+
+class LibratsConan(ConanFile):
+    name = "librats"
+    description = (
+        "C++17 peer-to-peer networking library: encrypted P2P (Noise XX), "
+        "DHT/mDNS discovery, NAT traversal (STUN/UPnP/NAT-PMP), GossipSub "
+        "pub/sub, file transfer, optional BitTorrent."
+    )
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/librats/librats"
+    topics = ("p2p", "networking", "dht", "noise-protocol", "gossipsub", "nat-traversal")
+
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "search_features": [True, False],   # BitTorrent subsystem
+        "storage": [True, False],           # distributed key/value store
+        "bindings": [True, False],          # C ABI (rats_*)
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "search_features": False,
+        "storage": False,
+        "bindings": True,
+    }
+    implements = ["auto_shared_fpic"]
+
+    @property
+    def _min_cppstd(self):
+        return 17
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "gcc": "8",
+            "clang": "7",
+            "apple-clang": "12",
+            "msvc": "192",
+        }
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def validate(self):
+        check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not fully support."
+            )
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        # Library kind is driven by Conan's `shared` option.
+        tc.cache_variables["RATS_SHARED_LIBRARY"] = bool(self.options.shared)
+        tc.cache_variables["RATS_STATIC_LIBRARY"] = not bool(self.options.shared)
+        tc.cache_variables["RATS_BUILD_TESTS"] = False
+        tc.cache_variables["RATS_BUILD_CLIENT"] = False
+        tc.cache_variables["RATS_BUILD_EXAMPLES"] = False
+        tc.cache_variables["RATS_BINDINGS"] = bool(self.options.bindings)
+        tc.cache_variables["RATS_SEARCH_FEATURES"] = bool(self.options.search_features)
+        tc.cache_variables["RATS_STORAGE"] = bool(self.options.storage)
+        tc.cache_variables["RATS_INSTALL"] = True
+        # The upstream CMakeLists derives the version from `git describe`;
+        # a source tarball has no .git, so feed it explicitly.
+        tc.cache_variables["RATS_VERSION_OVERRIDE"] = str(self.version)
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE",
+             src=self.source_folder,
+             dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "rats")
+        self.cpp_info.set_property("cmake_target_name", "rats::rats")
+        self.cpp_info.libs = ["rats"]
+        # Headers are installed as a tree under include/librats and are included
+        # as "node/node.h", "subsystems/pubsub.h", ... The crypto/ directory is a
+        # second root: security headers include "noise.h" unqualified. This
+        # mirrors the upstream exported CMake target's INSTALL_INTERFACE.
+        self.cpp_info.includedirs = ["include/librats", "include/librats/crypto"]
+
+        if self.options.search_features:
+            self.cpp_info.defines.append("RATS_SEARCH_FEATURES")
+        if self.options.storage:
+            self.cpp_info.defines.append("RATS_STORAGE")
+        if self.settings.os == "Windows" and self.options.shared:
+            self.cpp_info.defines.append("RATS_IMPORT_DLL")
+
+        if self.settings.os in ("Linux", "FreeBSD"):
+            self.cpp_info.system_libs = ["pthread"]
+        elif self.settings.os == "Windows":
+            self.cpp_info.system_libs = ["ws2_32", "iphlpapi", "bcrypt"]
+        elif self.settings.os == "Android":
+            self.cpp_info.system_libs = ["log"]

--- a/recipes/librats/all/test_package/CMakeLists.txt
+++ b/recipes/librats/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(rats REQUIRED CONFIG)
+
+add_executable(test_package test_package.cpp)
+target_link_libraries(test_package PRIVATE rats::rats)
+target_compile_features(test_package PRIVATE cxx_std_17)

--- a/recipes/librats/all/test_package/conanfile.py
+++ b/recipes/librats/all/test_package/conanfile.py
@@ -1,0 +1,27 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/librats/all/test_package/test_package.cpp
+++ b/recipes/librats/all/test_package/test_package.cpp
@@ -1,0 +1,11 @@
+#include "node/node.h"
+
+#include <cstdio>
+
+int main() {
+    librats::NodeConfig config;
+    config.listen_port = 0;  // ephemeral
+    librats::Node node(config);
+    std::printf("librats peer id: %s\n", node.local_id().short_hex().c_str());
+    return 0;
+}

--- a/recipes/librats/config.yml
+++ b/recipes/librats/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.0.6":
+    folder: all


### PR DESCRIPTION
### Summary
  Changes to recipe: **librats/2.0.6**

  #### Motivation
  librats ( https://github.com/librats/librats ) is not yet available on ConanCenter. It is an MIT-licensed C++17
  peer-to-peer networking library — encrypted transport (Noise_XX over TCP or
  reliable-UDP), peer discovery (Kademlia DHT, mDNS), NAT traversal
  (STUN/UPnP/NAT-PMP), GossipSub pub/sub, file transfer, and an optional
  BitTorrent stack. It has no external dependencies beyond the platform sockets
  and pthreads, so it packages cleanly.

  #### Details
  New recipe, one version (2.0.6), source taken from the upstream release
  tarball.

  The library has no dependencies — `system_libs` only: `pthread` on
  Linux, `ws2_32`/`iphlpapi`/`bcrypt` on Windows, `log` on Android.

  Tested locally with Conan 2.30.0 on Linux x86_64 / gcc 15, Release, both
  `shared=False` and `shared=True` — the recipe builds and `test_package` runs
  (it constructs a `Node` on an ephemeral port and prints its peer id).

  ---
  - [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
  - [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
  - [x] If this is a bug fix, please link related issue or provide bug details
  - [x] Tested locally with at least one configuration using a recent version of Conan