### PR TITLE
Cmake publish version 4.4.2

### DIFF
--- a/recipes/cmake/binary/conandata.yml
+++ b/recipes/cmake/binary/conandata.yml
@@ -2,22 +2,22 @@ sources:
   "4.4.0":
     Linux:
       armv8:
-        url: "https://cmake.org/files/v4.4/cmake-4.4.0-linux-aarch64.tar.gz"
-        sha256: "e98bb53e0b00a8f672424517d34c05bb9b94fd1c888c89e0b81bc8df51d1a94b"
+        url: "https://cmake.org/files/v4.4/cmake-4.4.2-linux-aarch64.tar.gz"
+        sha256: "9ca1aadb4451c5dcbdc67f9b4aff42dab52abbaebd8db9e2900026502dbed671"
       x86_64:
-        url: "https://cmake.org/files/v4.4/cmake-4.4.0-linux-x86_64.tar.gz"
-        sha256: "3864eb649b4466ae126a64bbde1657adad78efbbaa068bf38201de5cf1b5349f"
+        url: "https://cmake.org/files/v4.4/cmake-4.4.2-linux-x86_64.tar.gz"
+        sha256: "3ada9a3f5d8a85413579bdd0ea6aa8e8da86efdd6d15c91a1afa517f2021956c"
     Macos:
       universal:
-        url: "https://cmake.org/files/v4.4/cmake-4.4.0-macos-universal.tar.gz"
-        sha256: "09d6382059aa1b986b25fd1809459f5eb3da6a1ab342d44d6084265f38541397"
+        url: "https://cmake.org/files/v4.4/cmake-4.4.2-macos-universal.tar.gz"
+        sha256: "800fc86838e913fff969b499886c80baeb4ccfd00f0e39906b34aa334f39ab6c"
     Windows:
       armv8:
-        url: "https://cmake.org/files/v4.4/cmake-4.4.0-windows-arm64.zip"
-        sha256: "57437e918b2929bbd25b8d427611120149df02d4b216872e0f48f361f03d71e5"
+        url: "https://cmake.org/files/v4.4/cmake-4.4.2-windows-arm64.zip"
+        sha256: "8502cf1c5b1984e439d13df154c3c28d080d706efd52db4de1bb3cc7022db521"
       x86_64:
-        url: "https://cmake.org/files/v4.4/cmake-4.4.0-windows-x86_64.zip"
-        sha256: "156d70eb7625a7b469444df7d0861d2af8d5d0a437fce32c350372b08f5620e8"
+        url: "https://cmake.org/files/v4.4/cmake-4.4.2-windows-x86_64.zip"
+        sha256: "e8139d85b3813bc38833142ae1940472e9a587e9b5d2718ac1804c60f4e57a64"
   "3.31.12":
     Linux:
       armv8:

--- a/recipes/cmake/binary/conandata.yml
+++ b/recipes/cmake/binary/conandata.yml
@@ -1,5 +1,5 @@
 sources:
-  "4.4.0":
+  "4.4.2":
     Linux:
       armv8:
         url: "https://cmake.org/files/v4.4/cmake-4.4.2-linux-aarch64.tar.gz"

--- a/recipes/cmake/config.yml
+++ b/recipes/cmake/config.yml
@@ -1,7 +1,7 @@
 # List only the most recent 4.x version, and the most recent 3.x
 # older versions remain available in the Conan Center remote
 versions:
-  "4.4.0":
+  "4.4.2":
     folder: "binary"
   "3.31.12":
     folder: "binary"


### PR DESCRIPTION
### Summary
Changes to recipe:  **cmake/4.4.0**

#### Motivation
The version on conan center index is outdated as version 4.4.2 is out now

#### Details
Updated the sha256 and the paths for the cmake version to point towards 4.4.2 instead of 4.4.0


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
