### PR TITLE
install system requirements for egl support

### DIFF
--- a/recipes/qt/5.x.x/conanfile.py
+++ b/recipes/qt/5.x.x/conanfile.py
@@ -455,6 +455,8 @@ class QtConan(ConanFile):
             self.requires("dbus/1.15.8")
         if self.options.qtwayland:
             self.requires("wayland/1.22.0")
+            if self.options.get_safe("opengl", "no") != "no":
+                self.requires("egl/system")
         if self.settings.os in ['Linux', 'FreeBSD'] and self.options.with_gssapi:
             self.requires("krb5/1.21.2")
         if self.options.get_safe("with_atspi"):
@@ -1132,6 +1134,8 @@ Prefix = ..""")
                 if self.options.get_safe("with_x11", False):
                     gui_reqs.append("xorg::xorg")
             if self.options.get_safe("opengl", "no") != "no":
+                if self.options.get_safe("qtwayland", False):
+                    gui_reqs.append("egl::egl")
                 gui_reqs.append("opengl::opengl")
             if self.options.get_safe("with_vulkan", False):
                 gui_reqs.append("vulkan-loader::vulkan-loader")


### PR DESCRIPTION
### Summary
Changes to recipe:  **qt/5.15.19**

#### Motivation

Enabling Wayland support in the Qt package does not enable the wayland-egl plugins. Fixes #30839 

#### Details

If the `qtwayland` module and `opengl` support is enabled, install the `egl/system` package. This enables Qt to detect EGL support and build the required plugins.

```
tree /root/.conan2/p/b/qtc09d95c1736fe/p/plugins/platforms/
/root/.conan2/p/b/qtc09d95c1736fe/p/plugins/platforms/
|-- libqeglfs.so
|-- libqlinuxfb.so
|-- libqminimal.so
|-- libqminimalegl.so
|-- libqoffscreen.so
|-- libqvnc.so
|-- libqwayland-egl.so
|-- libqwayland-generic.so
|-- libqwayland-xcomposite-glx.so
`-- libqxcb.so
```

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
