### PR TITLE
libcurl: fix checking runtime libs during configure

### DIFF
--- a/recipes/libcurl/all/conandata.yml
+++ b/recipes/libcurl/all/conandata.yml
@@ -4,3 +4,6 @@ sources:
       - "https://curl.se/download/curl-8.21.0.tar.xz"
       - "https://github.com/curl/curl/releases/download/curl-8_21_0/curl-8.21.0.tar.xz"
     sha256: "aa1b66a70eace83dc624508745646c08ae561de512ab403adffb93ac87fc72e6"
+patches:
+  "8.21.0":
+    - patch_file: "patches/0002-fix-openssl-ldflags-multiple-l.patch"

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -3,9 +3,9 @@ from conan.errors import ConanInvalidConfiguration
 from conan.tools.apple import is_apple_os, fix_apple_shared_install_name
 from conan.tools.build import cross_building
 from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
-from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
+from conan.tools.env import VirtualBuildEnv
 from conan.tools.files import copy, download, get, load, replace_in_file, rm, rmdir, save
-from conan.tools.gnu import Autotools, AutotoolsToolchain, AutotoolsDeps, PkgConfigDeps
+from conan.tools.gnu import Autotools, AutotoolsToolchain, PkgConfigDeps
 from conan.tools.layout import basic_layout
 from conan.tools.microsoft import is_msvc, unix_path
 
@@ -283,6 +283,19 @@ class LibcurlConan(ConanFile):
         subdirs_to_build = "lib src" if self.options.build_executable else "lib"
         replace_in_file(self, top_makefile, "SUBDIRS = lib docs src scripts", f"SUBDIRS = {subdirs_to_build}")
 
+        # curl's configure constructs CURL_LIBRARY_PATH with paths to dependencies
+        # This is then used as LD_LIBRARY_PATH for test executables to test
+        # for runtime library availability.
+        # pkg-config can report multiple -L flags in SSL_LDFLAGS (e.g. when
+        # openssl.pc also requires zlib). curl only strips the first "-L",
+        # leaving the rest stuck to LIB_OPENSSL as a single malformed path.
+        # Without this patch, we either get "./conftest: error while loading shared libraries: ... "
+        # or  "checking runtime libs availability... failed" during configure.
+        replace_in_file(self,
+                            os.path.join(self.source_folder, "m4", "curl-openssl.m4"),
+                            "LIB_OPENSSL=`echo $SSL_LDFLAGS | sed -e 's/^-L//'`",
+                            "LIB_OPENSSL=`echo $SSL_LDFLAGS | sed -e 's/^-L//' -e 's/ -L/:/g'`")
+
         if self._is_mingw and self.options.shared:
             # patch for shared mingw build
             lib_makefile = os.path.join(self.source_folder, "lib", "Makefile.am")
@@ -465,8 +478,6 @@ class LibcurlConan(ConanFile):
 
         tc.generate(env)
         tc = PkgConfigDeps(self)
-        tc.generate()
-        tc = AutotoolsDeps(self)
         tc.generate()
 
     def _get_linux_arm_host(self):

--- a/recipes/libcurl/all/conanfile.py
+++ b/recipes/libcurl/all/conanfile.py
@@ -4,7 +4,7 @@ from conan.tools.apple import is_apple_os, fix_apple_shared_install_name
 from conan.tools.build import cross_building
 from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
 from conan.tools.env import VirtualBuildEnv
-from conan.tools.files import copy, download, get, load, replace_in_file, rm, rmdir, save
+from conan.tools.files import apply_conandata_patches, copy, download, export_conandata_patches, get, load, replace_in_file, rm, rmdir, save
 from conan.tools.gnu import Autotools, AutotoolsToolchain, PkgConfigDeps
 from conan.tools.layout import basic_layout
 from conan.tools.microsoft import is_msvc, unix_path
@@ -138,6 +138,7 @@ class LibcurlConan(ConanFile):
 
     def export_sources(self):
         copy(self, "lib_Makefile_add.am", self.recipe_folder, self.export_sources_folder)
+        export_conandata_patches(self)
 
     def config_options(self):
         if self.settings.os == "Windows":
@@ -218,6 +219,7 @@ class LibcurlConan(ConanFile):
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        apply_conandata_patches(self)
         cert_url = self.conf.get("user.libcurl.cert:url", check_type=str) or "https://curl.se/ca/cacert-2025-11-04.pem"
         cert_sha256 = self.conf.get("user.libcurl.cert:sha256", check_type=str) or "8ac40bdd3d3e151a6b4078d2b2029796e8f843e3f86fbf2adbc4dd9f05e79def"
         download(self, cert_url, "cacert.pem", verify=True, sha256=cert_sha256)
@@ -282,19 +284,6 @@ class LibcurlConan(ConanFile):
 
         subdirs_to_build = "lib src" if self.options.build_executable else "lib"
         replace_in_file(self, top_makefile, "SUBDIRS = lib docs src scripts", f"SUBDIRS = {subdirs_to_build}")
