### PR TITLE
[or-tools] Make the, compile with a C++20 conan profile 

### DIFF
--- a/recipes/or-tools/all/patches/0001-configure-cppstd.patch
+++ b/recipes/or-tools/all/patches/0001-configure-cppstd.patch
@@ -88,6 +88,14 @@ index 525903e..998b18d 100644
    CXX_STANDARD_REQUIRED ON
    CXX_EXTENSIONS OFF
    OUTPUT_NAME fzn-cp-sat
+@@ -162,7 +160,6 @@ target_include_directories(fzn-parser_test PRIVATE
+   )
+ ## Compile options
+ set_target_properties(fzn-parser_test PROPERTIES
+-  CXX_STANDARD 17
+   CXX_STANDARD_REQUIRED ON
+   CXX_EXTENSIONS OFF
+   OUTPUT_NAME fzn-parser-cp-sat
 diff --git a/ortools/third_party_solvers/CMakeLists.txt b/ortools/third_party_solvers/CMakeLists.txt
 index 97232c4..2bfd94e 100644
 --- a/ortools/third_party_solvers/CMakeLists.txt


### PR DESCRIPTION
### Summary
Changes to recipe:  **or-tools/9.15**

#### Motivation
I cannot compile the or-tools when I have a conan profile with `compiler.cppstd=20`.

```
conan create recipes/or-tools/all/conanfile.py --version 9.15

======== Exporting recipe to the cache ========
or-tools/9.15 export
Exporting package recipe: /home/ivhedtke/source/fork_conan-center-index/recipes/or-tools/all/conanfile.py
or-tools/9.15: exports: File 'conandata.yml' found. Exporting it...
or-tools/9.15: Calling export_sources()
Copied 1 '.py' file: conanfile.py
Copied 1 '.yml' file: conandata.yml
Copied 3 '.patch' files: 0001-configure-cppstd.patch, 0002-use-conan-protobuf.patch, 0003-conan-osx-target.patch
Exported to cache folder: /home/ivhedtke/.conan2/p/or-to43228d05ba570/e
Exported: or-tools/9.15#c43fb8ff021442e0f8bad598f3ffcfbe (2026-08-11 05:53:18 UTC)

======== Input profiles ========
Profile host:
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=20
compiler.libcxx=libstdc++11
compiler.version=16
os=Linux

Profile build:
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=20
compiler.libcxx=libstdc++11
compiler.version=16
os=Linux

[100%] Built target flatzinc
[100%] Building CXX object CMakeFiles/fzn-parser_test.dir/ortools/flatzinc/parser_main.cc.o
[100%] Building CXX object CMakeFiles/fzn.dir/ortools/flatzinc/fz.cc.o
In file included from /home/ivhedtke/.conan2/p/b/absei4e6c22f9e3e0f/p/include/absl/numeric/int128.h:41,
                 from /home/ivhedtke/.conan2/p/b/absei4e6c22f9e3e0f/p/include/absl/flags/marshalling.h:203,
                 from /home/ivhedtke/.conan2/p/b/absei4e6c22f9e3e0f/p/include/absl/flags/internal/flag.h:40,
                 from /home/ivhedtke/.conan2/p/b/absei4e6c22f9e3e0f/p/include/absl/flags/flag.h:42,
                 from /home/ivhedtke/.conan2/p/b/or-to5727eba4ad8cc/b/src/ortools/flatzinc/parser_main.cc:22:
/home/ivhedtke/.conan2/p/b/absei4e6c22f9e3e0f/p/include/absl/types/compare.h:60:12: error: ‘partial_ordering’ has not been declared in ‘std’
   60 | using std::partial_ordering;
      |            ^~~~~~~~~~~~~~~~
/home/ivhedtke/.conan2/p/b/absei4e6c22f9e3e0f/p/include/absl/types/compare.h:61:12: error: ‘strong_ordering’ has not been declared in ‘std’
   61 | using std::strong_ordering;
      |            ^~~~~~~~~~~~~~~
/home/ivhedtke/.conan2/p/b/absei4e6c22f9e3e0f/p/include/absl/types/compare.h:62:12: error: ‘weak_ordering’ has not been declared in ‘std’
   62 | using std::weak_ordering;
      |            ^~~~~~~~~~~~~
/home/ivhedtke/.conan2/p/b/absei4e6c22f9e3e0f/p/include/absl/types/compare.h:456:56: error: ‘weak_ordering’ in namespace ‘absl’ does not name a type
  456 | constexpr bool compare_result_as_less_than(const absl::weak_ordering r) {
      |                                                        ^~~~~~~~~~~~~
/home/ivhedtke/.conan2/p/b/absei4e6c22f9e3e0f/p/include/absl/types/compare.h:471:17: error: ‘weak_ordering’ in namespace ‘absl’ does not name a type
  471 | constexpr absl::weak_ordering compare_result_as_ordering(const Int c) {
      |                 ^~~~~~~~~~~~~
/home/ivhedtke/.conan2/p/b/absei4e6c22f9e3e0f/p/include/absl/types/compare.h:476:17: error: ‘weak_ordering’ in namespace ‘absl’ does not name a type
  476 | constexpr absl::weak_ordering compare_result_as_ordering(
      |                 ^~~~~~~~~~~~~
/home/ivhedtke/.conan2/p/b/absei4e6c22f9e3e0f/p/include/absl/types/compare.h:486:17: error: ‘weak_ordering’ in namespace ‘absl’ does not name a type
  486 | constexpr absl::weak_ordering do_three_way_comparison(const Compare& compare,
      |                 ^~~~~~~~~~~~~
/home/ivhedtke/.conan2/p/b/absei4e6c22f9e3e0f/p/include/absl/types/compare.h:495:17: error: ‘weak_ordering’ in namespace ‘absl’ does not name a type
  495 | constexpr absl::weak_ordering do_three_way_comparison(const Compare& compare,
      |                 ^~~~~~~~~~~~~
gmake[2]: *** [CMakeFiles/fzn-parser_test.dir/build.make:79: CMakeFiles/fzn-parser_test.dir/ortools/flatzinc/parser_main.cc.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:1607: CMakeFiles/fzn-parser_test.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
[100%] Linking CXX executable bin/fzn-cp-sat
[100%] Built target fzn
gmake: *** [Makefile:136: all] Error 2

or-tools/9.15: ERROR:
Package 'fb1450fea06f47fcdfdf63e7a970f9ca5aae6319' build failed
or-tools/9.15: WARN: Build folder /home/ivhedtke/.conan2/p/b/or-to5727eba4ad8cc/b/build/Release
ERROR: or-tools/9.15: Error in build() method, line 108
        cmake.build()
        ConanException: Error 2 while executing
```

#### Details
The existing patch 0001 did not drop the `CXX_STANDARD` from the target `fzn-parser_test`.
I fixed that. Now I can compile or-tools with my conan profile.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
