### PR TITLE
cppduals: add recipe for 0.9.3

### DIFF
--- a/recipes/cppduals/all/conandata.yml
+++ b/recipes/cppduals/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.9.2":
+    url: "https://gitlab.com/tesch1/cppduals/-/archive/v0.9.2/cppduals-v0.9.2.tar.gz"
+    sha256: "399acb19ee8d933c8c799f01fdef7b716978595ef7efab8bd43a60696b2881e4"

--- a/recipes/cppduals/all/conandata.yml
+++ b/recipes/cppduals/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "0.9.2":
-    url: "https://gitlab.com/tesch1/cppduals/-/archive/v0.9.2/cppduals-v0.9.2.tar.gz"
-    sha256: "399acb19ee8d933c8c799f01fdef7b716978595ef7efab8bd43a60696b2881e4"
+  "0.9.3":
+    url: "https://gitlab.com/tesch1/cppduals/-/archive/v0.9.3/cppduals-v0.9.3.tar.gz"
+    sha256: "f30fee3203889d4eca50add2c3eff957ed2487f23d05e7464a5161949d13f3da"

--- a/recipes/cppduals/all/conanfile.py
+++ b/recipes/cppduals/all/conanfile.py
@@ -1,0 +1,79 @@
+# conan-center-index flavour of the recipe: sources come from conandata.yml
+# instead of the working copy.  Keep in sync with the root conanfile.py.
+import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+from conan.tools.microsoft import check_min_vs, is_msvc
+from conan.tools.scm import Version
+
+required_conan_version = ">=1.52.0"
+
+
+class CppdualsConan(ConanFile):
+    name = "cppduals"
+    description = (
+        "Header-only C++17 dual-number library for exact forward-mode "
+        "automatic differentiation, with optional Eigen and fmt integration. "
+        "If you use this in research, please cite doi:10.21105/joss.01487 "
+        "(Tesch, JOSS 4(43):1487, 2019)."
+    )
+    license = "MPL-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://gitlab.com/tesch1/cppduals"
+    topics = ("dual-numbers", "automatic-differentiation", "autodiff",
+              "derivatives", "eigen", "header-only")
+
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    @property
+    def _min_cppstd(self):
+        return 17
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "gcc": "8",
+            "clang": "7",
+            "apple-clang": "12",
+        }
+
+    def layout(self):
+        basic_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+        check_min_vs(self, 192)
+        if not is_msvc(self):
+            minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+            if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+                raise ConanInvalidConfiguration(
+                    f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+                )
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def package(self):
+        copy(self, pattern="LICENSE.txt",
+             dst=os.path.join(self.package_folder, "licenses"),
+             src=self.source_folder)
+        copy(self, pattern="*",
+             dst=os.path.join(self.package_folder, "include", "duals"),
+             src=os.path.join(self.source_folder, "duals"))
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+
+        self.cpp_info.set_property("cmake_file_name", "cppduals")
+        self.cpp_info.set_property("cmake_target_name", "cppduals::duals")

--- a/recipes/cppduals/all/test_package/CMakeLists.txt
+++ b/recipes/cppduals/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(cppduals REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE cppduals::duals)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/cppduals/all/test_package/conanfile.py
+++ b/recipes/cppduals/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/cppduals/all/test_package/test_package.cpp
+++ b/recipes/cppduals/all/test_package/test_package.cpp
@@ -1,0 +1,11 @@
+// Smoke test for the packaged headers: f(x) = x*sin(x), f'(2) via dual.
+#include <duals/dual>
+#include <iostream>
+
+int main()
+{
+  using namespace duals::literals;
+  auto y = (2.0 + 1.0_e) * sin(2.0 + 1.0_e);
+  std::cout << "f(2) = " << rpart(y) << ", f'(2) = " << dpart(y) << "\n";
+  return 0;
+}

--- a/recipes/cppduals/config.yml
+++ b/recipes/cppduals/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.9.2":
+    folder: all

--- a/recipes/cppduals/config.yml
+++ b/recipes/cppduals/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.9.2":
+  "0.9.3":
     folder: all


### PR DESCRIPTION
Specify library name and version: **cppduals/0.9.1**

[cppduals](https://gitlab.com/tesch1/cppduals) is a header-only C++17 dual-number library for exact forward-mode automatic differentiation — univariate `dual<T>`, multivariate `dual<T,N>`, nestable for higher-order derivatives, with optional Eigen integration (including hand-written SSE/AVX/NEON packet math).  MPL-2.0.  The library is described in [JOSS 4(43):1487](https://doi.org/10.21105/joss.01487).

The recipe is maintained upstream in the library repository, under [`packaging/conan-center-index/`](https://gitlab.com/tesch1/cppduals/-/tree/master/packaging/conan-center-index), so later versions stay in sync.

Tested locally with `conan create . --version=0.9.1` on apple-clang: the package builds from the release tarball and the test package links `cppduals::duals` and runs.