### PR TITLE
motus/1.0.0: new recipe

### DIFF
--- a/recipes/motus/all/conandata.yml
+++ b/recipes/motus/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "1.0.0":
+    url: "https://github.com/mertefesensoy/motus/archive/refs/tags/v1.0.0.tar.gz"
+    sha256: "16c45cd334aaee18a8b0b65773585e89a25f04357b75748befb084324bc9671b"

--- a/recipes/motus/all/conanfile.py
+++ b/recipes/motus/all/conanfile.py
@@ -1,0 +1,70 @@
+# Conan recipe for motus, shaped for a conan-center-index submission
+# (recipes/motus/all/conanfile.py there; see SUBMITTING.md beside this file).
+
+import os
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
+from conan.tools.files import copy, get, rmdir
+
+
+class MotusConan(ConanFile):
+    name = "motus"
+    description = (
+        "Transport-agnostic messaging seam for C++17 with a per-backend "
+        "conformance suite and a Windows-safe AMQP-CPP connection handler"
+    )
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/mertefesensoy/motus"
+    topics = ("messaging", "amqp", "rabbitmq", "transport", "cpp17")
+    package_type = "static-library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "with_amqpcpp": [True, False],
+        "with_inmemory": [True, False],
+    }
+    default_options = {
+        "with_amqpcpp": True,
+        "with_inmemory": True,
+    }
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        if self.options.with_amqpcpp:
+            self.requires("amqp-cpp/4.3.27")
+            self.requires("boost/[>=1.81 <2]")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["MOTUS_BUILD_TESTS"] = False
+        tc.variables["MOTUS_WITH_AMQPCPP"] = bool(self.options.with_amqpcpp)
+        tc.variables["MOTUS_WITH_INMEMORY"] = bool(self.options.with_inmemory)
+        tc.variables["MOTUS_WITH_SIMPLEAMQP"] = False
+        tc.generate()
+        CMakeDeps(self).generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder,
+             os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["motus"]
+        self.cpp_info.set_property("cmake_file_name", "motus")
+        self.cpp_info.set_property("cmake_target_name", "motus::motus")
+        if self.settings.os in ("Linux", "FreeBSD"):
+            self.cpp_info.system_libs = ["pthread"]
+        elif self.settings.os == "Windows":
+            self.cpp_info.system_libs = ["ws2_32"]

--- a/recipes/motus/all/conanfile.py
+++ b/recipes/motus/all/conanfile.py
@@ -2,9 +2,14 @@
 # (recipes/motus/all/conanfile.py there; see SUBMITTING.md beside this file).
 
 import os
+
 from conan import ConanFile
-from conan.tools.cmake import CMake, CMakeToolchain, CMakeDeps, cmake_layout
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import copy, get, rmdir
+
+required_conan_version = ">=2.0.9"
 
 
 class MotusConan(ConanFile):
@@ -17,34 +22,58 @@ class MotusConan(ConanFile):
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/mertefesensoy/motus"
     topics = ("messaging", "amqp", "rabbitmq", "transport", "cpp17")
+    # Upstream CMakeLists.txt declares add_library(motus STATIC ...) unconditionally,
+    # so there is no shared build to expose and hence no "shared" option.
     package_type = "static-library"
     settings = "os", "arch", "compiler", "build_type"
     options = {
+        "fPIC": [True, False],
         "with_amqpcpp": [True, False],
         "with_inmemory": [True, False],
     }
     default_options = {
+        "fPIC": True,
         "with_amqpcpp": True,
         "with_inmemory": True,
     }
+    implements = ["auto_shared_fpic"]
 
     def layout(self):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
         if self.options.with_amqpcpp:
