### PR TITLE
nlohmann_json: add configuration options

### DIFF
--- a/recipes/nlohmann_json/all/conanfile.py
+++ b/recipes/nlohmann_json/all/conanfile.py
@@ -2,6 +2,7 @@ from conan import ConanFile
 from conan.tools.build import check_min_cppstd
 from conan.tools.files import copy, get
 from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.50.0"
@@ -17,10 +18,43 @@ class NlohmannJsonConan(ConanFile):
     package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
+    options = {
+        "enable_exceptions": [True, False],
+        "enable_implicit_conversions": [True, False],
+        "enable_enum_serialization": [True, False],
+        "enable_diagnostics": [True, False],
+        "enable_diagnostic_positions": [True, False],
+        "enable_global_udls": [True, False],
+        "enable_io": [True, False],
+        "enable_legacy_discarded_value_comparison": [True, False],
+    }
+    default_options = {
+        "enable_exceptions": True,
+        "enable_implicit_conversions": True,
+        "enable_enum_serialization": True,
+        "enable_diagnostics": False,
+        "enable_diagnostic_positions": False,
+        "enable_global_udls": True,
+        "enable_io": True,
+        "enable_legacy_discarded_value_comparison": False,
+    }
 
     @property
     def _minimum_cpp_standard(self):
         return 11
+
+    def config_options(self):
+        if Version(self.version) < "3.9.0":
+            self.options.rm_safe("enable_implicit_conversions")
+        if Version(self.version) < "3.10.0":
+            self.options.rm_safe("enable_diagnostics")
+            self.options.rm_safe("enable_io")
+        if Version(self.version) < "3.11.0":
+            self.options.rm_safe("enable_enum_serialization")
+            self.options.rm_safe("enable_global_udls")
+            self.options.rm_safe("enable_legacy_discarded_value_comparison")
+        if Version(self.version) < "3.12.0":
+            self.options.rm_safe("enable_diagnostic_positions")
 
     def layout(self):
         basic_layout(self, src_folder="src")
@@ -51,3 +85,22 @@ class NlohmannJsonConan(ConanFile):
         self.cpp_info.set_property("pkg_config_name", "nlohmann_json")
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
+
+        # Options unsupported by this version are removed in config_options() and define nothing.
+        # The 0/1 macros are always defined, so behavior never depends on the header defaults.
+        for option, enabled, disabled in [
+            ("enable_exceptions", None, "JSON_NOEXCEPTION"),
+            ("enable_io", None, "JSON_NO_IO"),
+            ("enable_implicit_conversions", "JSON_USE_IMPLICIT_CONVERSIONS=1", "JSON_USE_IMPLICIT_CONVERSIONS=0"),
+            ("enable_enum_serialization", "JSON_DISABLE_ENUM_SERIALIZATION=0", "JSON_DISABLE_ENUM_SERIALIZATION=1"),
+            ("enable_diagnostics", "JSON_DIAGNOSTICS=1", "JSON_DIAGNOSTICS=0"),
+            ("enable_diagnostic_positions", "JSON_DIAGNOSTIC_POSITIONS=1", "JSON_DIAGNOSTIC_POSITIONS=0"),
+            ("enable_global_udls", "JSON_USE_GLOBAL_UDLS=1", "JSON_USE_GLOBAL_UDLS=0"),
+            ("enable_legacy_discarded_value_comparison", "JSON_USE_LEGACY_DISCARDED_VALUE_COMPARISON=1", "JSON_USE_LEGACY_DISCARDED_VALUE_COMPARISON=0"),
+        ]:
+            value = self.options.get_safe(option)
+            if value is None:
+                continue
+            define = enabled if value else disabled
+            if define:
+                self.cpp_info.defines.append(define)


### PR DESCRIPTION
### Summary
Changes to recipe: **nlohmann_json/all versions**

#### Motivation
nlohmann/json is configured almost entirely through preprocessor macros (e.g. implicit conversion, enable exceptions, extended diagnostics etc). The recipe didn't expose any of them, so the only way to change that behavior was to define the macros by hand in your own package.

That works, but it has to be repeated in every consumer and it's easy to get wrong: the macros have to be defined consistently everywhere the headers are included, and some of them (JSON_DIAGNOSTICS in particular) change the layout of basic_json. Being able to set this once as a Conan option, or in a profile, is a lot harder to get wrong and helps especially with shared dependencies across packages.

#### Details

Adds an option per documented configuration macro, all defaulting to the same behavior as before, so nothing changes unless you set one. Since the macros were introduced in different releases, config_options() drops the ones a given version doesn't know about, and setting them there fails with "option doesn't exist" instead of quietly doing nothing.

Worth noting for review: the value macros are defined also when left at their default rather than only when they differ from the header default. That keeps the behavior pinned to the option, and makes a disagreement with a package that defines the same macro itself show up as a macro redefinition warning instead of one value silently winning on link order.

*json-schema-validator* does this today with JSON_DIAGNOSTICS, and should switch to the new option once this is in.

New options (see: https://json.nlohmann.me/features/macros/):

| option | macro |
| --- | --- |
| enable_exceptions | JSON_NOEXCEPTION |
| enable_io | JSON_NO_IO |
| enable_implicit_conversions | JSON_USE_IMPLICIT_CONVERSIONS |
| enable_enum_serialization | JSON_DISABLE_ENUM_SERIALIZATION |
| enable_diagnostics | JSON_DIAGNOSTICS |
| enable_diagnostic_positions | JSON_DIAGNOSTIC_POSITIONS |
| enable_global_udls | JSON_USE_GLOBAL_UDLS |
| enable_legacy_discarded_value_comparison | JSON_USE_LEGACY_DISCARDED_VALUE_COMPARISON |

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
