### PR TITLE
libultrahdr: Add version 2.0.1 and 1.5.1

### DIFF
--- a/recipes/libultrahdr/all/conandata.yml
+++ b/recipes/libultrahdr/all/conandata.yml
@@ -1,10 +1,17 @@
 
 sources:
-  "1.4.0":
-    url: "https://github.com/google/libultrahdr/archive/refs/tags/v1.4.0.tar.gz"
-    sha256: "e7e1252e2c44d8ed6b99ee0f67a3caf2d8a61c43834b13b1c3cd485574c03ab9"
+  "2.0.1":
+    url: "https://github.com/google/libultrahdr/archive/refs/tags/v2.0.1.tar.gz"
+    sha256: "588232d2c9adcd01541d48dc2e76f8448c52fea7fc2543e700a281b995ab50d2"
+  "1.5.1":
+    url: "https://github.com/google/libultrahdr/archive/refs/tags/v1.5.1.tar.gz"
+    sha256: "54d3f36c1d2b56ef9b8e63fd3f5fcac56c2c4540f8a56e0cc952f5010d790191"
 patches:
-  "1.4.0":
-    - patch_file: "patches/1.4.0_cmake-portability.patch"
+  "2.0.1":
+    - patch_file: "patches/2.0.1_cmake-portability.patch"
+      patch_description: "Ensure project builds correctly with Conan (Ensure correct finding & linkin of dependencies and prevent some forced overriden settings provided by the Conan CMake toolchain)"
+      patch_type: "conan"
+  "1.5.1":
+    - patch_file: "patches/1.5.1_cmake-portability.patch"
       patch_description: "Ensure project builds correctly with Conan (Ensure correct finding & linkin of dependencies and prevent some forced overriden settings provided by the Conan CMake toolchain)"
       patch_type: "conan"

--- a/recipes/libultrahdr/all/conanfile.py
+++ b/recipes/libultrahdr/all/conanfile.py
@@ -2,6 +2,8 @@ from conan import ConanFile
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
+from conan.tools.microsoft import is_msvc
+from conan.tools.scm import Version
 
 import os
 
@@ -21,11 +23,14 @@ class LibultrahdrConan(ConanFile):
         "shared": [True, False],
         "fPIC": [True, False],
         "with_jpeg": ["libjpeg", "libjpeg-turbo", "mozjpeg"],
+        # libheif support added in 2.0
+        "with_libheif": [True, False],
     }
     default_options = {
         "shared": False,
         "fPIC": True,
         "with_jpeg": "libjpeg",
+        "with_libheif": False,
     }
 
     def export_sources(self):
@@ -35,9 +40,15 @@ class LibultrahdrConan(ConanFile):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
+        if Version(self) < "2.0":
+            del self.options.with_libheif
+
     def configure(self):
         if self.options.shared:
             self.options.rm_safe("fPIC")
+
+        if Version(self) < "2.0":
+            self.options.rm_safe("with_libheif")
 
     def layout(self):
         cmake_layout(self, src_folder="src")
@@ -49,6 +60,9 @@ class LibultrahdrConan(ConanFile):
             self.requires("libjpeg-turbo/[>=3.0.0 <4]")
         elif self.options.with_jpeg == "mozjpeg":
             self.requires("mozjpeg/[>=4.1.3 <5]")
+
+        if self.options.get_safe("with_libheif", False):
+            self.requires("libheif/[>=1.16 <2]")
 
     def build_requirements(self):
         # The project requires cmake 3.15 but the use of CMAKE_REQUIRE_FIND_PACKAGE_JPEG below
@@ -69,8 +83,16 @@ class LibultrahdrConan(ConanFile):
         tc.cache_variables["UHDR_BUILD_DEPS"] = False
         tc.cache_variables['UHDR_BUILD_EXAMPLES'] = False
         tc.cache_variables["CMAKE_REQUIRE_FIND_PACKAGE_JPEG"] = True
+        if is_msvc(self) and not self.options.shared:
+            tc.cache_variables["BUILD_FOR_WINUI"] = True
+
+        if Version(self) >= "2.0":
+            # Always force activate/deactivate
+            tc.cache_variables["UHDR_ENABLE_HEIF"] = self.options.get_safe("with_libheif", False)
+            tc.cache_variables["CMAKE_REQUIRE_FIND_PACKAGE_libheif"] = True
 
         tc.generate()
+
         deps = CMakeDeps(self)
         if self.options.with_jpeg:
             deps.set_property(self.options.with_jpeg, "cmake_file_name", "JPEG")
@@ -90,7 +112,8 @@ class LibultrahdrConan(ConanFile):
         rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
 
     def package_info(self):
-        self.cpp_info.libs = ['uhdr']
+        suffix = "-static" if is_msvc(self) and not self.options.shared else ""
+        self.cpp_info.libs = [f"uhdr{suffix}"]
 
         if self.options.with_jpeg == "libjpeg":
             self.cpp_info.requires = ["libjpeg::libjpeg"]
@@ -98,6 +121,9 @@ class LibultrahdrConan(ConanFile):
             self.cpp_info.requires = ["libjpeg-turbo::jpeg"]
         elif self.options.with_jpeg == "mozjpeg":
             self.cpp_info.requires = ["mozjpeg::libjpeg"]
+
+        if self.options.get_safe("with_libheif", False):
+            self.cpp_info.requires.append("libheif::libheif")
 
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs = ["pthread"]

