### PR TITLE
Add crashcatch/1.6.0 recipe

### DIFF
--- a/recipes/crashcatch/all/conandata.yml
+++ b/recipes/crashcatch/all/conandata.yml
@@ -1,0 +1,7 @@
+sources:
+  "1.6.0":
+    url: "https://github.com/keithpotz/CrashCatch/archive/refs/tags/v1.6.0.tar.gz"
+    sha256: "601802CB2D99E3D302773520A50F97259C3BD5CFF771263A658A12D01BF8D013"
+
+
+    

--- a/recipes/crashcatch/all/conanfile.py
+++ b/recipes/crashcatch/all/conanfile.py
@@ -1,0 +1,44 @@
+from conan import ConanFile
+from conan.tools.files import copy, get
+import os
+
+
+class CrashCatchConan(ConanFile):
+    name = "crashcatch"
+    description = "A cross-platform, single-header C++ crash-reporting library for modern C++ applications."
+    license = "MIT"
+    author = "Keith Pottratz"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/keithpotz/CrashCatch"
+    topics = ("crash-reporting", "crash-handler", "minidump", "header-only", "single-header")
+    package_type = "header-library"
+    no_copy_source = True
+
+    def source(self):
+        get(self,
+            **self.conan_data["sources"][self.version],
+            strip_root=True)
+
+    def package_id(self):
+        # Header-only: binary is the same regardless of compiler/settings
+        self.info.clear()
+
+    def package(self):
+        copy(self, "LICENSE",
+             src=self.source_folder,
+             dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, "*.hpp",
+             src=os.path.join(self.source_folder, "include"),
+             dst=os.path.join(self.package_folder, "include"))
+
+    def package_info(self):
+        # No compiled lib — only headers
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+
+        os_name = self.settings.get_safe("os")
+        if os_name == "Windows":
+            self.cpp_info.system_libs = ["DbgHelp", "User32"]
+        elif os_name == "Linux":
+            # backtrace() and dladdr() live in libdl on some distros
+            self.cpp_info.system_libs = ["dl"]

--- a/recipes/crashcatch/all/test_package/CMakeLists.txt
+++ b/recipes/crashcatch/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(crashcatch REQUIRED CONFIG)
+
+add_executable(test_package test_package.cpp)
+target_link_libraries(test_package PRIVATE crashcatch::crashcatch)
+target_compile_features(test_package PRIVATE cxx_std_17)

--- a/recipes/crashcatch/all/test_package/conanfile.py
+++ b/recipes/crashcatch/all/test_package/conanfile.py
@@ -1,0 +1,27 @@
+import os
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import can_run
+
+
+class CrashCatchTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeToolchain", "CMakeDeps"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/crashcatch/all/test_package/test_package.cpp
+++ b/recipes/crashcatch/all/test_package/test_package.cpp
@@ -1,0 +1,8 @@
+#include "CrashCatch.hpp"
+#include <iostream>
+
+int main() {
+    CrashCatch::enable();
+    std::cout << "CrashCatch enabled successfully.\n";
+    return 0;
+}

--- a/recipes/crashcatch/config.yml
+++ b/recipes/crashcatch/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.6.0":
+    folder: all


### PR DESCRIPTION
### Summary
Adding CrashCatch to the Conan recipe list**

#### Motivation
Brand new addition to Conan for CrashCatch a lightweight, single-header,
cross-platform C++ crash-reporting library (Windows, Linux, macOS) with no
external dependencies. 

#### Details
- Recipe fetches source from a tagged GitHub release (v1.6.0) with a
  verified sha256 checksum in conandata.yml.
- Header-only package (package_type = "header-library"), no build step
  required for consumers.
- Links required system libraries automatically: DbgHelp/User32 on
  Windows, dl on Linux.
- Includes a test_package that links against crashcatch::crashcatch via
  CMake find_package and confirms CrashCatch::enable() compiles, links,
  and runs successfully.
- Tested locally on Windows with MSVC 2022 (Visual Studio 17 2022
  generator) recipe build, packaging, and test_package all pass.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
