### PR TITLE
sdl/3.x: add missing libdecor system dependency

### DIFF
--- a/recipes/sdl/3.x/conanfile.py
+++ b/recipes/sdl/3.x/conanfile.py
@@ -373,6 +373,9 @@ class SDLConan(ConanFile):
 
         if self.options.get_safe("wayland"):
             self.cpp_info.components["sdl3"].requires.extend(["wayland::wayland", "xkbcommon::xkbcommon", "egl::egl"])
+            if not self.dependencies["wayland"].options.shared:
+                self.cpp_info.components["sdl3"].system_libs.extend(["decor-0"])
+
 
         if self.options.get_safe("x11"):
             self.cpp_info.components["sdl3"].requires.extend(["xorg::x11", "xorg::xext"])


### PR DESCRIPTION
### Summary
Adds a missing system dependency.

#### Motivation
Fixes ##30793.

#### Details
Adds a system_lib dependency for libdecor-0 when using static wayland.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
