### PR TITLE
[make] Clean up embedded hardcoded CXX path from make database

### DIFF
--- a/recipes/make/all/conanfile.py
+++ b/recipes/make/all/conanfile.py
@@ -45,6 +45,7 @@ class MakeConan(ConanFile):
         if self.settings_build.os != "Windows":
             tc = AutotoolsToolchain(self)
             tc.configure_args.extend(["--disable-dependency-tracking"])
+            tc.configure_args.append("CXX=")
             tc.generate()
 
     def build(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **make/4.4.1**

#### Motivation

As explained in the issue and confirmed on https://github.com/conan-io/conan-center-index/issues/30837#issuecomment-5422249762, the Conan package for `make` has the C++ compiler used embedded in its database, it can be spotted by running `make -p`.

When building `make` from scratch, and having the cxx compiler explicitly configured, like CCI, it will be injected to make default CXX: https://github.com/mirror/make/blob/4.4.1/configure.ac#L41

For ConanCenterIndex, we can see the PR https://github.com/conan-io/conan-center-index/pull/30244/checks?check_run_id=77910854804 and its build log https://c3i.jfrog.io/artifactory/cci-build-logs/cci/prod/PR-30244/4/package_build_logs/build_log_make_4_4_1_c0254b3e1adc7aa6242b4a1ef6c26cc7_3593751651824fb813502c69c971267624ced41a.success.txt with `tools.build:compiler_executables` which will inject `CXX` in its build environment.

When `CXX` is not configured, `make` will result in `g++` instead. The documentation https://ftp.gnu.org/old-gnu/Manuals/make-3.80/html_node/make_102.html#SEC106 points:

> CXX
>   Program for compiling C++ programs; default `g++'. 

Tested locally to validate the original report: [make-4.4.1-macos-armv8.log](https://github.com/user-attachments/files/31458834/make-4.4.1-macos-armv8.log)

```
/Users/uilian/.conan2/p/b/make8a9fcc4e283da/p/bin/make -p | grep CXX
make: *** No targets specified and no makefile found.  Stop.
LINK.cc = $(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) $(TARGET_ARCH)
CXX = /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++
COMPILE.cc = $(CXX) $(CXXFLAGS) $(CPPFLAGS) $(TARGET_ARCH) -c
```

Once patched, using the very same Conan profile and command line, the resulted `make` does not keep the hardcoded `CXX`, but uses the default `g++`: [make-4.4.1-macos-armv8-patched.log](https://github.com/user-attachments/files/31458901/make-4.4.1-macos-armv8-patched.log)

```
/Users/uilian/.conan2/p/b/make184734065fee3/p/bin/make -p | grep CXX
make: *** No targets specified and no makefile found.  Stop.
LINK.cc = $(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) $(TARGET_ARCH)
CXX = g++
COMPILE.cc = $(CXX) $(CXXFLAGS) $(CPPFLAGS) $(TARGET_ARCH) -c
```

fixes #30837 
/cc @@igagis 

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
