### PR TITLE
unordered_dense: add version 4.9.0

### DIFF
--- a/recipes/unordered_dense/all/conandata.yml
+++ b/recipes/unordered_dense/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "4.9.0":
+    url: "https://github.com/martinus/unordered_dense/archive/v4.9.0.tar.gz"
+    sha256: "e4103f34d71a36784ef9610811c440111faa3f539f31354e21c0f3ccd4b9833f"
   "4.8.1":
     url: "https://github.com/martinus/unordered_dense/archive/v4.8.1.tar.gz"
     sha256: "9f7202ec6d8353932ef865d33f5872e4b7a1356e9032da7cd09c3a0c5bb2b7de"

--- a/recipes/unordered_dense/config.yml
+++ b/recipes/unordered_dense/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "4.9.0":
+    folder: all
   "4.8.1":
     folder: all
   "4.5.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **unordered_dense/4.9.0**

#### Motivation
New upstream release. ConanCenter currently offers 4.8.1, and 4.6.0, 4.7.0 and 4.8.0 were never added, so this brings the recipe up to the current release.

I'm the upstream author. [v4.9.0](https://github.com/martinus/unordered_dense/releases/tag/v4.9.0) is tagged and green across the project's full CI matrix — Linux/macOS/Windows/MinGW, gcc/clang/MSVC, C++17 and C++23, plus ASan/UBSan/TSan.

#### Details
Adds the 4.9.0 entry to `config.yml` and `conandata.yml`. No recipe changes are needed: the package is still header-only and the minimum standard is still C++17.

Note for consumers: the API is backwards compatible, but wyhash produces different values than 4.8.1 for inputs of 8–16 bytes and over 48 bytes, so hash values and iteration order change. Nothing ever guaranteed either across versions, but anything persisting a hash or an order should be re-checked.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details — not a bug fix, this adds a new upstream version.
- [x] Tested locally with at least one configuration using a recent version of Conan: `conan create . --version=4.9.0` on Linux/x86_64, gcc 16.1.1, `compiler.cppstd=gnu20`, `build_type=Release`. Package built and `test_package` compiled and ran successfully.

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!