### PR TITLE
mgclient: publish version 1.8.0

### DIFF
--- a/recipes/mgclient/all/conandata.yml
+++ b/recipes/mgclient/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.8.0":
+    url: "https://github.com/memgraph/mgclient/archive/refs/tags/v1.8.0.tar.gz"
+    sha256: "b5a892fd4db905acf8fb709b696e0606ea790986714f8ac0e8eda66fa973666c"
   "1.5.0":
     url: "https://github.com/memgraph/mgclient/archive/refs/tags/v1.5.0.tar.gz"
     sha256: "7934ee5fb2a5a9ddf861b9255cb092594e30b6b1fe88b55a4966d736933b5ef1"
@@ -9,6 +12,10 @@ sources:
     url: "https://github.com/memgraph/mgclient/archive/refs/tags/v1.4.2.tar.gz"
     sha256: "aa89422636b1e25b8f9f34453f331e15d32a5957a9b2381c3598fc3644dbc043"
 patches:
+  "1.8.0":
+    - patch_file: "patches/1.8.0-0001-static-shared.build.patch"
+      patch_description: "Build and install only the library type selected by the shared option"
+      patch_type: "conan"
   "1.5.0":
     - patch_file: "patches/1.5.0-0001-static-shared.build.patch"
       patch_description: "make static and shared build separated"

--- a/recipes/mgclient/all/patches/1.8.0-0001-static-shared.build.patch
+++ b/recipes/mgclient/all/patches/1.8.0-0001-static-shared.build.patch
@@ -1,0 +1,48 @@
+Upstream unconditionally defines and installs both a static and a shared
+mgclient target. A Conan package provides exactly one of the two, chosen by
+the shared option, so gate each target and its install rule on
+BUILD_SHARED_LIBS.
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index f29626d..94da660 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -51,6 +51,7 @@ else()
+     find_package(OpenSSL REQUIRED)
+     include(GenerateExportHeader)
+ 
++    if(NOT BUILD_SHARED_LIBS)
+     add_library(mgclient-static STATIC ${mgclient_src_files})
+ 
+     generate_export_header(mgclient-static
+@@ -75,6 +76,7 @@ else()
+         target_link_libraries(mgclient-static PUBLIC ws2_32 crypt32 gdi32)
+     endif()
+ 
++    else()
+     add_library(mgclient-shared SHARED ${mgclient_src_files})
+ 
+     generate_export_header(mgclient-shared
+@@ -103,13 +105,21 @@ else()
+     generate_export_header(mgclient-shared
+             BASE_NAME "mgclient"
+             EXPORT_FILE_NAME "mgclient-export.h")
++    endif()
+ 
+     include(GNUInstallDirs)
+ 
+-    install(TARGETS mgclient-static mgclient-shared
++    if(NOT BUILD_SHARED_LIBS)
++    install(TARGETS mgclient-static
+             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+             RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR})
++    else()
++    install(TARGETS mgclient-shared
++            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
++    endif()
+     install(DIRECTORY
+             "${PROJECT_SOURCE_DIR}/include/"
+             DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/recipes/mgclient/config.yml
+++ b/recipes/mgclient/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.8.0":
+    folder: all
   "1.5.0":
     folder: all
   "1.4.3":


### PR DESCRIPTION
### Summary
Changes to recipe:  **mgclient/1.8.0**

#### Motivation
Add the latest upstream release. The recipe currently tops out at 1.5.0.

#### Details
The recipe itself is unchanged. Upstream's CMake still defines and installs both
a static and a shared target unconditionally, so 1.8.0 needs the same split
patch the existing versions carry.

Note this is not a pure `config.yml`/`conandata.yml` bump: the 1.5.0 patch does
not apply as-is because 1.8.0 adds `mgrouting.c` to the source list, shifting
`src/CMakeLists.txt` by one line. `patch` tolerates the offset but Conan's
applier does not, so 1.8.0 gets its own copy of the same change.

Tested locally with Conan 2.27.0 on Linux/gcc 13: default (static, with_cpp),
`shared=True`, and `with_cpp=False` all build and pass test_package.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan
