### PR TITLE
dispenso: add version 1.6.0

### DIFF
--- a/recipes/dispenso/all/conandata.yml
+++ b/recipes/dispenso/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.6.0":
+    url: "https://github.com/facebookincubator/dispenso/archive/refs/tags/v1.6.0.tar.gz"
+    sha256: "1c188b8593411080d653776595a15049f9e7eecd5212b31b3ee7bb094ff63971"
   "1.5.1":
     url: "https://github.com/facebookincubator/dispenso/archive/refs/tags/v1.5.1.tar.gz"
     sha256: "e75b2a1bd428b2e9558ea99c03d266d2bf8881ba41689016e8c98052e1a0c17d"

--- a/recipes/dispenso/all/conandata.yml
+++ b/recipes/dispenso/all/conandata.yml
@@ -2,6 +2,3 @@ sources:
   "1.6.0":
     url: "https://github.com/facebookincubator/dispenso/archive/refs/tags/v1.6.0.tar.gz"
     sha256: "1c188b8593411080d653776595a15049f9e7eecd5212b31b3ee7bb094ff63971"
-  "1.5.1":
-    url: "https://github.com/facebookincubator/dispenso/archive/refs/tags/v1.5.1.tar.gz"
-    sha256: "e75b2a1bd428b2e9558ea99c03d266d2bf8881ba41689016e8c98052e1a0c17d"

--- a/recipes/dispenso/config.yml
+++ b/recipes/dispenso/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "1.6.0":
+    folder: all
   "1.5.1":
     folder: all

--- a/recipes/dispenso/config.yml
+++ b/recipes/dispenso/config.yml
@@ -1,5 +1,3 @@
 versions:
   "1.6.0":
     folder: all
-  "1.5.1":
-    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **dispenso/1.6.0**

fixes #30785

#### Motivation
Update dispenso to version 1.6.0.

#### Details
Added version 1.6.0 entry to `conandata.yml` and `config.yml`. No changes to `conanfile.py` (version-agnostic).

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan
---
