### PR TITLE
mongo-c-driver: fix problems with newer CMake versions

### DIFF
--- a/recipes/mongo-c-driver/all/conanfile.py
+++ b/recipes/mongo-c-driver/all/conanfile.py
@@ -89,6 +89,7 @@ class MongoCDriverConan(ConanFile):
             raise ConanInvalidConfiguration("with_sasl=sspi only allowed on Windows")
 
     def build_requirements(self):
+        self.tool_requires("cmake/[>=3.15 <4]")
         if self.options.with_ssl == "libressl" or self.options.with_zstd:
             if not self.conf.get("tools.gnu:pkg_config", check_type=str):
                 self.tool_requires("pkgconf/2.1.0")

--- a/recipes/mongo-c-driver/all/conanfile.py
+++ b/recipes/mongo-c-driver/all/conanfile.py
@@ -89,7 +89,7 @@ class MongoCDriverConan(ConanFile):
             raise ConanInvalidConfiguration("with_sasl=sspi only allowed on Windows")
 
     def build_requirements(self):
-        self.tool_requires("cmake/[>=3.15 <4]")
+        self.tool_requires("cmake/[>=3.15 <4.4]")
         if self.options.with_ssl == "libressl" or self.options.with_zstd:
             if not self.conf.get("tools.gnu:pkg_config", check_type=str):
                 self.tool_requires("pkgconf/2.1.0")
@@ -160,6 +160,8 @@ class MongoCDriverConan(ConanFile):
         tc.variables["HAVE_ASN1_STRING_GET0_DATA"] = True  # Requires OpenSSL 1.1.0+
         # https://github.com/mongodb/mongo-c-driver/blob/1.25.3/src/libmongoc/CMakeLists.txt#L366-L375
         tc.variables["SASL2_HAVE_SASL_CLIENT_DONE"] = True # Requires Cyrus-SASL 2.1.23+
+        if Version(self.version) < "1.25":
+            tc.variables["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5"
         tc.generate()
 
         deps = CMakeDeps(self)
@@ -184,6 +186,9 @@ class MongoCDriverConan(ConanFile):
         # cleanup rpath
         replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"),
                               "set (CMAKE_INSTALL_RPATH_USE_LINK_PATH ON)", "")
+        if Version(self.version) < "1.30.3":
+            replace_in_file(self, os.path.join(self.source_folder, "src", "libbson", "CMakeLists.txt"),
+                                  "cmake_policy (SET CMP0042 OLD)", "")
 
     def build(self):
         self._patch_sources()

--- a/recipes/mongo-c-driver/all/conanfile.py
+++ b/recipes/mongo-c-driver/all/conanfile.py
@@ -89,7 +89,6 @@ class MongoCDriverConan(ConanFile):
             raise ConanInvalidConfiguration("with_sasl=sspi only allowed on Windows")
 
     def build_requirements(self):
-        self.tool_requires("cmake/[>=3.15 <4.4]")
         if self.options.with_ssl == "libressl" or self.options.with_zstd:
             if not self.conf.get("tools.gnu:pkg_config", check_type=str):
                 self.tool_requires("pkgconf/2.1.0")
@@ -189,6 +188,10 @@ class MongoCDriverConan(ConanFile):
         if Version(self.version) < "1.30.3":
             replace_in_file(self, os.path.join(self.source_folder, "src", "libbson", "CMakeLists.txt"),
                                   "cmake_policy (SET CMP0042 OLD)", "")
+        if Version(self.version) < "2.4.0":
+            replace_in_file(self, os.path.join(self.source_folder, "src", "libmongoc", "CMakeLists.txt"),
+                                  "\"-Werror -DCMAKE_CXX_LINK_EXECUTABLE='echo not linking now...'\"",
+                                  "\"-DCOMPILE_DEFINITIONS=-Werror\" \"-DCMAKE_CXX_LINK_EXECUTABLE='echo not linking now...'\"")
 
     def build(self):
         self._patch_sources()


### PR DESCRIPTION
### Summary
Changes to recipe:  **mongo-c-driver**

#### Motivation
It's not possible to compile **mongo-c-driver** recipe when newer versions of CMake are on system path, the recipe doesn't declare any CMake range

#### Details
- <2.4.0 has broken TRY_COMPILE in src/libmongoc/CMakeLists.txt, failing in CMake 4.4+
  - https://github.com/mongodb/mongo-c-driver/commit/ea1b54791ec2f1aafb665f98af6cc9dd21116782
- <1.30.3/<2.1.0 has CMP0042 OLD in src/libbson/CMakeLists.txt, removed in CMake 4+
  - https://github.com/mongodb/mongo-c-driver/commit/23440389b76dad06ac11640f06e6e5682e5e4b35
  - https://github.com/mongodb/mongo-c-driver/commit/c60f45fcd10607b7fbf2c2de1b8904880b4709c7
- <1.25 has cmake_minimum_required (VERSION 3.1) in src/libbson/CMakeLists.txt, rejected in CMake 4+
  - https://github.com/mongodb/mongo-c-driver/commit/3c7951b46eb57995e65fd94cd7ee9f907df09d2e#diff-71a4c7cf57df62b3b3d8bb547bcf79c5fafb5accb4a6608d696ccdf43e17ad6a

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
