### PR TITLE
Update Avro version to 1.12.2 in conandata.yml

### DIFF
--- a/recipes/libavrocpp/all/conandata.yml
+++ b/recipes/libavrocpp/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "1.12.1":
-    url: "https://archive.apache.org/dist/avro/avro-1.12.1/avro-src-1.12.1.tar.gz"
-    sha256: "268e47c0850df04f952ea6fdfc3b12a8d0042124354bff6c0239be0b70016d2e"
+  "1.12.2":
+    url: "https://archive.apache.org/dist/avro/avro-1.12.2/avro-src-1.12.2.tar.gz"
+    sha256: "449722c442ec9514d8e6933f9c7ccf2e0544cb75c951c25b804ea1d8e73d12bb"

--- a/recipes/libavrocpp/config.yml
+++ b/recipes/libavrocpp/config.yml
@@ -1,3 +1,3 @@
 versions:
-  1.12.1:
+  1.12.2:
     folder: all


### PR DESCRIPTION
### Summary

Changes to recipe:  **libavrocpp/1.12.2**

#### Motivation
Old version seems no longer available. URL returns 404

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
