### PR TITLE
Add trinity 0.1.0

### DIFF
--- a/recipes/trinity/all/conandata.yml
+++ b/recipes/trinity/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.1.0":
+    url: "https://github.com/Aurora-Program/Aurora-Trinity/archive/refs/tags/v0.1.0.tar.gz"
+    sha256: "ebbcd34dc8e749ea493e51f413b69fb0b096f4d641fd9abc0a069be488ce74f5"

--- a/recipes/trinity/all/conanfile.py
+++ b/recipes/trinity/all/conanfile.py
@@ -1,0 +1,71 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get
+import os
+
+
+required_conan_version = ">=2.1"
+
+
+class TrinityConan(ConanFile):
+    name = "trinity"
+    description = "C11 execution library for the Aurora model"
+    license = "Apache-2.0 AND CC-BY-4.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/Aurora-Program/Aurora-Trinity"
+    topics = ("c", "cmake", "aurora", "trinity", "ternary")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        toolchain = CMakeToolchain(self)
+        toolchain.variables["BUILD_SHARED_LIBS"] = self.options.shared
+        toolchain.variables["BUILD_TESTING"] = False
+        if self.options.get_safe("fPIC") is not None:
+            toolchain.variables["CMAKE_POSITION_INDEPENDENT_CODE"] = self.options.fPIC
+        toolchain.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder,
+             dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "Trinity")
+
+        self.cpp_info.components["trinity"].set_property(
+            "cmake_target_name", "Trinity::trinity")
+        self.cpp_info.components["trinity"].libs = ["trinity"]
+
+        self.cpp_info.components["genesis"].set_property(
+            "cmake_target_name", "Trinity::genesis")
+        self.cpp_info.components["genesis"].libs = ["genesis"]
+        self.cpp_info.components["genesis"].requires = ["trinity"]

--- a/recipes/trinity/all/test_package/CMakeLists.txt
+++ b/recipes/trinity/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES C)
+
+find_package(Trinity REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE Trinity::trinity)

--- a/recipes/trinity/all/test_package/conanfile.py
+++ b/recipes/trinity/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TrinityTestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            self.run(os.path.join(self.cpp.build.bindirs[0], "test_package"),
+                     env="conanrun")

--- a/recipes/trinity/all/test_package/test_package.c
+++ b/recipes/trinity/all/test_package/test_package.c
@@ -1,0 +1,9 @@
+#include <assert.h>
+#include <trinity/trinity.h>
+
+int main(void) {
+    aurora_domain domain = aurora_domain_singleton(2u);
+    assert(aurora_domain_is_singleton(domain));
+    assert(aurora_domain_contains(domain, 2u));
+    return 0;
+}

--- a/recipes/trinity/config.yml
+++ b/recipes/trinity/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.1.0":
+    folder: all


### PR DESCRIPTION
## Description

Add the first ConanCenter recipe for Trinity 0.1.0, the C11 execution library for the Aurora model.

## Package details

- Source: https://github.com/Aurora-Program/Aurora-Trinity/releases/tag/v0.1.0
- CMake package targets: `Trinity::trinity` and `Trinity::genesis`
- Includes a C test package using `Trinity::trinity`
- Source archive checksum is pinned in `conandata.yml`

The upstream project has already verified a clean CMake build and its exhaustive test suite for this release.