### PR TITLE
Adding the version 3.0.1 of tinygltf

### DIFF
--- a/recipes/tinygltf/3.x/CMakeLists.txt
+++ b/recipes/tinygltf/3.x/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.15)
+project(tinygltf LANGUAGES C)
+
+include(GNUInstallDirs)
+
+add_library(tinygltf ${TINYGLTF_SRC_DIR}/tiny_gltf_v3.c)
+target_include_directories(tinygltf PRIVATE ${TINYGLTF_SRC_DIR})
+set_target_properties(tinygltf PROPERTIES
+    C_STANDARD 11
+    C_STANDARD_REQUIRED ON
+    C_EXTENSIONS OFF
+    WINDOWS_EXPORT_ALL_SYMBOLS ON
+)
+if(TINYGLTF_ENABLE_FS)
+    target_compile_definitions(tinygltf PRIVATE TINYGLTF3_ENABLE_FS)
+endif()
+
+install(TARGETS tinygltf
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+install(FILES
+    ${TINYGLTF_SRC_DIR}/tiny_gltf_v3.h
+    ${TINYGLTF_SRC_DIR}/tinygltf_json_c.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)

--- a/recipes/tinygltf/3.x/conandata.yml
+++ b/recipes/tinygltf/3.x/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "3.0.1":
+    url: "https://github.com/syoyo/tinygltf/archive/v3.0.1.tar.gz"
+    sha256: "b7e953f13a30d7b6fd677e484de35febde954143a265da15dacd92ed171c73e6"

--- a/recipes/tinygltf/3.x/conanfile.py
+++ b/recipes/tinygltf/3.x/conanfile.py
@@ -1,0 +1,66 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get
+import os
+
+required_conan_version = ">=2.0"
+
+
+class TinygltfConan(ConanFile):
+    name = "tinygltf"
+    description = "C11 glTF 2.0 loader and writer with arena based memory management."
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/syoyo/tinygltf"
+    topics = ("gltf", "3d", "graphics")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "with_filesystem": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "with_filesystem": True,
+    }
+
+    exports_sources = "CMakeLists.txt"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+        self.settings.rm_safe("compiler.cppstd")
+        self.settings.rm_safe("compiler.libcxx")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["TINYGLTF_SRC_DIR"] = self.source_folder.replace("\\", "/")
+        tc.variables["TINYGLTF_ENABLE_FS"] = self.options.with_filesystem
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure(build_script_folder=os.path.join(self.source_folder, os.pardir))
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "TinyGLTF")
+        self.cpp_info.set_property("cmake_target_name", "TinyGLTF::TinyGLTF")
+        self.cpp_info.libs = ["tinygltf"]

--- a/recipes/tinygltf/3.x/test_package/CMakeLists.txt
+++ b/recipes/tinygltf/3.x/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES C)
+
+find_package(TinyGLTF REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.c)
+target_link_libraries(${PROJECT_NAME} PRIVATE TinyGLTF::TinyGLTF)

--- a/recipes/tinygltf/3.x/test_package/conanfile.py
+++ b/recipes/tinygltf/3.x/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/tinygltf/3.x/test_package/test_package.c
+++ b/recipes/tinygltf/3.x/test_package/test_package.c
@@ -1,0 +1,25 @@
+#include <stdio.h>
+#include <string.h>
+
+#include <tiny_gltf_v3.h>
+
+int main(void) {
+    static const char json[] = "{\"asset\":{\"version\":\"2.0\"}}";
+
+    tg3_parse_options options;
+    tg3_error_stack errors;
+    tg3_model model;
+    tg3_error_code err;
+
+    tg3_parse_options_init(&options);
+    tg3_error_stack_init(&errors);
+
+    err = tg3_parse(&model, &errors, (const uint8_t *)json, strlen(json), NULL, 0, &options);
+    printf("tg3_parse: %d\n", (int)err);
+    if (err == TG3_OK) {
+        tg3_model_free(&model);
+    }
+    tg3_error_stack_free(&errors);
+
+    return 0;
+}

