### PR TITLE
qt: dont mix build and run environment

### DIFF
--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -365,7 +365,7 @@ class QtConan(ConanFile):
         if self.options.get_safe("with_fontconfig", False):
             self.requires("fontconfig/2.15.0")
         if self.options.get_safe("with_icu", False):
-            self.requires("icu/74.2")
+            self.requires("icu/[>=74.2]")
         if self.options.get_safe("with_harfbuzz", False) and not self.options.multiconfiguration:
             self.requires("harfbuzz/[>=8.3.0]")
         if self.options.get_safe("with_libjpeg", False) and not self.options.multiconfiguration:
@@ -474,30 +474,13 @@ class QtConan(ConanFile):
         pc = PkgConfigDeps(self)
         pc.generate()
 
-        vbe = VirtualBuildEnv(self)
-        vbe.generate()
-        if not cross_building(self):
-            vre = VirtualRunEnv(self)
-            vre.generate(scope="build")
         env = Environment()
         # Tell Python to assume UTF-8 encoding to work around character encoding issues while building Qt WebEngine on Polish locale on Windows.
         env.define("PYTHONUTF8", "1")
-        # TODO: to remove when properly handled by conan (see https://github.com/conan-io/conan/issues/11962)
         env.unset("VCPKG_ROOT")
+        # PKG_CONFIG_PATH is exposed in CMakeToolchain, but the env var is needed when building QtWebEngine
         env.prepend_path("PKG_CONFIG_PATH", self.generators_folder)
-        env.vars(self).save_script("conanbuildenv_pkg_config_path")
-        if self.settings_build.os == "Macos":
-            # On macOS, SIP resets DYLD_LIBRARY_PATH injected by VirtualBuildEnv & VirtualRunEnv
-            dyld_library_path = "$DYLD_LIBRARY_PATH"
-            dyld_library_path_build = vbe.vars().get("DYLD_LIBRARY_PATH")
-            if dyld_library_path_build:
-                dyld_library_path = f"{dyld_library_path_build}:{dyld_library_path}"
-            if not cross_building(self):
-                dyld_library_path_host = vre.vars().get("DYLD_LIBRARY_PATH")
-                if dyld_library_path_host:
-                    dyld_library_path = f"{dyld_library_path_host}:{dyld_library_path}"
-            save(self, "bash_env", f'export DYLD_LIBRARY_PATH="{dyld_library_path}"')
-            env.define_path("BASH_ENV", os.path.abspath("bash_env"))
+        env.vars(self).save_script("conanbuildenv_extra_vars")
 
         tc = CMakeToolchain(self, generator="Ninja")
 

--- a/recipes/qt/6.x.x/conanfile.py
+++ b/recipes/qt/6.x.x/conanfile.py
@@ -8,7 +8,7 @@ from conan import ConanFile
 from conan.tools.apple import is_apple_os
 from conan.tools.build import cross_building, check_min_cppstd, default_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.env import VirtualBuildEnv, VirtualRunEnv, Environment
+from conan.tools.env import VirtualBuildEnv, Environment
 from conan.tools.files import copy, get, replace_in_file, apply_conandata_patches, save, rm, rmdir, export_conandata_patches
 from conan.tools.gnu import PkgConfigDeps
 from conan.tools.microsoft import msvc_runtime_flag, is_msvc
@@ -653,6 +653,15 @@ class QtConan(ConanFile):
         tc.variables["CMAKE_DISABLE_FIND_PACKAGE_EGL"] = not with_egl
 
         tc.generate()
+
+        if self.settings_build.os == "Windows" and not cross_building(self):
+            # moc.exe, uic.exe, etc are built first and used subsequently during the build
+            # and have DLL dependencies through QtCore library - copy the DLLs so that they
+            # are found at runtime to avoid exposing the "host" runenv to the build environment
+            dest_folder = os.path.join(self.build_folder, "qtbase", "bin") 
+            for dep in self.dependencies.host.values():
+                for bindir in dep.cpp_info.bindirs:
+                    copy(self, pattern="*.dll", src=bindir, dst=dest_folder, keep_path=False)
 
     def package_id(self):
         del self.info.options.cross_compile

--- a/recipes/qt/6.x.x/test_package/conanfile.py
+++ b/recipes/qt/6.x.x/test_package/conanfile.py
@@ -3,7 +3,6 @@ import os
 from conan import ConanFile
 from conan.tools.build import can_run
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.env import VirtualRunEnv
 from conan.tools.files import copy, save
 
 
