### PR TITLE
perf-cpp: add new recipe (1.1.0)

### DIFF
--- a/recipes/perf-cpp/all/conandata.yml
+++ b/recipes/perf-cpp/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.1.0":
+    url: "https://github.com/jmuehlig/perf-cpp/archive/refs/tags/v1.1.0.tar.gz"
+    sha256: "85745bdc4cfd4cfbbe01f3572d559e7d6c3f28ec5abf3a1d0e80a318d8cd9671"

--- a/recipes/perf-cpp/all/conanfile.py
+++ b/recipes/perf-cpp/all/conanfile.py
@@ -1,0 +1,92 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, rmdir
+from conan.tools.scm import Version
+import os
+
+required_conan_version = ">=2.0.9"
+
+
+class PerfCppConan(ConanFile):
+    name = "perf-cpp"
+    description = (
+        "Lightweight C++17 library for hardware performance counter "
+        "monitoring and sampling using the Linux perf subsystem."
+    )
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/jmuehlig/perf-cpp"
+    topics = ("performance", "profiling", "perf", "hardware-counters", "sampling", "pebs", "ibs", "linux")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+    implements = ["auto_shared_fpic"]
+
+    @property
+    def _min_cppstd(self):
+        return 17
+
+    @property
+    def _compilers_minimum_version(self):
+        # Upstream requires complete std::from_chars support and enforces this in CMakeLists.txt
+        return {
+            "gcc": "11",
+            "clang": "14",
+        }
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def validate(self):
+        if self.settings.os != "Linux":
+            raise ConanInvalidConfiguration(
+                f"{self.ref} is only supported on Linux: it is built on the perf_event_open syscall."
+            )
+        check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler))
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires {self.settings.compiler} >= {minimum_version}."
+            )
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        # Upstream uses a custom option name rather than BUILD_SHARED_LIBS
+        tc.cache_variables["BUILD_LIB_SHARED"] = bool(self.options.shared)
+        tc.cache_variables["BUILD_EXAMPLES"] = False
+        tc.cache_variables["BUILD_TESTS"] = False
+        # Defaults to ON for a standalone build, which this is; packaged builds should not lint
+        tc.cache_variables["ENABLE_CLANG_TIDY"] = False
+        # Would shell out to python3 to generate a processor-specific event table at build time
+        tc.cache_variables["GEN_PROCESSOR_EVENTS"] = False
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["perf-cpp"]
+        self.cpp_info.set_property("cmake_file_name", "perf-cpp")
+        self.cpp_info.set_property("cmake_target_name", "perf-cpp::perf-cpp")
+        # The sampler's overflow worker runs on a std::thread
+        self.cpp_info.system_libs.append("pthread")

--- a/recipes/perf-cpp/all/test_package/CMakeLists.txt
+++ b/recipes/perf-cpp/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(perf-cpp REQUIRED CONFIG)
+
+add_executable(test_package src/test_package.cpp)
+target_link_libraries(test_package PRIVATE perf-cpp::perf-cpp)
+target_compile_features(test_package PRIVATE cxx_std_17)

--- a/recipes/perf-cpp/all/test_package/conanfile.py
+++ b/recipes/perf-cpp/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/perf-cpp/all/test_package/src/test_package.cpp
+++ b/recipes/perf-cpp/all/test_package/src/test_package.cpp
@@ -1,0 +1,16 @@
+#include <cstdlib>
+#include <iostream>
+#include <perfcpp/event_counter.hpp>
+
+int
+main()
+{
+  // Only build the counter definition; opening the counter would need perf_event access.
+  auto counter_definitions = perf::CounterDefinition{};
+  auto event_counter = perf::EventCounter{ counter_definitions };
+  event_counter.add("instructions");
+
+  std::cout << "perf-cpp: successfully configured the 'instructions' counter." << std::endl;
+
+  return EXIT_SUCCESS;
+}

--- a/recipes/perf-cpp/config.yml
+++ b/recipes/perf-cpp/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.1.0":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe: **perf-cpp/1.1.0**

#### Motivation
New recipe. [perf-cpp](https://github.com/jmuehlig/perf-cpp) is a C++17 library for recording hardware performance counters and sampling (PEBS/IBS) from inside an application, built on the Linux `perf_event_open` syscall. It is not currently available in ConanCenter.

I am the upstream author.

#### Details
Adds `recipes/perf-cpp` with version 1.1.0, sourced from the upstream release tarball.

The library is Linux-only by nature. It wraps `perf_event_open`, so `validate()` raises `ConanInvalidConfiguration` on every other OS. It also requires GCC 11 / Clang 14 for complete `std::from_chars` support, which upstream's CMakeLists.txt enforces with a `FATAL_ERROR`; the recipe checks the same bound so unsupported compilers are reported as invalid configurations rather than failing during the build.

Notes for reviewers:

- Upstream names its shared-library switch `BUILD_LIB_SHARED` rather than `BUILD_SHARED_LIBS`,   so the recipe passes it explicitly from `options.shared`.
- `GEN_PROCESSOR_EVENTS` is forced off. It is off by default upstream, but when enabled it shells out to `python3` during configure to generate a processor-specific event table.
- `ENABLE_CLANG_TIDY` is forced off. Upstream defaults it to on for standalone builds, which a Conan build is, and we don't want linting the library on every package build here.
- Upstream installs its own CMake package config; `package()` removes `lib/cmake` so only the Conan-generated config remains. Target and file names match upstream (`perf-cpp::perf-cpp`).
- `pthread` is added to `system_libs`: the sampler's overflow worker runs on a `std::thread`.

Tested locally with Conan 2.29.1 on Linux/x86_64, GCC 15:

| Configuration | Result |
| --- | --- |
| `shared=False` | builds, `test_package` runs |
| `shared=True` | builds, `test_package` runs, soname chain intact |
| `compiler.cppstd=20` | builds, `test_package` runs |
| `compiler.version=10` | `Invalid: requires gcc >= 11` |
| `compiler.cppstd=14` | `Invalid: current cppstd (14) is lower than the required C++ standard (17)` |
| `os=Windows` | `Invalid: only supported on Linux` |

The `test_package` builds a counter definition and configures an `instructions` counter without opening it, so it needs no `perf_event` privileges and is safe under a restricted `perf_event_paranoid`.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!