### PR TITLE
Support Linux AArch64 build on clang

### DIFF
--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -553,7 +553,7 @@ class QtConan(ConanFile):
             elif self.settings.compiler == "clang":
                 if self.settings.arch == "x86":
                     return "linux-clang-libc++-32" if self.settings.compiler.libcxx == "libc++" else "linux-clang-32"
-                elif self.settings.arch == "x86_64":
+                else:
                     return "linux-clang-libc++" if self.settings.compiler.libcxx == "libc++" else "linux-clang"
 
         elif self.settings.os == "Macos":
@@ -817,7 +817,7 @@ class QtConan(ConanFile):
                 else:
                     args += [f"-xplatform {xplatform_val}"]
             else:
-                self.output.warn("host not supported: %s %s %s %s" %
+                raise ConanInvalidConfiguration("host not supported: %s %s %s %s" %
                                  (self.settings.os, self.settings.compiler,
                                   self.settings.compiler.version, self.settings.arch))
         if self.options.cross_compile:


### PR DESCRIPTION
### Summary
Changes to recipe:  **qt/5.15.19**

#### Motivation

Enable building Qt package for Linux Aarch64 platforms with clang. Closes #30820 

#### Details

* Remove the restriction that enables the non-32bit clang build configuration only for `x86_64` platforms. This configuration will work for any native clang target.
* Replace the `self.output.warn` call if the host platform is not supported, with an error condition. `self.output.warn` does not exist in conan v2.0 so it seems likely this branch was rarely if ever executed.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