--- a/recipes/libultrahdr/all/patches/1.5.1_cmake-portability.patch
+++ b/recipes/libultrahdr/all/patches/1.5.1_cmake-portability.patch
@@ -1,16 +1,7 @@
 diff --git CMakeLists.txt CMakeLists.txt
-index 69a249b..9fb78be 100644
+index f81653e..3264ea3 100644
 --- CMakeLists.txt
 +++ CMakeLists.txt
-@@ -19,7 +19,7 @@ cmake_minimum_required(VERSION 3.15)
- # CMP0091: MSVC runtime library flags are selected by an abstraction.
- # New in CMake 3.15. https://cmake.org/cmake/help/latest/policy/CMP0091.html
- if(POLICY CMP0091)
--  cmake_policy(SET CMP0091 OLD)
-+  cmake_policy(SET CMP0091 NEW)
- endif()
- 
- set(UHDR_MAJOR_VERSION 1)
 @@ -144,7 +144,7 @@ if(UHDR_BUILD_BENCHMARK AND EMSCRIPTEN)
  endif()
  
@@ -20,24 +11,24 @@ index 69a249b..9fb78be 100644
    set(UHDR_ENABLE_INSTALL FALSE) # disable install and uninstall targets during cross compilation.
    message(STATUS "Install and uninstall targets - Disabled")
  endif()
-@@ -171,9 +171,9 @@ endif()
+@@ -184,9 +184,9 @@ endif()
  ###########################################################
  # Compile flags
  ###########################################################
 -set(CMAKE_CXX_STANDARD 17)
 -set(CMAKE_CXX_STANDARD_REQUIRED ON)
 -set(CMAKE_CXX_EXTENSIONS OFF)
-+# set(CMAKE_CXX_STANDARD 17)
-+# set(CMAKE_CXX_STANDARD_REQUIRED ON)
-+# set(CMAKE_CXX_EXTENSIONS OFF)
++#set(CMAKE_CXX_STANDARD 17)
++#set(CMAKE_CXX_STANDARD_REQUIRED ON)
++#set(CMAKE_CXX_EXTENSIONS OFF)
  if(BUILD_SHARED_LIBS)
    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
    set(CMAKE_CXX_VISIBILITY_PRESET hidden)
-@@ -796,7 +796,7 @@ if(UHDR_BUILD_JAVA)
- endif()
- 
+@@ -868,7 +868,7 @@ endif()
  if(UHDR_ENABLE_INSTALL)
--  if(NOT(MSVC OR XCODE))
+   # XCODE seems to have issues when the target has only object files as input
+   # we use combine_static_libs to prepare install targets
+-  if(NOT XCODE)
 +  if(TRUE)
      include(GNUInstallDirs)
  

--- a/recipes/libultrahdr/all/patches/2.0.1_cmake-portability.patch
+++ b/recipes/libultrahdr/all/patches/2.0.1_cmake-portability.patch
@@ -1,0 +1,35 @@
+diff --git CMakeLists.txt CMakeLists.txt
+index 0d565a1..202195c 100644
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -145,7 +145,7 @@ if(UHDR_BUILD_BENCHMARK AND EMSCRIPTEN)
+ endif()
+ 
+ # side effects
+-if(CMAKE_CROSSCOMPILING AND UHDR_ENABLE_INSTALL)
++if(FALSE)
+   set(UHDR_ENABLE_INSTALL FALSE) # disable install and uninstall targets during cross compilation.
+   message(STATUS "Install and uninstall targets - Disabled")
+ endif()
+@@ -185,9 +185,9 @@ endif()
+ ###########################################################
+ # Compile flags
+ ###########################################################
+-set(CMAKE_CXX_STANDARD 17)
+-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+-set(CMAKE_CXX_EXTENSIONS OFF)
++#set(CMAKE_CXX_STANDARD 17)
++#set(CMAKE_CXX_STANDARD_REQUIRED ON)
++#set(CMAKE_CXX_EXTENSIONS OFF)
+ if(BUILD_SHARED_LIBS)
+   set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+   set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+@@ -976,7 +976,7 @@ endif()
+ if(UHDR_ENABLE_INSTALL)
+   # XCODE seems to have issues when the target has only object files as input
+   # we use combine_static_libs to prepare install targets
+-  if(NOT XCODE)
++  if(TRUE)
+     include(GNUInstallDirs)
+ 
+     # pkg-config: libuhdr.pc

--- a/recipes/libultrahdr/config.yml
+++ b/recipes/libultrahdr/config.yml
@@ -1,3 +1,5 @@
 versions:
-  "1.4.0":
+  "2.0.1":
+    folder: all
+  "1.5.1":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **lib/[version]**

#### Motivation

Adding 2.0.1 as the most recent release and 1.5.1 for backwards compatibility.

#### Details

**IMPORTANT**: Needs input on the libheif integration. There is two open points I wasn't able to solve where conanfile.py isn't working as I was expecting:
- I thought the implementation of the options handling should remove `with_libheif` from 1.5.1, but still I can pass it without an error and then get libheif as a requirement.
- To test the enforcement of requiering it, to ensure that if the user sets the option, it fails if not found, does not work. If I just comment out the "requires"-Line, it reports as a warning that it didn't find libheif but still builds without an error. Which from my point of view I'd say is an error.

- Some changes orient at the comment in #30720
- https://github.com/google/libultrahdr/releases/tag/v2.0.1
- https://github.com/google/libultrahdr/releases/tag/v1.5.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
