### PR TITLE
opencv: add cuda_arch_ptx option

### DIFF
--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -113,6 +113,7 @@ class OpenCVConan(ConanFile):
         "with_cufft": [True, False],
         "with_cudnn": [True, False],
         "cuda_arch_bin": [None, "ANY"],
+        "cuda_arch_ptx": [None, "ANY"],
         "cpu_baseline": [None, "ANY"],
         "cpu_dispatch": [None, "ANY"],
         "world": [True, False],
@@ -172,6 +173,7 @@ class OpenCVConan(ConanFile):
         "with_cufft": False,
         "with_cudnn": False,
         "cuda_arch_bin": None,
+        "cuda_arch_ptx": None,
         "cpu_baseline": None,
         "cpu_dispatch": None,
         "world": False,
@@ -1019,6 +1021,7 @@ class OpenCVConan(ConanFile):
             self.options.rm_safe("with_cufft")
             self.options.rm_safe("dnn_cuda")
             self.options.rm_safe("cuda_arch_bin")
+            self.options.rm_safe("cuda_arch_ptx")
         if not self.options.text:
             self.options.rm_safe("with_tesseract")
 
@@ -1472,6 +1475,8 @@ class OpenCVConan(ConanFile):
             tc.variables["CUDA_NVCC_FLAGS"] = "--expt-relaxed-constexpr"
             if self.options.cuda_arch_bin:
                 tc.variables["CUDA_ARCH_BIN"] = self.options.cuda_arch_bin
+            if self.options.cuda_arch_ptx:
+                tc.variables["CUDA_ARCH_PTX"] = self.options.cuda_arch_ptx
         tc.variables["WITH_CUBLAS"] = self.options.get_safe("with_cublas", False)
         tc.variables["WITH_CUFFT"] = self.options.get_safe("with_cufft", False)
         tc.variables["WITH_CUDNN"] = self.options.get_safe("with_cudnn", False)


### PR DESCRIPTION
### Summary
Changes to recipe:  **opencv/[4.x]**

#### Details

The recipe forwards cuda_arch_bin to OpenCV's CUDA_ARCH_BIN but never sets CUDA_ARCH_PTX, and there is no other way to reach it. OpenCV builds its PTX -gencode arch=compute_NN,code=compute_NN entries from ARCH_PTX alone (cmake/OpenCVDetectCUDA.cmake; ocv_set_cuda_arch_bin_and_ptx in cmake/OpenCVDetectCUDAUtils.cmake does set(__cuda_arch_ptx ${CUDA_ARCH_PTX})).

The result is that every CUDA-enabled opencv package built through Conan ships cubins only, with no PTX at all. A GPU whose compute capability has no matching cubin then has nothing to JIT from.

cuda_arch_ptx mirrors cuda_arch_bin exactly: same [None, "ANY"] type, same None default, same rm_safe when with_cuda is off, and the same conditional forward in generate(). Defaulting to None leaves behaviour unchanged for anyone who does not set it.
