### PR TITLE
minio-cpp: Add version 0.7.0

### DIFF
--- a/recipes/minio-cpp/all/conandata.yml
+++ b/recipes/minio-cpp/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "0.4.0":
-    url: "https://github.com/minio/minio-cpp/archive/refs/tags/v0.4.0.tar.gz"
-    sha256: "31cca03d32a3a27955d21764e3719097895f243f3b3add932f3c207758624eda"
+  "0.7.0":
+    url: "https://github.com/minio/minio-cpp/archive/refs/tags/v0.7.0.tar.gz"
+    sha256: "87564e15846642af64c45d28eb81cf2841a44949883ef81db5cf79e80d4730b5"
 patches:
-  "0.4.0":
-    - patch_file: "patches/0.4.0-0001-fix-fpic-cmake.patch"
+  "0.7.0":
+    - patch_file: "patches/0.7.0-0001-fix-fpic-cmake.patch"

--- a/recipes/minio-cpp/all/conanfile.py
+++ b/recipes/minio-cpp/all/conanfile.py
@@ -35,7 +35,7 @@ class MinioCppConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("cpp-httplib/0.53.1")
+        self.requires("cpp-httplib/0.53.1", options={"with_openssl": True})
         self.requires("inih/58")
         self.requires("nlohmann_json/3.11.3", transitive_headers=True)
         self.requires("openssl/[>=1.1 <4]")

--- a/recipes/minio-cpp/all/conanfile.py
+++ b/recipes/minio-cpp/all/conanfile.py
@@ -35,11 +35,11 @@ class MinioCppConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("curlpp/0.8.1.cci.20240530", transitive_headers=True)
+        self.requires("cpp-httplib/0.53.1")
         self.requires("inih/58")
         self.requires("nlohmann_json/3.11.3", transitive_headers=True)
         self.requires("openssl/[>=1.1 <4]")
-        self.requires("pugixml/1.14")
+        self.requires("pugixml/1.16", transitive_headers=True)
         self.requires("zlib/[>=1.2.11 <2]")
 
     def validate(self):
@@ -52,8 +52,6 @@ class MinioCppConan(ConanFile):
         tc = CMakeToolchain(self)
         tc.generate()
         deps = CMakeDeps(self)
-        deps.set_property("curlpp", "cmake_file_name", "unofficial-curlpp")
-        deps.set_property("curlpp", "cmake_target_name", "unofficial::curlpp::curlpp")
         deps.set_property("inih", "cmake_file_name", "unofficial-inih")
         deps.set_property("inih", "cmake_target_name", "unofficial::inih::inireader")
         deps.set_property("pugixml", "cmake_target_name", "pugixml")

--- a/recipes/minio-cpp/all/conanfile.py
+++ b/recipes/minio-cpp/all/conanfile.py
@@ -1,4 +1,5 @@
 from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
 from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir

--- a/recipes/minio-cpp/all/conanfile.py
+++ b/recipes/minio-cpp/all/conanfile.py
@@ -44,6 +44,8 @@ class MinioCppConan(ConanFile):
 
     def validate(self):
         check_min_cppstd(self, 17)
+        if not self.dependencies["cpp-httplib"].options.get_safe("with_openssl"):
+            raise ConanInvalidConfiguration("Requires cpp-httplib with OpenSSL support. Use -o 'cpp-httplib/*:with_openssl=True'")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/minio-cpp/all/patches/0.7.0-0001-fix-fpic-cmake.patch
+++ b/recipes/minio-cpp/all/patches/0.7.0-0001-fix-fpic-cmake.patch
@@ -2,7 +2,7 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index c2610db..52bbffa 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -178,7 +178,6 @@
+@@ -186,7 +186,6 @@
    target_compile_definitions(miniocpp PUBLIC MINIO_CPP_RDMA)
  endif()
  set_target_properties(miniocpp PROPERTIES VERSION "${MINIO_CPP_VERSION_STRING}")

--- a/recipes/minio-cpp/config.yml
+++ b/recipes/minio-cpp/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.4.0":
+  "0.7.0":
     folder: all


### PR DESCRIPTION
### Summary

Add minio-cpp version 0.7.0

#### Motivation

Make available version 0.7.0, which remove the unmaintained curlpp with cpp-httplib. Also has bugfixes over 0.4.0.

https://github.com/minio/minio-cpp/releases/tag/v0.7.0

#### Details

Replaced curlpp dependency with cpp-httplib. The CMakeLists in minio-cpp enforces requirements for the cpp-httplib dependency, so #30861 needs to be merged and built first.

Also make pugixml headers be transitive - the header is now included in minio-cpp's headers.

---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