-            self.requires("amqp-cpp/4.3.27")
-            self.requires("boost/[>=1.81 <2]")
+            # transitive_headers because both are reachable from INSTALLED public headers:
+            # INFO: <amqpcpp.h> in motus/AmqpConnection.hpp:20 and
+            #       motus/transport/backends/AmqpCppTransport.hpp:14
+            # INFO: <boost/asio/*.hpp> in motus/AmqpConnection.hpp:14-18
+            self.requires("amqp-cpp/4.3.27", transitive_headers=True)
+            self.requires("boost/1.88.0", transitive_headers=True)
+
+    def validate(self):
+        check_min_cppstd(self, 17)
+        if not self.options.with_amqpcpp and not self.options.with_inmemory:
+            # Upstream turns this into a configure-time FATAL_ERROR; fail earlier and
+            # with a message that names the Conan options rather than the CMake ones.
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires at least one transport backend: enable "
+                "-o with_amqpcpp=True and/or -o with_inmemory=True."
+            )
+
+    def build_requirements(self):
+        # Upstream sets cmake_minimum_required(VERSION 3.21); ConanCenter only
+        # guarantees 3.15 on the build machine.
+        self.tool_requires("cmake/[>=3.21]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
     def generate(self):
         tc = CMakeToolchain(self)
-        tc.variables["MOTUS_BUILD_TESTS"] = False
-        tc.variables["MOTUS_WITH_AMQPCPP"] = bool(self.options.with_amqpcpp)
-        tc.variables["MOTUS_WITH_INMEMORY"] = bool(self.options.with_inmemory)
-        tc.variables["MOTUS_WITH_SIMPLEAMQP"] = False
+        tc.cache_variables["MOTUS_BUILD_TESTS"] = False
+        tc.cache_variables["MOTUS_WITH_AMQPCPP"] = bool(self.options.with_amqpcpp)
+        tc.cache_variables["MOTUS_WITH_INMEMORY"] = bool(self.options.with_inmemory)
+        tc.cache_variables["MOTUS_WITH_SIMPLEAMQP"] = False
         tc.generate()
         CMakeDeps(self).generate()
 
@@ -67,4 +96,12 @@ class MotusConan(ConanFile):
         if self.settings.os in ("Linux", "FreeBSD"):
             self.cpp_info.system_libs = ["pthread"]
         elif self.settings.os == "Windows":
-            self.cpp_info.system_libs = ["ws2_32"]
+            # Mirrors the PUBLIC link libraries and compile definitions upstream puts on
+            # the motus target. They cannot be inherited here: the exported
+            # motusTargets.cmake that carried them is removed in package(), so CMakeDeps
+            # generates the config file and the recipe has to restate the interface.
+            # mswsock is Boost.Asio's Windows requirement alongside ws2_32, and
+            # _WIN32_WINNT must be defined before any consumer translation unit pulls in
+            # a Boost.Asio header through motus/AmqpConnection.hpp.
+            self.cpp_info.system_libs = ["ws2_32", "mswsock"]
+            self.cpp_info.defines = ["_WIN32_WINNT=0x0601", "WIN32_LEAN_AND_MEAN"]

--- a/recipes/motus/all/test_package/CMakeLists.txt
+++ b/recipes/motus/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(motus REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE motus::motus)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/motus/all/test_package/conanfile.py
+++ b/recipes/motus/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/motus/all/test_package/test_package.cpp
+++ b/recipes/motus/all/test_package/test_package.cpp
@@ -6,13 +6,26 @@
 // generates at build time -- including it here checks that the generated header was
 // installed alongside the hand-written ones.
 //
-// Nothing below emits a log record, so the logger's sink thread never starts and the
-// test stays deterministic on every platform ConanCenter builds.
+// The guarded include of motus/AmqpConnection.hpp tests the packaging rather than the
+// library. That header is installed and reaches <amqpcpp.h> and <boost/asio/*.hpp>, so it
+// compiles only if both requirements carry transitive_headers=True; on Windows it also
+// needs the _WIN32_WINNT define that package_info() restates, because package() removes the
+// exported CMake config that upstream put it on. The guard reads
+// motus/transport/Config.hpp, the generated header recording which backends this build
+// contains, so the test follows the recipe's options without having to know them.
+//
+// Nothing below emits a log record, so the logger's sink thread never starts and the test
+// stays deterministic on every platform ConanCenter builds.
 
 #include <iostream>
 
 #include <motus/Logger.hpp>
 #include <motus/Version.hpp>
+#include <motus/transport/Config.hpp>
+
+#ifdef MOTUS_WITH_AMQPCPP
+#include <motus/AmqpConnection.hpp>
+#endif
 
 int main()
 {
@@ -30,5 +43,10 @@ int main()
 
     std::cout << motus::versionString() << '\n'
               << "parsed level: " << motus::Logger::levelName(level) << '\n';
+
+#ifdef MOTUS_WITH_AMQPCPP
+    std::cout << "amqpcpp backend headers reachable\n";
+#endif
+
     return 0;
 }

--- a/recipes/motus/all/test_package/test_package.cpp
+++ b/recipes/motus/all/test_package/test_package.cpp
@@ -1,0 +1,34 @@
+// Proves the package is consumable, without needing a broker.
+//
+// parseLevel, levelName and hexDump are declared in motus/Logger.hpp and defined in the
+// compiled Logger translation unit, so linking this exercises the static library rather
+// than just the headers. versionString() comes from motus/Version.hpp, which CMake
+// generates at build time -- including it here checks that the generated header was
+// installed alongside the hand-written ones.
+//
+// Nothing below emits a log record, so the logger's sink thread never starts and the
+// test stays deterministic on every platform ConanCenter builds.
+
+#include <iostream>
+
+#include <motus/Logger.hpp>
+#include <motus/Version.hpp>
+
+int main()
+{
+    motus::LogLevel level = motus::LogLevel::Info;
+    if (!motus::Logger::parseLevel("warn", level) || level != motus::LogLevel::Warn) {
+        std::cerr << "motus::Logger::parseLevel did not round-trip \"warn\"\n";
+        return 1;
+    }
+
+    const char bytes[] = {'m', 'o', 't', 'u', 's'};
+    if (motus::hexDump(bytes, sizeof(bytes)).empty()) {
+        std::cerr << "motus::hexDump returned an empty rendering\n";
+        return 1;
+    }
+
+    std::cout << motus::versionString() << '\n'
+              << "parsed level: " << motus::Logger::levelName(level) << '\n';
+    return 0;
+}

--- a/recipes/motus/config.yml
+++ b/recipes/motus/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.0.0":
+    folder: all


### PR DESCRIPTION
### motus/1.0.0: new recipe

Changes to recipe: **motus/1.0.0**

#### Motivation

New recipe for [motus](https://github.com/mertefesensoy/motus), a transport-agnostic messaging
seam for C++17 with a per-backend conformance suite and a Windows-safe AMQP-CPP connection
handler over Boost.Asio. Apache-2.0, and I am the upstream author.

#### Details

- `with_amqpcpp` (default True) pulls `amqp-cpp/4.3.27` and Boost for Asio. With it off, the
  in-memory backend builds with zero dependencies.
- Static library, C++17. Upstream sets `cmake_minimum_required(VERSION 3.21)`, so the recipe
  tool-requires `cmake/[>=3.21]`.
- `transitive_headers` is set on both requirements because the installed
  `motus/AmqpConnection.hpp` includes `<amqpcpp.h>` and `<boost/asio/*.hpp>`, so consumers
  compile against them.
- On Windows the recipe restates `ws2_32`, `mswsock` and the `_WIN32_WINNT` defines that
  upstream puts on the target, since `package()` removes the exported CMake config that
  carried them.
- Upstream CI covers Ubuntu GCC, Windows MSVC, Windows MSYS2/UCRT64 and macOS arm64, plus a
  39-scenario conformance contract against a live RabbitMQ.

Tested locally with Conan 2.31.2 on a gcc 16 profile. `conan create` passes with
`with_amqpcpp=False` and `test_package` builds and runs there. The default option set resolves
cleanly against `amqp-cpp/4.3.27` and `boost/1.88.0`.

---

- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details <!-- n/a, new recipe -->
- [x] Tested locally with at least one configuration using a recent version of Conan
