### PR TITLE
icu: detect riscv64 as a 64-bit architecture

### DIFF
--- a/recipes/icu/all/conanfile.py
+++ b/recipes/icu/all/conanfile.py
@@ -167,7 +167,7 @@ class ICUConan(ConanFile):
                 tc.update_configure_args({"--host": host_triplet,
                                           "--build": build_triplet})
         else:
-            arch64 = ["x86_64", "sparcv9", "ppc64", "ppc64le", "armv8", "armv8.3", "mips64"]
+            arch64 = ["x86_64", "sparcv9", "ppc64", "ppc64le", "armv8", "armv8.3", "mips64", "riscv64"]
             bits = "64" if self.settings.arch in arch64 else "32"
             tc.configure_args.append(f"--with-library-bits={bits}")
         if self.settings.os != "Windows":


### PR DESCRIPTION
### Summary

Treat `riscv64` as a 64-bit architecture when configuring ICU.

The ICU recipe currently determines `--with-library-bits` using an architecture allowlist. Since `riscv64` is missing from that list, native 64-bit RISC-V builds incorrectly receive:

```text
--with-library-bits=32
```

This causes ICU configure to fail with:

```text
Requested 32 bit binaries but could not compile and execute them.
```

### Changes

- Add `riscv64` to the ICU recipe's 64-bit architecture list.

### Testing

Tested natively on Linux `riscv64` with GCC 15 and Conan 2.25.1 using ICU 74.2:

```bash
conan create recipes/icu/all \
  --version=74.2 \
  -pr:h default \
  -pr:b default
```

Verified that:

- ICU configure receives `--with-library-bits=64`.
- The build system is detected as `riscv64-unknown-linux-gnu`.
- `sizeof(void *)` is detected as 8.
- The ICU Conan package builds successfully.
- The existing `test_package` builds and runs successfully.