### PR TITLE
icu: set rpath=\$ORIGIN on linux

### DIFF
--- a/recipes/icu/all/conanfile.py
+++ b/recipes/icu/all/conanfile.py
@@ -136,6 +136,10 @@ class ICUConan(ConanFile):
             tc.extra_defines.append("U_STATIC_IMPLEMENTATION")
         if is_apple_os(self):
             tc.extra_defines.append("_DARWIN_C_SOURCE")
+        if self.settings.os == "Linux":
+            # $ survives bash (sourcing conanautotoolstoolchain.sh) once, then Make's own
+            # $(LDFLAGS) expansion once more, so it needs escaping for both: \\ + \$ + \$
+            tc.extra_ldflags.append(r"-Wl,-rpath,\\\$\$ORIGIN")
         yes_no = lambda v: "yes" if v else "no"
         tc.configure_args.extend([
             "--datarootdir=${prefix}/lib", # do not use share


### PR DESCRIPTION
### Summary
Changes to recipe:  **icu/***

icu: set rpath=\$ORIGIN on linux
from @jcar87's https://github.com/conan-io/conan-center-index/issues/29187#issuecomment-5115994572

#### Motivation
it allows removing `VirtualRunEnv(self).generate(scope="build")` for recipes linking and invoking executables linking to icu 

#### Details
Without this fix, a typical error is: `/home/runner/.conan2/p/b/qt058ef5010c5e5/b/build/Release/qtbase/libexec/rcc: error while loading shared libraries: libicudata.so.76: cannot open shared object file: No such file or directory`
as can be seen on https://github.com/ericLemanissier/cocorepo/actions/runs/30372708348/job/90321022898


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
