### PR TITLE
dispenso: add version 1.6.2

### DIFF
--- a/recipes/dispenso/all/conandata.yml
+++ b/recipes/dispenso/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "1.6.0":
-    url: "https://github.com/facebookincubator/dispenso/archive/refs/tags/v1.6.0.tar.gz"
-    sha256: "1c188b8593411080d653776595a15049f9e7eecd5212b31b3ee7bb094ff63971"
+  "1.6.2":
+    url: "https://github.com/facebookincubator/dispenso/archive/refs/tags/v1.6.2.tar.gz"
+    sha256: "9641511a6b14a77f68817f1a6e72fa9e55bc3ef2628a10011dcab07c6ba10539"

--- a/recipes/dispenso/all/conanfile.py
+++ b/recipes/dispenso/all/conanfile.py
@@ -32,7 +32,7 @@ class DispensoPackage(ConanFile):
 
     def requirements(self):
         # Part of the public api in dispenso/thread_pool.h (and more), unvendorized
-        self.requires("concurrentqueue/1.0.4", transitive_headers=True)
+        self.requires("concurrentqueue/1.0.5", transitive_headers=True)
 
     def validate(self):
         check_min_cppstd(self, 14)

--- a/recipes/dispenso/all/conanfile.py
+++ b/recipes/dispenso/all/conanfile.py
@@ -43,6 +43,7 @@ class DispensoPackage(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.cache_variables["DISPENSO_USE_SYSTEM_CONCURRENTQUEUE"] = True
+        tc.cache_variables["DISPENSO_WERROR"] = False
         tc.generate()
         tc = CMakeDeps(self)
         tc.generate()

--- a/recipes/dispenso/config.yml
+++ b/recipes/dispenso/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.6.0":
+  "1.6.2":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe: **dispenso/1.6.2**

fixes #30825

#### Motivation
Update dispenso to version 1.6.2.

#### Details
Set `conandata.yml` and `config.yml` to 1.6.2, replacing the previous entry.

Also raises `concurrentqueue` from 1.0.4 to 1.0.5 in `conanfile.py`.
`moodycamel::ConcurrentQueue` is a by-value member of `dispenso::ThreadPool`,
so its layout is part of dispenso's ABI; dispenso bundles 1.0.5 for every
other consumer, and this brings the conan build in line rather than leaving it
on a different queue version.

1.6.1 is skipped deliberately. It required
`find_package(concurrentqueue 1.0.5 CONFIG REQUIRED)`, which no installed
concurrentqueue satisfies -- upstream reports `1.0.0` from its CMake config at
every release -- so `DISPENSO_USE_SYSTEM_CONCURRENTQUEUE=ON`, which this recipe
sets, could not configure. 1.6.2 removes that requirement.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
---