### PR TITLE
[libsystemd] Add version 261.2

### DIFF
--- a/recipes/libsystemd/all/conandata.yml
+++ b/recipes/libsystemd/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "261.2":
+    url: "https://github.com/systemd/systemd/archive/refs/tags/v261.2.tar.gz"
+    sha256: "ed1059ff964f5df35b6056434cc17cc83f86dc913f10489948a0b19b6081c5ec"
   "255.10":
     url: "https://github.com/systemd/systemd-stable/archive/v255.10.tar.gz"
     sha256: "1747b848e68223597abb90ca2758b25230ac4c19e252e9ec77c8518750f621ed"
@@ -15,6 +18,8 @@ sources:
     url: "https://github.com/systemd/systemd-stable/archive/v253.6.tar.gz"
     sha256: "a0aebcfaa2e001a4d846691631d1722c4cfa1a175e4ea62db6edca0ea3cf1e3e"
 patches:
+  "261.2":
+    - patch_file: "patches/261.2/0001-Remove-dependency-from-coreutils.patch"
   "255.10":
     - patch_file: "patches/251.18/0001-Remove-dependency-from-coreutils.patch"
   "255.2":

--- a/recipes/libsystemd/all/conanfile.py
+++ b/recipes/libsystemd/all/conanfile.py
@@ -83,7 +83,8 @@ class LibsystemdConan(ConanFile):
         download(self, **self.conan_data["sources"][self.version], filename="sources.tar.gz")
         with tarfile.open("sources.tar.gz", "r:gz") as tar:
             tar.extractall()
-        move_folder_contents(self, os.path.join(self.source_folder, f"systemd-stable-{self.version}"), self.source_folder)
+        folder_name = f"systemd-stable-{self.version}" if Version(self.version) < "261" else f"systemd-{self.version}"
+        move_folder_contents(self, os.path.join(self.source_folder, folder_name), self.source_folder)
 
     @property
     def _so_version(self):
@@ -138,8 +139,9 @@ class LibsystemdConan(ConanFile):
             "libiptc", "elfutils", "repart", "homed", "importd", "acl",
             "dns-over-tls", "log-trace"]
 
-        unrelated.append("oomd")
-        unrelated.extend(["sysext", "nscd"])
+        unrelated.extend(["oomd", "sysext"])
+        if Version(self.version) < "261":
+            unrelated.append("nscd")
         unrelated.append("link-boot-shared")
         unrelated.append("link-journalctl-shared")
         if Version(self.version) < "254.7":
@@ -149,6 +151,9 @@ class LibsystemdConan(ConanFile):
 
         for opt in unrelated:
             tc.project_options[opt] = "false"
+        if Version(self.version) >= "261":
+            tc.project_options["libidn"] = "disabled"
+            tc.project_options["libiptc"] = "disabled"
 
         if Version(self.version) < "255":
             # 'rootprefix' is unused during libsystemd packaging but systemd > v247
@@ -181,7 +186,8 @@ class LibsystemdConan(ConanFile):
         meson.configure()
         target = ("systemd:shared_library" if self.options.shared
                   else "systemd:static_library")
-        meson.build(target=f"version.h {target}")
+        version = "version.h" if Version(self.version) < "261" else "version"
+        meson.build(target=f"{version} {target}")
 
     def package(self):
         copy(self, "LICENSE.LGPL2.1", self.source_folder,

--- a/recipes/libsystemd/all/patches/261.2/0001-Remove-dependency-from-coreutils.patch
+++ b/recipes/libsystemd/all/patches/261.2/0001-Remove-dependency-from-coreutils.patch
@@ -1,0 +1,16 @@
+diff --git a/meson.build b/meson.build
+index 438ce4f..b6e23aa 100644
+--- a/meson.build
++++ b/meson.build
+@@ -44,10 +44,7 @@ if meson.version().version_compare('>=1.3.0')
+         relative_source_path = fs.relative_to(meson.project_source_root(),
+                                               meson.project_build_root())
+ else
+-        relative_source_path = run_command('realpath',
+-                                           '--relative-to=@0@'.format(meson.project_build_root()),
+-                                           meson.project_source_root(),
+-                                           check : true).stdout().strip()
++        relative_source_path = @CONAN_SRC_REL_PATH@
+ endif
+ conf.set_quoted('RELATIVE_SOURCE_PATH', relative_source_path)
+ 

--- a/recipes/libsystemd/config.yml
+++ b/recipes/libsystemd/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "261.2":
+    folder: all
   "255.10":
     folder: all
   "255.2":


### PR DESCRIPTION
Changes to recipe:  **libsystemd/261.2**

#### Motivation

Issue #30420 points out a limitation in libsystemd that was already fixed in version 260. This PR brings the latest stable version of that project and includes the upstream fix.

#### Details

* The patch `0001-Remove-dependency-from-coreutils.patch` is a reflect of `251.18/0001-Remove-dependency-from-coreutils.patch`
* A bunch of options moved from boolean values (true, false) to enabled, disabled (you can see in the build log
* The build target version.h is now version
* Built locally on Linux:
  * [systemd-261.2-linux-amd64-gcc13-release-shared.log](https://github.com/user-attachments/files/31508712/systemd-261.2-linux-amd64-gcc13-release-shared.log)
  * [systemd-261.2-linux-amd64-gcc13-release-static.log](https://github.com/user-attachments/files/31508717/systemd-261.2-linux-amd64-gcc13-release-static.log)
* I did not remove old version logic as libsystemd is used by other recipes: libseat, grpc, dbus, zyre, czmq, zyre

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