@@ -34,10 +33,6 @@ Prefix = {path}""")
             for tool in ["moc", "rcc", "uic"]:
                 tc.cache_variables[f"CMAKE_AUTO{tool.upper()}_EXECUTABLE"] = os.path.join(qt_tools_rootdir, f"{tool}.exe" if self.settings_build.os == "Windows" else tool)
         tc.generate()
-
-        VirtualRunEnv(self).generate()
-        if can_run(self):
-            VirtualRunEnv(self).generate(scope="build")
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/qt/6.x.x/test_package/conanfile.py
+++ b/recipes/qt/6.x.x/test_package/conanfile.py
@@ -19,9 +19,9 @@ class TestPackageConan(ConanFile):
         self.requires(self.tested_reference_str, run=can_run(self))
 
     def build_requirements(self):
+        self.tool_requires("cmake/[>=3.27]") # needed for `CMAKE_AUTO{tool}_EXECUTABLE` variables
         if not can_run(self):
             self.tool_requires(self.tested_reference_str)
-            self.tool_requires("cmake/[>=3.27 <4]")
 
     def generate(self):
         path = self.dependencies["qt"].package_folder.replace("\\", "/")

--- a/recipes/qt/6.x.x/test_package/conanfile.py
+++ b/recipes/qt/6.x.x/test_package/conanfile.py
@@ -1,9 +1,10 @@
 import os
+import textwrap
 
 from conan import ConanFile
 from conan.tools.build import can_run
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, save
+from conan.tools.files import chmod, copy, save
 
 
 class TestPackageConan(ConanFile):
@@ -32,6 +33,34 @@ Prefix = {path}""")
             qt_tools_rootdir = self.conf.get("user.qt:tools_directory", None)
             for tool in ["moc", "rcc", "uic"]:
                 tc.cache_variables[f"CMAKE_AUTO{tool.upper()}_EXECUTABLE"] = os.path.join(qt_tools_rootdir, f"{tool}.exe" if self.settings_build.os == "Windows" else tool)
+        else:
+            bindir = "bin" if self.settings.os == "Windows" else "libexec"
+            qt_tools_rootdir = os.path.join(self.dependencies["qt"].package_folder, bindir)
+            is_windows = self.settings.os == "Windows"
+            if is_windows:
+                exe_ext, wrapper_ext, conanrun_name = ".exe", ".bat", "conanrun.bat"
+                template = textwrap.dedent("""\
+                    @echo off
+                    call "{conanrun_script}"
+                    "{real_tool}" %*
+                    exit /b %ERRORLEVEL%
+                    """)
+            else:
+                exe_ext, wrapper_ext, conanrun_name = "", "", "conanrun.sh"
+                template = textwrap.dedent("""\
+                    #!/bin/bash
+                    source "{conanrun_script}"
+                    exec "{real_tool}" "$@"
+                    """)
+
+            for tool in ["moc", "rcc", "uic"]:
+                real_tool = os.path.join(qt_tools_rootdir, f"{tool}{exe_ext}")
+                wrapper_path = os.path.join(self.generators_folder, f"{tool}{wrapper_ext}")
+                conanrun_script = os.path.join(self.generators_folder, conanrun_name)
+                save(self, wrapper_path, template.format(conanrun_script=conanrun_script, real_tool=real_tool))
+                if not is_windows:
+                    chmod(self, wrapper_path, execute=True)
+                tc.cache_variables[f"CMAKE_AUTO{tool.upper()}_EXECUTABLE"] = wrapper_path
         tc.generate()
 
     def build(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **qt/***
all credit goes to @jcar87 

#### Motivation
it avoids this kind of errors when building qt with qtwebengine enabled:
```
  Command "/Users/runner/.conan2/p/b/bison9608c4a2e0fa9/p/bin/bison
  --version" failed with output:
  dyld[27434]: Symbol not found: _iconv
    Referenced from: <A6201986-6E4F-34B9-AE19-E895FA317793> /Users/runner/.conan2/p/b/bison9608c4a2e0fa9/p/bin/bison
    Expected in:     <1506F455-FFDA-35C5-BA78-A12712735965> /Users/runner/.conan2/p/b/libic1c62f36c0e7f8/p/lib/libiconv.2.dylib
```

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [X] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
