### PR TITLE
gtest: add version 1.18.0

### DIFF
--- a/recipes/gtest/all/conandata.yml
+++ b/recipes/gtest/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.18.0":
+    url: "https://github.com/google/googletest/archive/v1.18.0.tar.gz"
+    sha256: "6e3191c1455468b3fc35a417fb565c1c5071aee1b7e7f85e30cf48a98d37d8b5"
   "1.17.0":
     url: "https://github.com/google/googletest/archive/v1.17.0.tar.gz"
     sha256: "65fab701d9829d38cb77c14acdc431d2108bfdbf8979e40eb8ae567edf10b27c"

--- a/recipes/gtest/all/conanfile.py
+++ b/recipes/gtest/all/conanfile.py
@@ -55,8 +55,12 @@ class GTestConan(ConanFile):
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
-        internal_utils = os.path.join(self.source_folder, "googletest", "cmake", "internal_utils.cmake")
-        replace_in_file(self, internal_utils, "-WX", "")
+        if Version(self.version) < "1.18.0":
+            # Removed in 1.18.0
+            # https://github.com/google/googletest/commit/4cb0ab12a15aa95649cb59c4063c206e3f2ee9ba
+            internal_utils = os.path.join(
+                self.source_folder, "googletest", "cmake", "internal_utils.cmake")
+            replace_in_file(self, internal_utils, "-WX", "")
 
     def generate(self):
         tc = CMakeToolchain(self)

--- a/recipes/gtest/config.yml
+++ b/recipes/gtest/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.18.0":
+    folder: all
   "1.17.0":
     folder: all
   "1.16.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **gtest/[1.18.0]**

#### Motivation
Update recipe to build the latest release

#### Details
gtest 1.18.0 was release earlier today - https://github.com/google/googletest/releases/tag/v1.18.0


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
