### PR TITLE
sqlcipher: fix windows arm compilation

### DIFF
--- a/recipes/sqlcipher/all/conanfile.py
+++ b/recipes/sqlcipher/all/conanfile.py
@@ -122,7 +122,11 @@ class SqlcipherConan(ConanFile):
         if self.settings.build_type == "Debug":
             env.define("DEBUG", "2")
         env.define("FOR_WIN10", "1")
-        env.define("PLATFORM", {"x86": "x86", "x86_64": "x64"}[str(self.settings.arch)])
+        env.define("PLATFORM", {
+            "x86": "x86",
+            "x86_64": "x64",
+            "armv8": "arm64"
+            }[str(self.settings.arch)])
         tc.generate(env)
 
         tc = NMakeDeps(self)

--- a/recipes/sqlcipher/all/conanfile.py
+++ b/recipes/sqlcipher/all/conanfile.py
@@ -3,8 +3,6 @@ import os
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import is_apple_os, fix_apple_shared_install_name
-from conan.tools.build import cross_building
-from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
 from conan.tools.files import apply_conandata_patches, chdir, copy, export_conandata_patches, get, replace_in_file, rm, rmdir, mkdir
 from conan.tools.gnu import Autotools, AutotoolsDeps, AutotoolsToolchain
 from conan.tools.layout import basic_layout
@@ -96,9 +94,6 @@ class SqlcipherConan(ConanFile):
         }.get(str(self.options.temporary_store))
 
     def _generate_msvc(self):
-        env = VirtualBuildEnv(self)
-        env.generate()
-
         tc = NMakeToolchain(self)
         env = tc.environment()
         crypto_dep = self.dependencies[str(self.options.crypto_library)].cpp_info
@@ -141,13 +136,6 @@ class SqlcipherConan(ConanFile):
         return self.options.crypto_library == "commoncrypto" and is_apple_os(self)
 
     def _generate_unix(self):
-        env = VirtualBuildEnv(self)
-        env.generate()
-
-        if not cross_building(self):
-            env = VirtualRunEnv(self)
-            env.generate(scope="build")
-
         tc = AutotoolsToolchain(self)
         tc.update_configure_args({
             "--oldincludedir": None,  # remove this arg (SQLCipher/SQLite configure doesn't support it)

--- a/recipes/sqlcipher/all/conanfile.py
+++ b/recipes/sqlcipher/all/conanfile.py
@@ -116,6 +116,7 @@ class SqlcipherConan(ConanFile):
             env.define("SQLITE_TEMP_STORE", self._temp_store_nmake_value)
         env.define("OPT_FEATURE_FLAGS", " ".join(opt_feature_flags))
         env.define("TCLSH_CMD", self.dependencies.build['tcl'].runenv_info.vars(self)['TCLSH'])
+        env.define("WITHOUT_JIMSH", "1")
 
         if not is_msvc_static_runtime(self):
             env.define("USE_CRT_DLL", "1")


### PR DESCRIPTION
### Summary
Changes to recipe:  **sqlcipher/***

#### Motivation
fix windows arm compilation as specified [here](https://github.com/sqlcipher/sqlcipher/blob/810db22f575ee7cf94ea96a3e91622b5fcece3dc/Makefile.msc#L456-L457)

#### Details
also, remove unneeded virtual run/build environments

CI success at https://github.com/ericLemanissier/cocorepo/actions/runs/31490088549/job/93774431004#step:13:171


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
