### PR TITLE
libavrocpp: use archive.apache.org for 1.12.1 sources

### DIFF
--- a/recipes/libavrocpp/all/conandata.yml
+++ b/recipes/libavrocpp/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
   "1.12.1":
-    url: "https://dlcdn.apache.org/avro/avro-1.12.1/avro-src-1.12.1.tar.gz"
+    url: "https://archive.apache.org/dist/avro/avro-1.12.1/avro-src-1.12.1.tar.gz"
     sha256: "268e47c0850df04f952ea6fdfc3b12a8d0042124354bff6c0239be0b70016d2e"

--- a/recipes/libavrocpp/all/conanfile.py
+++ b/recipes/libavrocpp/all/conanfile.py
@@ -60,6 +60,8 @@ class LibavrocppConan(ConanFile):
         tc.cache_variables["AVRO_BUILD_TESTS"] = False
         tc.cache_variables["AVRO_USE_BOOST"] = self.options.with_boost
         tc.cache_variables["CMAKE_DISABLE_FIND_PACKAGE_zstd"] = True # please open an issue if this is needed
+        # fmt 12.2.0 stopped pulling fmt/format.h from fmt/core.h. Remove this once upstream fixes it.
+        tc.preprocessor_definitions["FMT_DEPRECATED_HEAVY_CORE"] = None
         tc.generate()
 
         deps = CMakeDeps(self)
@@ -88,6 +90,8 @@ class LibavrocppConan(ConanFile):
         self.cpp_info.set_property("cmake_target_name", "avro-cpp::avrocpp" if self.options.shared else "avro-cpp::avrocpp_s")
         if self.options.shared:
             self.cpp_info.defines.append("AVRO_DYN_LINK")
+        # Exception.hh is a public header, so consumers need this too. Remove this once upstream fixes it.
+        self.cpp_info.defines.append("FMT_DEPRECATED_HEAVY_CORE")
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs.append("m")
 


### PR DESCRIPTION
### Summary
Changes to recipe: **libavrocpp/1.12.1**

#### Motivation
`libavrocpp/1.12.1` can no longer be installed at all: its source archive 404s.

`dlcdn.apache.org` is Apache's CDN for *current* releases only — once a version is
superseded, the tarball is removed. 1.12.1 has been superseded by 1.12.2, so the
URL in `conandata.yml` is now dead:

```
$ curl -sI https://dlcdn.apache.org/avro/avro-1.12.1/avro-src-1.12.1.tar.gz
HTTP/2 404

$ curl -sI https://archive.apache.org/dist/avro/avro-1.12.1/avro-src-1.12.1.tar.gz
HTTP/1.1 200 OK
Content-Length: 4099115
```
fixes #30783
Fix bug as reported in https://github.com/conan-io/conan-center-index/issues/30783#issue-5140425885

#### Details
Repointed the 1.12.1 source URL from `dlcdn.apache.org` to `archive.apache.org`,
which permanently retains all past Apache releases. **The artifact is byte-identical
— `sha256` is unchanged**, which the build verifies.

`archive.apache.org` is already the established convention for Apache sources.

**Not a duplicate of #30781, but related.** That PR replaces 1.12.1 with 1.12.2.
Worth flagging for reviewers: bumping the version does *not* by itself fix the
build, because `lang/c++/include/avro/Exception.hh` is identical in
`release-1.12.1` and `release-1.12.2` — both call `fmt::format` while including
only `<fmt/core.h>`. Since fmt 12.2.0, `fmt/core.h` no longer declares
`fmt::format`, so both versions fail to compile against it. (Upstream `main` has
since dropped fmt for `std::format`, so there is no 1.12.x release with a fix.)

**Known CI failure, disclosed up front.** `fmt/[>=12 <13]` resolves to
`fmt/12.2.0`, and the compile then fails in `Exception.hh` regardless of where the
sources are downloaded from — i.e. this is pre-existing and orthogonal to the URL
change. Measured locally with Conan 2.27.0, macOS armv8, apple-clang 21, varying
*only* the fmt version:

| fmt resolved | Result |
|---|---|
| 12.1.0 | passes (builds + `test_package` runs) |
| 12.2.0 | fails: 16× `no member named 'format' in namespace 'fmt'` at `Exception.hh:37` |

Two options to make CI green, happy to do either here or in a follow-up —
whichever the team prefers:

1. A one-line source fix, `#include <fmt/core.h>` → `#include <fmt/format.h>`
   (verified: all four configurations below pass against fmt 12.2.0 with it).
   Precedent for this shape exists, e.g. `rmm` adds a missing `<array>` include
   via `replace_in_file`.
2. Cap the requirement to `fmt/[>=12 <12.2]` — no source patching, but it blocks
   consumers who need fmt 12.2.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan
---
