### PR TITLE
wxwidgets: enable secretstore on Macos without libsecret

### DIFF
--- a/recipes/wxwidgets/all/conanfile.py
+++ b/recipes/wxwidgets/all/conanfile.py
@@ -81,8 +81,12 @@ class wxWidgetsConan(ConanFile):
         if self.settings.os == "Windows":
             self.options.rm_safe("fPIC")
         if self.settings.os != "Linux":
-            self.options.rm_safe("secretstore")
             self.options.rm_safe("cairo")
+        # secretstore needs no extra dependency on macOS (Keychain, via the
+        # Security framework already linked below) - only strip it where
+        # wx doesn't support wxSecretStore without extra deps at all.
+        if self.settings.os not in ("Linux", "Macos"):
+            self.options.rm_safe("secretstore")
 
     def configure(self):
         if self.options.shared:
@@ -117,7 +121,7 @@ class wxWidgetsConan(ConanFile):
                 self.requires("gst-plugins-base/1.19.2")
             self.requires("libcurl/[>=7.78.0 <9]")
 
-        if self.options.get_safe("secretstore"):
+        if self.options.get_safe("secretstore") and self.settings.os == "Linux":
             self.requires("libsecret/[>=0.21.7 <1]")
         if self.options.jpeg == "libjpeg":
             self.requires("libjpeg/[>=9e]")
@@ -230,7 +234,7 @@ class wxWidgetsConan(ConanFile):
             deps.set_property("gtk", "cmake_file_name", "GTK3")
             deps.set_property("xkbcommon", "cmake_file_name", "XKBCommon")
             deps.set_property("xkbcommon", "cmake_additional_variables_prefixes", ["XKBCOMMON",])
-        if self.options.get_safe("secretstore"):
+        if self.options.get_safe("secretstore") and self.settings.os == "Linux":
             deps.set_property("libsecret", "cmake_file_name", "LIBSECRET")
         if self.options.webview:
             deps.set_property("libsoup", "cmake_file_name", "LIBSOUP")


### PR DESCRIPTION
### Summary
Changes to recipe: **wxwidgets/all**

#### Motivation
On macOS, `config_options()` unconditionally strips the `secretstore` option for every non-Linux os, which forces `wxUSE_SECRETSTORE=OFF` regardless of what upstream's CMake build actually supports. This silently disables `wxSecretStore` for all Conan consumers on macOS, even though wxWidgets ships a Keychain-backed implementation there (`src/osx/core/secretstore.cpp`) that needs no extra dependency - only the `Security` framework, which this recipe already links unconditionally for macOS.

#### Details
- `config_options()`: only strip `secretstore` where wx has no secretstore backend at all (i.e. keep it for Linux and macOS, drop it elsewhere).
- `requirements()`: only require `libsecret` when `secretstore` is enabled on Linux, since macOS doesn't need it.
- `generate()`: only set the `LIBSECRET` CMake property when `secretstore` is enabled on Linux, matching the dependency change above.

No new dependencies are introduced; macOS builds continue to link only what they already link today.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
