### PR TITLE
givp/1.0.1: add recipe

### DIFF
--- a/recipes/givp/all/conandata.yml
+++ b/recipes/givp/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.0.1":
+    url: "https://github.com/Arnime/givp/archive/refs/tags/v1.0.1.tar.gz"
+    sha256: "a76a25a41905f9501c696e413ecb014f85d2a62d5985618ba2a7b3565bdc2910"

--- a/recipes/givp/all/conandata.yml
+++ b/recipes/givp/all/conandata.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Arnaldo Mendes Pires Junior
+# SPDX-License-Identifier: MIT
+
 sources:
   "1.0.1":
     url: "https://github.com/Arnime/givp/archive/refs/tags/v1.0.1.tar.gz"

--- a/recipes/givp/all/conanfile.py
+++ b/recipes/givp/all/conanfile.py
@@ -1,0 +1,65 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get
+
+required_conan_version = ">=2.0"
+
+
+class GivpConan(ConanFile):
+    name = "givp"
+    license = "MIT"
+    homepage = "https://github.com/Arnime/givp"
+    url = "https://github.com/conan-io/conan-center-index"
+    description = (
+        "GRASP-ILS-VND with Path Relinking optimizer for continuous and "
+        "mixed-integer black-box optimization."
+    )
+    topics = "optimization", "metaheuristic", "grasp", "ils", "vnd", "header-only"
+    package_type = "header-library"
+
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    def layout(self):
+        cmake_layout(self, src_folder="cpp")
+
+    def validate(self):
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, 17)
+
+    def package_id(self):
+        self.info.clear()
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        toolchain = CMakeToolchain(self)
+        toolchain.variables["GIVP_BUILD_TESTS"] = False
+        toolchain.variables["GIVP_BUILD_BENCHMARKS"] = False
+        toolchain.variables["GIVP_BUILD_FUZZ"] = False
+        toolchain.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+        copy(
+            self,
+            "LICENSE",
+            src=self.source_folder,
+            dst=os.path.join(self.package_folder, "licenses"),
+        )
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "givp")
+        self.cpp_info.set_property("cmake_target_name", "givp::givp")
+        self.cpp_info.set_property("cmake_find_mode", "config")
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/givp/all/conanfile.py
+++ b/recipes/givp/all/conanfile.py
@@ -1,3 +1,11 @@
+# SPDX-FileCopyrightText: 2026 Arnaldo Mendes Pires Junior
+# SPDX-License-Identifier: MIT
+# mypy: disable-error-code=attr-defined
+# pyright: reportAttributeAccessIssue=false, reportOptionalMemberAccess=false, reportOptionalSubscript=false, reportCallIssue=false, reportArgumentType=false
+# pylint: disable=no-member,unsubscriptable-object,invalid-name
+
+"""ConanCenter recipe for the GIVP header-only C++ library."""
+
 import os
 
 from conan import ConanFile
@@ -5,10 +13,12 @@ from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get
 
-required_conan_version = ">=2.0"
+required_conan_version = ">=2.0"  # pylint: disable=invalid-name
 
 
 class GivpConan(ConanFile):
+    """Package the released GIVP C++ library for ConanCenter."""
+
     name = "givp"
     license = "MIT"
     homepage = "https://github.com/Arnime/givp"
@@ -23,31 +33,40 @@ class GivpConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 
-    def layout(self):
+    def layout(self) -> None:
+        """Use the upstream CMake project stored in the cpp subdirectory."""
         cmake_layout(self, src_folder="cpp")
 
-    def validate(self):
-        if self.settings.compiler.cppstd:
+    def validate(self) -> None:
+        """Reject consumers that do not enable the upstream C++17 requirement."""
+        if self.settings.compiler.cppstd:  # type: ignore[attr-defined]  # pylint: disable=no-member
             check_min_cppstd(self, 17)
 
-    def package_id(self):
+    def package_id(self) -> None:
+        """Make the header-only package independent of consumer settings."""
         self.info.clear()
 
-    def source(self):
-        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+    def source(self) -> None:
+        """Download and verify the immutable upstream release source archive."""
+        get(  # pylint: disable=unsubscriptable-object
+            self, **self.conan_data["sources"][self.version], strip_root=True
+        )
 
-    def generate(self):
+    def generate(self) -> None:
+        """Generate the CMake toolchain with optional upstream targets disabled."""
         toolchain = CMakeToolchain(self)
         toolchain.variables["GIVP_BUILD_TESTS"] = False
         toolchain.variables["GIVP_BUILD_BENCHMARKS"] = False
         toolchain.variables["GIVP_BUILD_FUZZ"] = False
         toolchain.generate()
 
