### PR TITLE
sdl/3.x: do not require cmake if it is already configured

### DIFF
--- a/recipes/sdl/3.x/conanfile.py
+++ b/recipes/sdl/3.x/conanfile.py
@@ -240,7 +240,8 @@ class SDLConan(ConanFile):
             self.requires("xorg/system")
 
     def build_requirements(self):
-        self.tool_requires("cmake/[>=3.24]")
+        if not self.conf.get("tools.cmake:cmake_program", check_type=str):
+            self.tool_requires("cmake/[>=3.24]")
         if self._is_unix_sys and not self.conf.get("tools.gnu:pkg_config", check_type=str):
             self.tool_requires("pkgconf/[>=2.2 <3]")
         if self.options.get_safe("wayland"):


### PR DESCRIPTION
### Summary
Changes to recipe:  **sdl/3.x**

#### Motivation
I just want to use system cmake (already installed on my host)

#### Details
Only conanfile.py was changed. Just check cmake configuration like for pkgconf in this recipe.


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan
