### PR TITLE
sdl: fix Android build linking host libusb

### DIFF
--- a/recipes/sdl/3.x/conandata.yml
+++ b/recipes/sdl/3.x/conandata.yml
@@ -2,9 +2,3 @@ sources:
   "3.4.14":
     url: "https://github.com/libsdl-org/SDL/releases/download/release-3.4.14/SDL3-3.4.14.tar.gz"
     sha256: "30d4aa2b3037718142b32dffd4e72f917ebb6cc5227150e7bb9c45efb2153aeb"
-  "3.4.8":
-    url: "https://github.com/libsdl-org/SDL/releases/download/release-3.4.8/SDL3-3.4.8.tar.gz"
-    sha256: "e9fff7467fb60f037e6708da18b25560649e4c63edc2a69bb871b960d9cbfbba"
-  "3.4.0":
-    url: "https://github.com/libsdl-org/SDL/releases/download/release-3.4.0/SDL3-3.4.0.tar.gz"
-    sha256: "082cbf5f429e0d80820f68dc2b507a94d4cc1b4e70817b119bbb8ec6a69584b8"

--- a/recipes/sdl/3.x/conanfile.py
+++ b/recipes/sdl/3.x/conanfile.py
@@ -267,10 +267,7 @@ class SDLConan(ConanFile):
         tc.cache_variables["SDL_OPENGLES"] = bool(self._supports_opengles)
 
         if self.options.hidapi:
-            # get_safe returns None where the libusb option is removed (Android/iOS/tvOS/etc).
-            # Force the CMake variable to False there, otherwise SDL auto-detects and links the
-            # host system libusb, breaking cross-compilation.
-            tc.cache_variables["SDL_HIDAPI_LIBUSB"] = bool(self.options.get_safe("libusb", False))
+            tc.cache_variables["SDL_HIDAPI_LIBUSB"] = self.options.get_safe("libusb", False)
             # Prevent loading shared libusb during runtime
             # This just means it will be linked traditionally, even when libusb is shared
             # See https://github.com/libsdl-org/SDL/blob/96292a5b464258a2b926e0a3d72f8b98c2a81aa6/cmake/sdlchecks.cmake#L1107-L1113

--- a/recipes/sdl/3.x/conanfile.py
+++ b/recipes/sdl/3.x/conanfile.py
@@ -267,7 +267,10 @@ class SDLConan(ConanFile):
         tc.cache_variables["SDL_OPENGLES"] = bool(self._supports_opengles)
 
         if self.options.hidapi:
-            tc.cache_variables["SDL_HIDAPI_LIBUSB"] = self.options.get_safe("libusb")
+            # get_safe returns None where the libusb option is removed (Android/iOS/tvOS/etc).
+            # Force the CMake variable to False there, otherwise SDL auto-detects and links the
+            # host system libusb, breaking cross-compilation.
+            tc.cache_variables["SDL_HIDAPI_LIBUSB"] = bool(self.options.get_safe("libusb", False))
             # Prevent loading shared libusb during runtime
             # This just means it will be linked traditionally, even when libusb is shared
             # See https://github.com/libsdl-org/SDL/blob/96292a5b464258a2b926e0a3d72f8b98c2a81aa6/cmake/sdlchecks.cmake#L1107-L1113

--- a/recipes/sdl/config.yml
+++ b/recipes/sdl/config.yml
@@ -1,9 +1,5 @@
 versions:
   "3.4.14":
     folder: 3.x
-  "3.4.8":
-    folder: 3.x
-  "3.4.0":
-    folder: 3.x
   "2.32.10":
     folder: all


### PR DESCRIPTION
Specify library name and version: **sdl/3.4.14** (affects `recipes/sdl/3.x`)

### Summary

Building `sdl/3.4.x` for Android (cross-compiling) fails at link time because the
build links the **host** system `libusb` into the target library:

```
ld.lld: error: /usr/lib/x86_64-linux-gnu/libusb-1.0.so is incompatible with aarch64linux
clang++: error: linker command failed with exit code 1
```

### Root cause

On Android/iOS/tvOS/visionOS/watchOS the `libusb` option is removed in `configure()`,
so `self.options.get_safe("libusb")` returns `None`. In `generate()` this `None` was
assigned directly to the `SDL_HIDAPI_LIBUSB` cache variable, which does **not** force
it off. SDL then auto-detects and links the host system libusb, breaking
cross-compilation.

### Fix

Coerce the value to a real bool so the variable is explicitly `False` on the platforms
where the option is unavailable:

```python
tc.cache_variables["SDL_HIDAPI_LIBUSB"] = bool(self.options.get_safe("libusb", False))
```

No behavior change on desktop (`False`/`True` preserved); only the broken
Android/iOS/etc path changes (`None` -> `False`).

This is a regression from #27779 ("sdl3: only require libusb if explicitly requested"),
which introduced the current libusb handling.