-
-        # curl's configure constructs CURL_LIBRARY_PATH with paths to dependencies
-        # This is then used as LD_LIBRARY_PATH for test executables to test
-        # for runtime library availability.
-        # pkg-config can report multiple -L flags in SSL_LDFLAGS (e.g. when
-        # openssl.pc also requires zlib). curl only strips the first "-L",
-        # leaving the rest stuck to LIB_OPENSSL as a single malformed path.
-        # Without this patch, we either get "./conftest: error while loading shared libraries: ... "
-        # or  "checking runtime libs availability... failed" during configure.
-        replace_in_file(self,
-                            os.path.join(self.source_folder, "m4", "curl-openssl.m4"),
-                            "LIB_OPENSSL=`echo $SSL_LDFLAGS | sed -e 's/^-L//'`",
-                            "LIB_OPENSSL=`echo $SSL_LDFLAGS | sed -e 's/^-L//' -e 's/ -L/:/g'`")
 
         if self._is_mingw and self.options.shared:
             # patch for shared mingw build
@@ -457,6 +446,13 @@ class LibcurlConan(ConanFile):
                     tc.extra_ldflags.extend(["-Wl,-framework,CoreFoundation", "-Wl,-framework,Security"])
             elif self.settings.os == "Android":
                 pass # this just works, conan is great!
+
+        if self.settings.os == "Macos":
+            # Configure rpath for ./configure script runtime checks when not crossbuilding.
+            for dep in self.dependencies.host.values():
+                if dep.package_type == "shared-library":
+                    tc.extra_ldflags.extend(f"-Wl,-rpath,{libdir}" for libdir in
+                                             dep.cpp_info.aggregated_components().libdirs)
 
         env = tc.environment()
 

--- a/recipes/libcurl/all/patches/0002-fix-openssl-ldflags-multiple-l.patch
+++ b/recipes/libcurl/all/patches/0002-fix-openssl-ldflags-multiple-l.patch
@@ -1,0 +1,16 @@
+When pkg-config returns multiple `-L` entries to link against OpenSSL, 
+the `curl-openssl.m4` macro only takes the first one and ignores the rest.
+This patch fixes that by replacing all `-L` entries with a colon-separated list of directories.
+
+--- a/m4/curl-openssl.m4
++++ b/m4/curl-openssl.m4
+@@ -126,7 +126,7 @@
+       AC_MSG_NOTICE([pkg-config: SSL_LIBS: "$SSL_LIBS"])
+       AC_MSG_NOTICE([pkg-config: SSL_LDFLAGS: "$SSL_LDFLAGS"])
+       AC_MSG_NOTICE([pkg-config: SSL_CPPFLAGS: "$SSL_CPPFLAGS"])
+
+-      LIB_OPENSSL=`echo $SSL_LDFLAGS | sed -e 's/^-L//'`
++      LIB_OPENSSL=`echo $SSL_LDFLAGS | sed -e 's/^-L//' -e 's/ -L/:/g'`
+
+       dnl use the values pkg-config reported.  This is here
+       dnl instead of below with CPPFLAGS and LDFLAGS because we only


### PR DESCRIPTION
### Summary

Fix bug as reported in https://github.com/conan-io/conan-center-index/issues/23933#issuecomment-5285264570
with details at https://github.com/conan-io/conan-center-index/issues/23933#issuecomment-5308693156

#### Motivation
* when not crossbuilding and using autotools, the configure script will build _and_ run some test executables.
* when dependencies are shred, those tests may fail on some systems
* earlier revisions of the recipe were exposing the virtualrunenv at build time so that `LD_LIBRARY_PATH` is set - this is *not* necessary (and causes other issues), since libcurl's configure script already keeps track of those directories in `CURL_LIBRARY_PATH`, which is then used to initialise `LD_LIBRARY_PATH` during those try-run tests (https://github.com/curl/curl/blob/8eb978b9c212068371c39b37be1522904a790811/m4/curl-functions.m4#L3959-L3981)
* On some systems those were still failing when the compiler did not pass `--as-needed` to the linker (in those cases, the tests are largely redundant because the resulting executables did not encode a runtime dependency anyway)


#### Details
Fix two things:
- Remove AutotoolsDeps, which causes unnecessary overlinking. libcurl uses pkgconfig so work out the flags - `AutotoolsDeps` should very sparingly be used
- Patch a file in the libcurl autotools macros that was causing `CURL_LIBRARY_PATH` to be malformed and not work. The scripts are assuming that pkgconfig link flags for OpenSSL only return a single `-L` directory, when it can be multiple (e.g., if zlib is a dependency and lives in a different prefix). This is an upstream bug that is only surfacing here because Conan places different libraries in isolated directories.



---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
