### PR TITLE
sentil: add 0.3.0

### DIFF
--- a/recipes/sentil/all/conandata.yml
+++ b/recipes/sentil/all/conandata.yml
@@ -1,0 +1,14 @@
+sources:
+  "0.3.0":
+    linux-x86_64:
+      url: "https://github.com/sedislab/SENTIL/releases/download/v0.3.0/sentil-0.3.0-linux-x86_64.tar.gz"
+      sha256: "920e98a46f82074f176bfab07fe04a44236300d8262ca6905a4a4644d600eb23"
+    macos-x86_64:
+      url: "https://github.com/sedislab/SENTIL/releases/download/v0.3.0/sentil-0.3.0-macos-x86_64.tar.gz"
+      sha256: "c7f3fbc36edd5b1cb6e5117751c8acac3ea9a0f9650813af9e70b52645797a37"
+    macos-arm64:
+      url: "https://github.com/sedislab/SENTIL/releases/download/v0.3.0/sentil-0.3.0-macos-arm64.tar.gz"
+      sha256: "3ce341d1133f6c054a5fdbf0751f94fbf5f6532a41a788292caa44c0a6dda4f3"
+    windows-x86_64:
+      url: "https://github.com/sedislab/SENTIL/releases/download/v0.3.0/sentil-0.3.0-windows-x86_64.tar.gz"
+      sha256: "3649cdbd640708e037da641a1471522786b434d5bde55de8a89a3f03d4fc2a3f"

--- a/recipes/sentil/all/conanfile.py
+++ b/recipes/sentil/all/conanfile.py
@@ -1,0 +1,57 @@
+import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.files import copy, download, get
+
+class SentilConan(ConanFile):
+    name = "sentil"
+    version = "0.3.0"
+    license = "MIT OR Apache-2.0"
+    description = "C ABI for SENTIL, runtime verification for Signal Temporal Logic and its probabilistic extension PrSTL"
+    homepage = "https://github.com/sedislab/SENTIL"
+    url = "https://github.com/conan-io/conan-center-index"
+    topics = ("runtime-verification", "temporal-logic", "stl", "prstl", "formal-methods")
+    settings = "os", "arch", "compiler", "build_type"
+
+    _assets = {
+        ("Linux", "x86_64"): "linux-x86_64",
+        ("Macos", "x86_64"): "macos-x86_64",
+        ("Macos", "armv8"): "macos-arm64",
+        ("Windows", "x86_64"): "windows-x86_64",
+    }
+
+    def _platform(self):
+        return self._assets.get((str(self.settings.os), str(self.settings.arch)))
+
+    def validate(self):
+        if self._platform() is None:
+            raise ConanInvalidConfiguration(
+                f"SENTIL has no prebuilt bundle for {self.settings.os}/{self.settings.arch}. "
+                "The released platforms are Linux x86_64, macOS x86_64, macOS armv8, and Windows x86_64."
+            )
+
+    def build(self):
+        get(self, **self.conan_data["sources"][self.version][self._platform()], strip_root=True)
+
+    def package(self):
+        licenses = os.path.join(self.package_folder, "licenses")
+        base = f"https://raw.githubusercontent.com/sedislab/SENTIL/v{self.version}"
+        for name in ("LICENSE-MIT", "LICENSE-APACHE"):
+            download(self, f"{base}/{name}", os.path.join(licenses, name))
+        copy(self, "*.h", os.path.join(self.build_folder, "include"),
+             os.path.join(self.package_folder, "include"))
+        copy(self, "*.hpp", os.path.join(self.build_folder, "include"),
+             os.path.join(self.package_folder, "include"))
+        copy(self, "*", os.path.join(self.build_folder, "lib"),
+             os.path.join(self.package_folder, "lib"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["sentil"]
+        self.cpp_info.includedirs = ["include"]
+        self.cpp_info.libdirs = ["lib"]
+        self.cpp_info.set_property("pkg_config_name", "sentil")
+        self.cpp_info.set_property("cmake_file_name", "Sentil")
+        self.cpp_info.set_property("cmake_target_name", "Sentil::sentil")
+        if self.settings.os in ("Linux", "FreeBSD"):
+            self.cpp_info.system_libs = ["m", "pthread", "dl"]

--- a/recipes/sentil/config/config.yml
+++ b/recipes/sentil/config/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.3.0":
+    folder: all


### PR DESCRIPTION
Adds the `sentil` recipe at 0.3.0. Runtime verification for Signal Temporal Logic and its probabilistic extension. `conan create` was run in CI against this recipe.