### PR TITLE
ffmpeg: Add version 9.0.1

### DIFF
--- a/recipes/ffmpeg/all/conandata.yml
+++ b/recipes/ffmpeg/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "9.0":
-    url: "https://ffmpeg.org/releases/ffmpeg-9.0.tar.xz"
-    sha256: "7f607a00dd0d28a729d5a4811205812eef01cf6ef6155025febb6f36a9062d52"
+  "9.0.1":
+    url: "https://ffmpeg.org/releases/ffmpeg-9.0.1.tar.xz"
+    sha256: "cf38e0e28c7e5605942c4a77755349b0145804a397af37eb1fb4c77cb237f635"
   "8.1.2":
     url: "https://ffmpeg.org/releases/ffmpeg-8.1.2.tar.xz"
     sha256: "464beb5e7bf0c311e68b45ae2f04e9cc2af88851abb4082231742a74d97b524c"

--- a/recipes/ffmpeg/all/conandata.yml
+++ b/recipes/ffmpeg/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "9.0":
+    url: "https://ffmpeg.org/releases/ffmpeg-9.0.tar.xz"
+    sha256: "7f607a00dd0d28a729d5a4811205812eef01cf6ef6155025febb6f36a9062d52"
   "8.1.2":
     url: "https://ffmpeg.org/releases/ffmpeg-8.1.2.tar.xz"
     sha256: "464beb5e7bf0c311e68b45ae2f04e9cc2af88851abb4082231742a74d97b524c"

--- a/recipes/ffmpeg/config.yml
+++ b/recipes/ffmpeg/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "9.0":
+    folder: "all"
   "8.1.2":
     folder: "all"
   "7.1.5":

--- a/recipes/ffmpeg/config.yml
+++ b/recipes/ffmpeg/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "9.0":
+  "9.0.1":
     folder: "all"
   "8.1.2":
     folder: "all"


### PR DESCRIPTION
### Summary
Changes to recipe:  **ffmpeg/9.0**

#### Motivation
Number of small new additions like Apple Video Toolbox for raw decoding etc.

Intentionally leaving the previous two prooven versions as this is the first 9.0 release and the others are well in their cycle.

#### Details
https://git.ffmpeg.org/gitweb/ffmpeg.git/blob_plain/844e10e1a74929c27dfe0aac1c34e92bb6edbf5a:/Changelog

According to changelog no new external libs etc., also tried to browse a bit through the repository and saw nothing jumping out in the build files, changes following added or maybe also renamed files.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
