### PR TITLE
units/3.x.x: add 3.6.0

### DIFF
--- a/recipes/units/3.x.x/conandata.yml
+++ b/recipes/units/3.x.x/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "3.6.0":
+    url: "https://github.com/nholthaus/units/archive/v3.6.0.tar.gz"
+    sha256: "8d3e4113d22502b771821d77674983289121e493532ba501cd93a8dc47902f0c"

--- a/recipes/units/3.x.x/conanfile.py
+++ b/recipes/units/3.x.x/conanfile.py
@@ -1,0 +1,72 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
+import os
+
+required_conan_version = ">=1.52.0"
+
+
+class UnitsConan(ConanFile):
+    name = "units"
+    description = (
+        "A compile-time, header-only, dimensional analysis and unit conversion "
+        "library for C++23 with no dependencies"
+    )
+    license = "MIT"
+    topics = ("unit-conversion", "dimensional-analysis", "cpp23",
+              "template-metaprogramming", "compile-time", "header-only",
+              "no-dependencies")
+    homepage = "https://github.com/nholthaus/units"
+    url = "https://github.com/conan-io/conan-center-index"
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    @property
+    def _min_cppstd(self):
+        return "23"
+
+    @property
+    def _minimum_compilers_version(self):
+        return {
+            "clang": "17",
+            "gcc": "13",
+            "apple-clang": "15",
+            "msvc": "193",
+        }
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._minimum_compilers_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support.",
+            )
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def build(self):
+        pass
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        # units is a multi-header tree (units.h plus include/units/*.h); copy all of include/.
+        copy(self, "*.h", src=os.path.join(self.source_folder, "include"),
+             dst=os.path.join(self.package_folder, "include"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "units")
+        self.cpp_info.set_property("cmake_target_name", "units::units")
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/units/3.x.x/test_package/CMakeLists.txt
+++ b/recipes/units/3.x.x/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(units REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE units::units)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_23)

--- a/recipes/units/3.x.x/test_package/conanfile.py
+++ b/recipes/units/3.x.x/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/units/3.x.x/test_package/test_package.cpp
+++ b/recipes/units/3.x.x/test_package/test_package.cpp
@@ -1,0 +1,14 @@
+#include <iostream>
+
+#include <units.h>
+
+using namespace units::literals;
+using namespace units::length;
+
+int main()
+{
+    meters<double> a = 3.0_m;
+    meters<double> b = 4.0_m;
+    meters<double> c = units::sqrt(units::pow<2>(a) + units::pow<2>(b)); // Pythagorean theorem.
+    std::cout << c << std::endl;                                         // prints: "5 m"
+}

--- a/recipes/units/config.yml
+++ b/recipes/units/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.6.0":
+    folder: 3.x.x
   "2.3.3":
     folder: all
   "2.3.1":


### PR DESCRIPTION
Adds `units/3.6.0`.

`units` requires C++23 since 3.5.0 and is now a multi-header library, so the 3.x line gets its own recipe folder (`recipes/units/3.x.x`), mirroring the `qt` 5.x.x/6.x.x and `openssl` 1.x.x/3.x.x split. The existing `recipes/units/all` recipe and the 2.3.x versions are left untouched.

The `3.x.x` recipe:
- declares C++23 (`_min_cppstd = 23`) and the minimum compilers (gcc 13, clang 17, apple-clang 15, msvc 193),
- copies the whole `include/` tree (the earlier recipe copied only `units.h`, which is incomplete for 3.x),
- ships a `test_package` on the current API (`meters<double>`, `units::sqrt`).

Specify library name and version: **units/3.6.0**

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan-center-index/blob/master/docs/preparing_recipes_for_release.md) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/docs/supported_platforms_and_configurations.md).
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/conan-center-index/blob/master/docs/error_knowledge_base.md) activated.