### PR TITLE
stduuid: Add missing options to recipe

### DIFF
--- a/recipes/stduuid/all/conanfile.py
+++ b/recipes/stduuid/all/conanfile.py
@@ -21,6 +21,15 @@ class StduuidConan(ConanFile):
         # True: Use std::span
         # False: Use gsl::span
         "with_cxx20_span": [True, False],
+        "with_system_generator": [True, False],
+        "with_time_generator": [True, False],
+        "hash_string_based": [True, False]
+    }
+    default_options = {
+        "with_cxx20_span": True,
+        "with_system_generator": False,
+        "with_time_generator": False,
+        "hash_string_based": False,
     }
 
     @property
@@ -36,7 +45,7 @@ class StduuidConan(ConanFile):
             "msvc": "191",
             "Visual Studio": "15",
         }
-    
+
     def export_sources(self):
         export_conandata_patches(self)
 
@@ -88,3 +97,9 @@ class StduuidConan(ConanFile):
         self.cpp_info.libdirs = []
         if self.options.get_safe("with_cxx20_span"):
             self.cpp_info.defines = ["LIBUUID_CPP20_OR_GREATER"]
+        if self.options.get_safe("with_system_generator"):
+            self.cpp_info.system_libs = ["UUID_SYSTEM_GENERATOR"]
+        if self.options.get_safe("with_time_generator"):
+            self.cpp_info.system_libs = ["UUID_TIME_GENERATOR"]
+        if self.options.get_safe("hash_string_based"):
+            self.cpp_info.defines = ["UUID_HASH_STRING_BASED"]

--- a/recipes/stduuid/all/conanfile.py
+++ b/recipes/stduuid/all/conanfile.py
@@ -22,14 +22,12 @@ class StduuidConan(ConanFile):
         # False: Use gsl::span
         "with_cxx20_span": [True, False],
         "with_system_generator": [True, False],
-        "with_time_generator": [True, False],
-        "hash_string_based": [True, False]
+        "with_time_generator": [True, False]
     }
     default_options = {
         "with_cxx20_span": True,
         "with_system_generator": False,
-        "with_time_generator": False,
-        "hash_string_based": False,
+        "with_time_generator": False
     }
 
     @property
@@ -102,5 +100,4 @@ class StduuidConan(ConanFile):
             self.cpp_info.defines.append("UUID_SYSTEM_GENERATOR")
         if self.options.get_safe("with_time_generator"):
             self.cpp_info.defines.append("UUID_TIME_GENERATOR")
-        if self.options.get_safe("hash_string_based"):
-            self.cpp_info.defines.append("UUID_HASH_STRING_BASED")
+

--- a/recipes/stduuid/all/conanfile.py
+++ b/recipes/stduuid/all/conanfile.py
@@ -95,11 +95,12 @@ class StduuidConan(ConanFile):
     def package_info(self):
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
+        self.cpp_info.defines = []
         if self.options.get_safe("with_cxx20_span"):
-            self.cpp_info.defines = ["LIBUUID_CPP20_OR_GREATER"]
+            self.cpp_info.defines.append("LIBUUID_CPP20_OR_GREATER")
         if self.options.get_safe("with_system_generator"):
-            self.cpp_info.system_libs = ["UUID_SYSTEM_GENERATOR"]
+            self.cpp_info.defines.append("UUID_SYSTEM_GENERATOR")
         if self.options.get_safe("with_time_generator"):
-            self.cpp_info.system_libs = ["UUID_TIME_GENERATOR"]
+            self.cpp_info.defines.append("UUID_TIME_GENERATOR")
         if self.options.get_safe("hash_string_based"):
-            self.cpp_info.defines = ["UUID_HASH_STRING_BASED"]
+            self.cpp_info.defines.append("UUID_HASH_STRING_BASED")


### PR DESCRIPTION

### Summary
Changes to recipe:  **stduuid**. 

#### Motivation
This PR extends the conan recipe so all stduuid generator options are available to users. Currrently the only option in the recipe enables C++20 spans and two of the UUID generators are disabled and unusable by users via recipe options.

#### Details
This PR adds a few new recipe options that enable preprocessor definitions in package_info(). The new options are False by default so existing users are not impacted by the extensions.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
