### PR TITLE
wxwidgets: fix libdir on windows ARM

### DIFF
--- a/recipes/wxwidgets/all/conanfile.py
+++ b/recipes/wxwidgets/all/conanfile.py
@@ -409,7 +409,7 @@ class wxWidgetsConan(ConanFile):
                                "gcc": "gcc",
                                "clang": "clang"}.get(str(self.settings.compiler))
 
-            arch_suffix = "_x64" if self.settings.arch == "x86_64" else ""
+            arch_suffix = "_x64" if self.settings.arch in ["x86_64", "armv8"] else ""
             lib_suffix = "_dll" if self.options.shared else "_lib"
             basedir = f"{compiler_prefix}{arch_suffix}{lib_suffix}"
             libdir = os.path.join("lib", basedir)


### PR DESCRIPTION
### Summary
Changes to recipe:  **wxwidgets/***

#### Motivation
without this change, consuming wxwidgets (even from the test recipe) fails with :
```
CMake Error at build/msvc-194-armv8-14-release/generators/cmakedeps_macros.cmake:81 (message):
  Library 'wxmsw33u_xrc' not found in package.  If 'wxmsw33u_xrc' is a system
  library, declare it with 'cpp_info.system_libs' property
Call Stack (most recent call first):
  build/msvc-194-armv8-14-release/generators/wxWidgets-Target-release.cmake:23 (conan_package_library_targets)
  build/msvc-194-armv8-14-release/generators/wxWidgetsTargets.cmake:24 (include)
  build/msvc-194-armv8-14-release/generators/wxWidgetsConfig.cmake:16 (include)
  CMakeLists.txt:4 (find_package)
  ```
  We can see during build: `[879/881] Linking CXX static library lib\vc_x64_lib\wxmsw33u_xrc.lib`

full log of failure: https://github.com/ericLemanissier/cocorepo/actions/runs/31029334779/job/92386040701#step:13:219

With this change, it passes: https://github.com/ericLemanissier/cocorepo/actions/runs/31172412994/job/92847063121#step:13:233

#### Details
lib dir suffix is _x64 for all 64 bits architectures on windows : https://github.com/wxWidgets/wxWidgets/blob/8d8967a29ac76b78a02b79eab7494545f09fff06/build/cmake/init.cmake#L176-L177


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
