### PR TITLE
plutosvg: Add version 0.0.8

### DIFF
--- a/recipes/plutosvg/all/conandata.yml
+++ b/recipes/plutosvg/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "0.0.7":
-    url: "https://github.com/sammycage/plutosvg/archive/refs/tags/v0.0.7.tar.gz"
-    sha256: "78561b571ac224030cdc450ca2986b4de915c2ba7616004a6d71a379bffd15f3"
+  "0.0.8":
+    url: "https://github.com/sammycage/plutosvg/archive/refs/tags/v0.0.8.tar.gz"
+    sha256: "49d5cfe772d3aa10cd4879f2f6e189f5083c08e4c8ea01bf3d5b87c97dfca7d2"

--- a/recipes/plutosvg/all/conandata.yml
+++ b/recipes/plutosvg/all/conandata.yml
@@ -2,3 +2,6 @@ sources:
   "0.0.8":
     url: "https://github.com/sammycage/plutosvg/archive/refs/tags/v0.0.8.tar.gz"
     sha256: "49d5cfe772d3aa10cd4879f2f6e189f5083c08e4c8ea01bf3d5b87c97dfca7d2"
+  "0.0.7":
+    url: "https://github.com/sammycage/plutosvg/archive/refs/tags/v0.0.7.tar.gz"
+    sha256: "78561b571ac224030cdc450ca2986b4de915c2ba7616004a6d71a379bffd15f3"

--- a/recipes/plutosvg/all/conanfile.py
+++ b/recipes/plutosvg/all/conanfile.py
@@ -36,7 +36,7 @@ class PlutoSVGConan(ConanFile):
 
     def requirements(self):
         # Public symbols and used in headers
-        self.requires("plutovg/1.0.0", transitive_headers=True, transitive_libs=True)
+        self.requires("plutovg/[>=1.0.0 <2]", transitive_headers=True, transitive_libs=True)
         if self.options.with_freetype:
             self.requires("freetype/[>=2.13.2 <3]")
 

--- a/recipes/plutosvg/config.yml
+++ b/recipes/plutosvg/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.0.7":
+  "0.0.8":
     folder: all

--- a/recipes/plutosvg/config.yml
+++ b/recipes/plutosvg/config.yml
@@ -1,3 +1,5 @@
 versions:
   "0.0.8":
     folder: all
+  "0.0.7":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **plutosvg/0.0.8**

#### Motivation
Update plutosvg to the latest release.

#### Details
The current version of plutosvg depends on plutovg version (>=1.0.0), so I removed the strict version requirement of 1.0.0
https://github.com/sammycage/plutosvg/blob/master/meson.build#L13


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] ~~If this is a bug fix, please link related issue or provide bug details~~
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
