### PR TITLE
simd-f128/1.6.2

### DIFF
--- a/recipes/simd-f128/all/conandata.yml
+++ b/recipes/simd-f128/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "1.6.0":
+  "1.6.2":
     url: "https://github.com/tiw302/simd-f128/archive/refs/tags/v1.6.0.tar.gz"
-    sha256: "69b936b9629072e22b327421dbe3c05013c79d4a00c7d5a2fa4666a7e7ee4306"
+    sha256: "96f3640d1a5d51e90fef860467ddbf2b84fae2966024cbb1c188f13e04402bbc"

--- a/recipes/simd-f128/all/conandata.yml
+++ b/recipes/simd-f128/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.6.0":
+    url: "https://github.com/tiw302/simd-f128/archive/refs/tags/v1.6.0.tar.gz"
+    sha256: "69b936b9629072e22b327421dbe3c05013c79d4a00c7d5a2fa4666a7e7ee4306"

--- a/recipes/simd-f128/all/conanfile.py
+++ b/recipes/simd-f128/all/conanfile.py
@@ -1,0 +1,36 @@
+from conan import ConanFile
+from conan.tools.files import get, copy
+from conan.tools.layout import basic_layout
+import os
+
+required_conan_version = ">=1.52.0"
+
+class SimdF128Conan(ConanFile):
+    name = "simd-f128"
+    description = "128-bit Double-Double SIMD floating-point math library"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://tiw302.github.io/simd-f128/"
+    topics = ("math", "simd", "double-double", "header-only")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def package(self):
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        copy(self, pattern="*.h", dst=os.path.join(self.package_folder, "include"), src=os.path.join(self.source_folder, "include"))
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.set_property("cmake_file_name", "simd_f128")
+        self.cpp_info.set_property("cmake_target_name", "simd_f128::simd_f128")

--- a/recipes/simd-f128/config.yml
+++ b/recipes/simd-f128/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.6.0":
+    folder: all

--- a/recipes/simd-f128/config.yml
+++ b/recipes/simd-f128/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.6.0":
+  "1.6.2":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe: **simd-f128/1.6.2**

#### Motivation
Add new recipe for `simd-f128`, a high-performance 128-bit Double-Double SIMD floating-point math library.

#### Details
This is a new header-only library. The recipe uses `copy` to package the headers and sets the correct CMake target `simd_f128::simd_f128` for consumers.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
