### PR TITLE
neargye-semver: publish version 1.0.1

### DIFF
--- a/recipes/neargye-semver/all/conandata.yml
+++ b/recipes/neargye-semver/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.1":
+    url: "https://github.com/Neargye/semver/archive/refs/tags/v1.0.1.tar.gz"
+    sha256: "3fc9c17e993e1dc1c5de95a253c632807d4c2b1cf4862b61aa9a55680ed15ac1"
   "1.0.0":
     url: "https://github.com/Neargye/semver/archive/refs/tags/v1.0.0.tar.gz"
     sha256: "14fe5060fa1f039811c9969e638b1968b93265e1ecc799515c38196c8c62617b"

--- a/recipes/neargye-semver/config.yml
+++ b/recipes/neargye-semver/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.0.1":
+    folder: all
   "1.0.0":
     folder: all
   "0.3.1":


### PR DESCRIPTION
### Summary

Changes to recipe: **neargye-semver/1.0.1**

#### Motivation

Publish the upstream neargye-semver 1.0.1 release.

The release fixes compilation when Windows headers define the `min` and `max`
macros and includes the project license in CMake installations.

#### Details

- Added version 1.0.1 to `config.yml`.
- Added the official source archive and SHA256 to `conandata.yml`.
- Tested package creation and `test_package` with Conan 2.31.2, CMake 4.4,
  MSVC 19.51, and C++17.

---
- [x] Read the contributing guidelines.
- [x] Checked that this PR is not a duplicate.
- [x] Bug-fix issue link is not applicable; this PR publishes a new upstream version.
- [x] Tested locally with a recent version of Conan.