### PR TITLE
abscom: add recipe 0.2.6

### DIFF
--- a/recipes/abscom/all/conandata.yml
+++ b/recipes/abscom/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.2.6":
+    url: "https://github.com/rkriad585/Abscom/archive/refs/tags/v0.2.6.tar.gz"
+    sha256: "5158cb30415b29f6558c487f28a040597e39de29b27fe6942107e1bc05ed172b"

--- a/recipes/abscom/all/conanfile.py
+++ b/recipes/abscom/all/conanfile.py
@@ -1,0 +1,76 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, rmdir
+import os
+
+required_conan_version = ">=2.1"
+
+
+class AbscomConan(ConanFile):
+    name = "abscom"
+    description = "A C11 library of reusable data structures and a Python-inspired dynamic runtime"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/rkriad585/Abscom"
+    topics = ("data-structures", "runtime", "c11", "python")
+    settings = "os", "arch", "compiler", "build_type"
+    package_type = "library"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["ABSCOM_BUILD_STATIC"] = not self.options.shared
+        tc.variables["ABSCOM_BUILD_SHARED"] = self.options.shared
+        tc.variables["ABSCOM_BUILD_TESTS"] = False
+        tc.variables["ABSCOM_BUILD_EXAMPLES"] = False
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(
+            self,
+            "LICENSE",
+            src=self.source_folder,
+            dst=os.path.join(self.package_folder, "licenses"),
+        )
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "abscom")
+        self.cpp_info.set_property("cmake_target_name", "abscom::abscom")
+        self.cpp_info.set_property("pkg_config_name", "abscom")
+        self.cpp_info.libs = ["abscom"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs = ["m", "dl", "pthread"]
+        elif self.settings.os == "Windows":
+            self.cpp_info.system_libs = ["ws2_32"]

--- a/recipes/abscom/all/test_package/CMakeLists.txt
+++ b/recipes/abscom/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.16)
+project(test_package LANGUAGES C)
+
+find_package(abscom CONFIG REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE abscom::abscom)

--- a/recipes/abscom/all/test_package/conanfile.py
+++ b/recipes/abscom/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/abscom/all/test_package/test_package.c
+++ b/recipes/abscom/all/test_package/test_package.c
@@ -1,0 +1,15 @@
+#include <abscom/abs.h>
+#include <stdio.h>
+
+int main(void) {
+    abs_init();
+    var l = abs_new_list();
+    append(l, abs_new_int(40));
+    append(l, abs_new_int(2));
+    var s = add(get(l, 0), get(l, 1));
+    printf("sum=%.0f\n", abs_num_val(s));
+    del(s);
+    del(l);
+    abs_cleanup();
+    return 0;
+}

--- a/recipes/abscom/config.yml
+++ b/recipes/abscom/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.2.6":
+    folder: all


### PR DESCRIPTION
Add the \bscom\ recipe v0.2.6.

**About:** A C11 library of reusable data structures and a Python-inspired dynamic runtime (dynamic arrays, strings, hashmaps, matrices, ML, data frames, WebSockets, crypto, and more).

**Verification:** \conan create\ passes with static and shared options on Windows (clang/mingw); test package compiles and runs.