### PR TITLE
asio-grpc: support new asio version and add new releases

### DIFF
--- a/recipes/asio-grpc/all/conandata.yml
+++ b/recipes/asio-grpc/all/conandata.yml
@@ -1,4 +1,10 @@
 sources:
+  "3.7.0":
+    url: "https://github.com/Tradias/asio-grpc/archive/refs/tags/v3.7.0.tar.gz"
+    sha256: "441d88fcffdc9136d843706390d68a3dd6e2090513b44f352a04157a4e5aa937"
+  "3.6.1":
+    url: "https://github.com/Tradias/asio-grpc/archive/refs/tags/v3.6.1.tar.gz"
+    sha256: "656f7ed8a251774f6ea65ec33a3769de8a6aaa1b20ff9f0ab8b0c34e55b65e6b"
   "3.5.0":
     url: "https://github.com/Tradias/asio-grpc/archive/refs/tags/v3.5.0.tar.gz"
     sha256: "b189fe66a2c74d9a790fc156751445412b59d27f2ddd121e5ddf0a8668194170"

--- a/recipes/asio-grpc/all/conandata.yml
+++ b/recipes/asio-grpc/all/conandata.yml
@@ -2,9 +2,3 @@ sources:
   "3.7.0":
     url: "https://github.com/Tradias/asio-grpc/archive/refs/tags/v3.7.0.tar.gz"
     sha256: "441d88fcffdc9136d843706390d68a3dd6e2090513b44f352a04157a4e5aa937"
-  "3.6.1":
-    url: "https://github.com/Tradias/asio-grpc/archive/refs/tags/v3.6.1.tar.gz"
-    sha256: "656f7ed8a251774f6ea65ec33a3769de8a6aaa1b20ff9f0ab8b0c34e55b65e6b"
-  "3.5.0":
-    url: "https://github.com/Tradias/asio-grpc/archive/refs/tags/v3.5.0.tar.gz"
-    sha256: "b189fe66a2c74d9a790fc156751445412b59d27f2ddd121e5ddf0a8668194170"

--- a/recipes/asio-grpc/all/conanfile.py
+++ b/recipes/asio-grpc/all/conanfile.py
@@ -32,18 +32,10 @@ class AsioGrpcConan(ConanFile):
         # executor in Boost 1.90 / standalone Asio 1.38.0. asio-grpc hardcoded the
         # old default until 3.6.0, so 3.5.x needs an upper bound.
 
-        if Version(self.version) >= "3.6.0":
-            if self.options.backend == "boost":
-                self.requires("boost/[>=1.74 <2]", transitive_headers=True)
-
-            if self.options.backend == "asio":
-                self.requires("asio/[>=1.17 <2]", transitive_headers=True)
-        else:
-            if self.options.backend == "boost":
-                self.requires("boost/[>=1.74 <1.90]", transitive_headers=True)
-
-            if self.options.backend == "asio":
-                self.requires("asio/[>=1.17 <1.37]", transitive_headers=True)
+        if self.options.backend == "boost":
+            self.requires("boost/[>=1.74 <2]", transitive_headers=True)
+        if self.options.backend == "asio":
+            self.requires("asio/[>=1.17 <2]", transitive_headers=True)
 
         if self.options.backend == "unifex":
             self.requires("libunifex/0.4.0", transitive_headers=True, transitive_libs=True)

--- a/recipes/asio-grpc/all/conanfile.py
+++ b/recipes/asio-grpc/all/conanfile.py
@@ -2,7 +2,6 @@ from conan import ConanFile
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rm
-from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=2.1"

--- a/recipes/asio-grpc/all/conanfile.py
+++ b/recipes/asio-grpc/all/conanfile.py
@@ -44,7 +44,7 @@ class AsioGrpcConan(ConanFile):
                 self.requires("boost/[>=1.74 <1.90]", transitive_headers=True)
 
             if self.options.backend == "asio":
-                self.requires("asio/[>=1.17 <1.38]", transitive_headers=True)
+                self.requires("asio/[>=1.17 <1.37]", transitive_headers=True)
 
         if self.options.backend == "unifex":
             self.requires("libunifex/0.4.0", transitive_headers=True, transitive_libs=True)

--- a/recipes/asio-grpc/all/conanfile.py
+++ b/recipes/asio-grpc/all/conanfile.py
@@ -2,6 +2,7 @@ from conan import ConanFile
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rm
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=2.1"
@@ -27,10 +28,24 @@ class AsioGrpcConan(ConanFile):
 
     def requirements(self):
         self.requires("grpc/[>=1.67.1 <2]", transitive_headers=True, transitive_libs=True)
-        if self.options.backend == "boost":
-            self.requires(f"boost/1.88.0", transitive_headers=True)
-        if self.options.backend == "asio":
-            self.requires(f"asio/1.32.0", transitive_headers=True)
+
+        # asio::inline_executor replaced system_executor as the default associated
+        # executor in Boost 1.90 / standalone Asio 1.38.0. asio-grpc hardcoded the
+        # old default until 3.6.0, so 3.5.x needs an upper bound.
+
+        if Version(self.version) >= "3.6.0":
+            if self.options.backend == "boost":
+                self.requires("boost/[>=1.74 <2]", transitive_headers=True)
+
+            if self.options.backend == "asio":
+                self.requires("asio/[>=1.17 <2]", transitive_headers=True)
+        else:
+            if self.options.backend == "boost":
+                self.requires("boost/[>=1.74 <1.90]", transitive_headers=True)
+
+            if self.options.backend == "asio":
+                self.requires("asio/[>=1.17 <1.38]", transitive_headers=True)
+
         if self.options.backend == "unifex":
             self.requires("libunifex/0.4.0", transitive_headers=True, transitive_libs=True)
 

--- a/recipes/asio-grpc/config.yml
+++ b/recipes/asio-grpc/config.yml
@@ -1,3 +1,7 @@
 versions:
+  "3.7.0":
+    folder: all
+  "3.6.1":
+    folder: all
   "3.5.0":
     folder: all

--- a/recipes/asio-grpc/config.yml
+++ b/recipes/asio-grpc/config.yml
@@ -1,7 +1,3 @@
 versions:
   "3.7.0":
     folder: all
-  "3.6.1":
-    folder: all
-  "3.5.0":
-    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **asio-grpc/3.5.0**

#### Motivation
Current recipe pins `boost` and `asio` versions despite it works with a number of versions.
Also, `3.6.1` and `3.7.0` are added.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
