### PR TITLE
fix msvc version requirements for log4cplus 2.1.2 and newer

### DIFF
--- a/recipes/log4cplus/all/conanfile.py
+++ b/recipes/log4cplus/all/conanfile.py
@@ -68,8 +68,8 @@ class Log4cplusConan(ConanFile):
             if Version(self.version) < 2 and valid_min_cppstd(self, 17):
                 raise ConanInvalidConfiguration(f"${self.ref} does not support C++17")
         if Version(self.version) >= "2.1.2" and \
-           is_msvc(self) and Version(self.settings.compiler.version) < 192:
-            raise ConanInvalidConfiguration(f"${self.ref} requires Visual Studio 2019 or newer")
+           is_msvc(self) and Version(self.settings.compiler.version) < 191:
+            raise ConanInvalidConfiguration(f"${self.ref} requires Visual Studio 2017 or newer")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/log4cplus/config.yml
+++ b/recipes/log4cplus/config.yml
@@ -1,7 +1,7 @@
 versions:
   "2.1.2":
     folder: all
-  # 2.1.1 is the last version for Visual Studio 2017
+  # 2.1.1 is the last version for Visual Studio 2015
   "2.1.1":
     folder: all
   "2.1.0":


### PR DESCRIPTION
### Summary
Changes to recipe:  **log4cplus/***

#### Motivation
Fix https://github.com/conan-io/conan-center-index/issues/30824

#### Details
https://github.com/log4cplus/log4cplus/releases#release-REL_2_1_2

I believe last time version was set too high: https://github.com/conan-io/conan-center-index/pull/25761

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