-    def build(self):
+    def build(self) -> None:
+        """Configure the released CMake project for installation."""
         cmake = CMake(self)
         cmake.configure()
 
-    def package(self):
+    def package(self) -> None:
+        """Install the CMake package and preserve the upstream license."""
         cmake = CMake(self)
         cmake.install()
         copy(
@@ -57,7 +76,8 @@ class GivpConan(ConanFile):
             dst=os.path.join(self.package_folder, "licenses"),
         )
 
-    def package_info(self):
+    def package_info(self) -> None:
+        """Expose the same CMake target shipped by the upstream project."""
         self.cpp_info.set_property("cmake_file_name", "givp")
         self.cpp_info.set_property("cmake_target_name", "givp::givp")
         self.cpp_info.set_property("cmake_find_mode", "config")

--- a/recipes/givp/all/test_package/CMakeLists.txt
+++ b/recipes/givp/all/test_package/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Arnaldo Mendes Pires Junior
+# SPDX-License-Identifier: MIT
+
 cmake_minimum_required(VERSION 3.21)
 project(givp_conan_test LANGUAGES CXX)
 

--- a/recipes/givp/all/test_package/CMakeLists.txt
+++ b/recipes/givp/all/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.21)
+project(givp_conan_test LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(givp CONFIG REQUIRED)
+
+add_executable(example example.cpp)
+target_link_libraries(example PRIVATE givp::givp)

--- a/recipes/givp/all/test_package/conanfile.py
+++ b/recipes/givp/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+
+class GivpTestConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            self.run(os.path.join(self.cpp.build.bindir, "example"), env="conanrun")

--- a/recipes/givp/all/test_package/conanfile.py
+++ b/recipes/givp/all/test_package/conanfile.py
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2026 Arnaldo Mendes Pires Junior
+# SPDX-License-Identifier: MIT
+# pyright: reportOptionalCall=false, reportOptionalMemberAccess=false
+
+"""Consumer test for the ConanCenter GIVP recipe."""
+
 import os
 
 from conan import ConanFile
@@ -6,20 +12,26 @@ from conan.tools.cmake import CMake, cmake_layout
 
 
 class GivpTestConan(ConanFile):
+    """Build and run a consumer linked to the tested GIVP package."""
+
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeDeps", "CMakeToolchain"
 
-    def layout(self):
+    def layout(self) -> None:
+        """Use Conan's standard CMake layout for the test consumer."""
         cmake_layout(self)
 
-    def requirements(self):
+    def requirements(self) -> None:
+        """Require the package instance produced by conan create."""
         self.requires(self.tested_reference_str)
 
-    def build(self):
+    def build(self) -> None:
+        """Configure and compile the CMake consumer."""
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
 
-    def test(self):
+    def test(self) -> None:
+        """Run the consumer when the build and host platforms match."""
         if can_run(self):
             self.run(os.path.join(self.cpp.build.bindir, "example"), env="conanrun")

--- a/recipes/givp/all/test_package/example.cpp
+++ b/recipes/givp/all/test_package/example.cpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Arnaldo Mendes Pires Junior
+// SPDX-License-Identifier: MIT
+
 #include <utility>
 #include <vector>
 

--- a/recipes/givp/all/test_package/example.cpp
+++ b/recipes/givp/all/test_package/example.cpp
@@ -1,0 +1,22 @@
+#include <utility>
+#include <vector>
+
+#include <givp/givp.hpp>
+
+int main() {
+    const auto sphere = [](const std::vector<double>& values) {
+        double sum = 0.0;
+        for (const double value : values) {
+            sum += value * value;
+        }
+        return sum;
+    };
+
+    const std::vector<std::pair<double, double>> bounds(3, {-5.0, 5.0});
+    givp::GivpConfig config;
+    config.max_iterations = 10;
+    config.seed = 42;
+
+    const auto result = givp::givp(sphere, bounds, config);
+    return result.success ? 0 : 1;
+}

--- a/recipes/givp/config.yml
+++ b/recipes/givp/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.0.1":
+    folder: all

--- a/recipes/givp/config.yml
+++ b/recipes/givp/config.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Arnaldo Mendes Pires Junior
+# SPDX-License-Identifier: MIT
+
 versions:
   "1.0.1":
     folder: all


### PR DESCRIPTION
Adds ConanCenter recipe for GIVP 1.0.1.

- Upstream: https://github.com/Arnime/givp
- Release: https://github.com/Arnime/givp/releases/tag/v1.0.1
- License: MIT
- C++ standard: 17
- Header-only CMake package target: `givp::givp`
- Source archive is pinned with SHA256 in `conandata.yml`.

Local validation:
```text
conan create recipes/givp/all --version 1.0.1 --build=missing -s compiler.cppstd=17
