### PR TITLE
zeus_expected: add version 1.4.0

### DIFF
--- a/recipes/zeus_expected/all/conandata.yml
+++ b/recipes/zeus_expected/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.4.0":
+    url: "https://github.com/zeus-cpp/expected/archive/refs/tags/v1.4.0.tar.gz"
+    sha256: "70f7118651be51f5c02c0aa10bfb903f5a6c0bcd13ae726dfe34bf8836aaece0"
   "1.3.0":
     url: "https://github.com/zeus-cpp/expected/archive/refs/tags/v1.3.0.tar.gz"
     sha256: "d45bd4a38bde787577d16983ba8efee25e8d445af711510619f7b49ef60f1e72"

--- a/recipes/zeus_expected/config.yml
+++ b/recipes/zeus_expected/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.4.0":
+    folder: all
   "1.3.0":
     folder: all
   "1.2.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **zeus_expected/1.4.0**

#### Motivation
Update to the latest version.

#### Details
Add the recipe for [v1.4.0](https://github.com/zeus-cpp/expected/releases/tag/v1.4.0).

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