--- a/recipes/tinygltf/all/conandata.yml
+++ b/recipes/tinygltf/all/conandata.yml
@@ -4,7 +4,7 @@ sources:
     sha256: "b7e953f13a30d7b6fd677e484de35febde954143a265da15dacd92ed171c73e6"
   "2.9.7":
     url: "https://github.com/syoyo/tinygltf/archive/v2.9.7.tar.gz"
-    sha256: "9d31cf7f22e81febaf1ad587d7722582c154f7d9125673ee46c0c594765e8f35"
+    sha256: "bf92fe53b86302f9415e77504ecd81a58659292ed04dffec873f5c71665046a0"
   "2.8.23":
     url: "https://github.com/syoyo/tinygltf/archive/v2.8.23.tar.gz"
     sha256: "e6dbbb0952cdefa1d9c87a99b686d1e67755fd9b0a5872b4008d042159e77de5"

--- a/recipes/tinygltf/all/conandata.yml
+++ b/recipes/tinygltf/all/conandata.yml
@@ -5,6 +5,3 @@ sources:
   "2.9.7":
     url: "https://github.com/syoyo/tinygltf/archive/v2.9.7.tar.gz"
     sha256: "bf92fe53b86302f9415e77504ecd81a58659292ed04dffec873f5c71665046a0"
-  "2.8.23":
-    url: "https://github.com/syoyo/tinygltf/archive/v2.8.23.tar.gz"
-    sha256: "e6dbbb0952cdefa1d9c87a99b686d1e67755fd9b0a5872b4008d042159e77de5"

--- a/recipes/tinygltf/all/conandata.yml
+++ b/recipes/tinygltf/all/conandata.yml
@@ -1,7 +1,4 @@
 sources:
-  "3.0.1":
-    url: "https://github.com/syoyo/tinygltf/archive/v3.0.1.tar.gz"
-    sha256: "b7e953f13a30d7b6fd677e484de35febde954143a265da15dacd92ed171c73e6"
   "2.9.7":
     url: "https://github.com/syoyo/tinygltf/archive/v2.9.7.tar.gz"
     sha256: "bf92fe53b86302f9415e77504ecd81a58659292ed04dffec873f5c71665046a0"

--- a/recipes/tinygltf/all/conandata.yml
+++ b/recipes/tinygltf/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.0.1":
+    url: "https://github.com/syoyo/tinygltf/archive/v3.0.1.tar.gz"
+    sha256: "b7e953f13a30d7b6fd677e484de35febde954143a265da15dacd92ed171c73e6"
   "2.9.7":
     url: "https://github.com/syoyo/tinygltf/archive/v2.9.7.tar.gz"
     sha256: "9d31cf7f22e81febaf1ad587d7722582c154f7d9125673ee46c0c594765e8f35"

--- a/recipes/tinygltf/config.yml
+++ b/recipes/tinygltf/config.yml
@@ -1,5 +1,5 @@
 versions:
   "3.0.1":
-    folder: all
+    folder: 3.x
   "2.9.7":
     folder: all

--- a/recipes/tinygltf/config.yml
+++ b/recipes/tinygltf/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.0.1":
+    folder: all
   "2.9.7":
     folder: all
   "2.8.23":

--- a/recipes/tinygltf/config.yml
+++ b/recipes/tinygltf/config.yml
@@ -3,5 +3,3 @@ versions:
     folder: all
   "2.9.7":
     folder: all
-  "2.8.23":
-    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **tinygltf/3.0.1**

#### Motivation
Adding the latest version 3.0.1
Also, the wrong sha256 was used for 2.9.7 updated to the correct one.
<img width="930" height="197" alt="image" src="https://github.com/user-attachments/assets/6635b12e-115e-4b3c-b2cf-ca86848fe79c" />

#### Details
None


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
