### PR TITLE
cpp-httplib: Add version 0.53.1

### DIFF
--- a/recipes/cpp-httplib/all/conandata.yml
+++ b/recipes/cpp-httplib/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.53.1":
+    url: "https://github.com/yhirose/cpp-httplib/archive/v0.53.1.tar.gz"
+    sha256: "185af9587e270de9a3bfee234c6740f02e82265da33c7a41f97e02ee42f979d2"
   "0.47.0":
     url: "https://github.com/yhirose/cpp-httplib/archive/v0.47.0.tar.gz"
     sha256: "f6676dd6539c1d05978aa8ecfae86d71e73c46f48c7766a04b991aa545c2f065"

--- a/recipes/cpp-httplib/config.yml
+++ b/recipes/cpp-httplib/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.53.1":
+    folder: all
   "0.47.0":
     folder: all
   "0.28.0":


### PR DESCRIPTION
### Summary
Changes to recipe: cpp-httplib - add version 0.53.1

#### Motivation

I'm trying to use the latest minio-cpp version (0.7.0), which notably migrated from curlpp to cpp-httplib. The cpp-httplib version required must be greater than 0.51 - if not present, the minio-cpp build will download and build it, which is undesirable.

#### Details

Add version 0.53.1

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
