### PR TITLE
gaia-ecs: add version 1.0.0

### DIFF
--- a/recipes/gaia-ecs/all/conandata.yml
+++ b/recipes/gaia-ecs/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.0":
+    url: "https://github.com/richardbiely/gaia-ecs/archive/refs/tags/v1.0.0.tar.gz"
+    sha256: "0e6c4d8dbea7c9a6e01b84244aefa0a041c913ba289bbcaaa0770ece9a02c25d"
   "0.9.2":
     url: "https://github.com/richardbiely/gaia-ecs/archive/refs/tags/v0.9.2.tar.gz"
     sha256: "2fbed6c70fb80ae20812adfe073a0d2b396c447b56167be2c917979fdc95cc8d"

--- a/recipes/gaia-ecs/config.yml
+++ b/recipes/gaia-ecs/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.0.0":
+    folder: all
   "0.9.2":
     folder: all
   "0.8.6":


### PR DESCRIPTION
Add gaia-ecs 1.0.0 to the existing recipe.

## Summary

- Adds the gaia-ecs 1.0.0 version to the existing recipe (`recipes/gaia-ecs`).
- Two files changed: `config.yml` (version tuple) and `all/conandata.yml` (source + sha256).
- The recipe itself is unchanged; it packages the authored `include/` tree via `get()` with a verified SHA-256.

## Details

- **Library:** gaia-ecs — a simple and powerful entity component system (ECS) written in C++17, header-only, zero dependencies
- **Upstream:** https://github.com/richardbiely/gaia-ecs
- **Tarball:** https://github.com/richardbiely/gaia-ecs/archive/refs/tags/v1.0.0.tar.gz
- **sha256:** `0e6c4d8dbea7c9a6e01b84244aefa0a041c913ba289bbcaaa0770ece9a02c25d` (verified against the fetched tarball)

## Validation

`conan create recipes/gaia-ecs/all --version=1.0.0 --build=missing` passes locally on
apple-clang 21/arm64 (Release and Debug, C++17): package exports, real v1.0.0 tarball
downloaded and hash-checked, test package (`World`/`add()`/`valid()`) compiled and ran.
