### PR TITLE
threadschedule: add version 3.0.0

### DIFF
--- a/recipes/threadschedule/all/conandata.yml
+++ b/recipes/threadschedule/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "3.0.0":
+    url: "https://github.com/Katze719/ThreadSchedule/releases/download/v3.0.0/threadschedule-3.0.0-source.tar.gz"
+    sha256: "05610f65d6238b48ba1ebf3e619849fc841ff0be937cc860b1f7ce20725d399f"

--- a/recipes/threadschedule/all/conanfile.py
+++ b/recipes/threadschedule/all/conanfile.py
@@ -1,0 +1,91 @@
+import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, rmdir
+
+
+required_conan_version = ">=2.0"
+
+
+class ThreadScheduleConan(ConanFile):
+    name = "threadschedule"
+    description = "C++17 thread management and scheduling library"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/Katze719/ThreadSchedule"
+    topics = ("threading", "concurrency", "thread-pool", "scheduling", "header-only")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "windows_vista_compat": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "windows_vista_compat": False,
+    }
+
+    def config_options(self):
+        if self.settings.os != "Windows":
+            self.options.rm_safe("windows_vista_compat")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def package_id(self):
+        if not self.info.options.shared:
+            self.info.settings.clear()
+
+    def validate(self):
+        check_min_cppstd(self, 17)
+        if self.settings.os not in ("Linux", "Windows"):
+            raise ConanInvalidConfiguration(f"{self.ref} only supports Linux and Windows")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        toolchain = CMakeToolchain(self)
+        toolchain.cache_variables["THREADSCHEDULE_RUNTIME"] = bool(self.options.shared)
+        toolchain.cache_variables["THREADSCHEDULE_BUILD_EXAMPLES"] = False
+        toolchain.cache_variables["THREADSCHEDULE_BUILD_TESTS"] = False
+        toolchain.cache_variables["THREADSCHEDULE_BUILD_BENCHMARKS"] = False
+        toolchain.cache_variables["THREADSCHEDULE_BUILD_DOCS"] = False
+        toolchain.cache_variables["THREADSCHEDULE_INSTALL"] = True
+        toolchain.cache_variables["THREADSCHEDULE_WINDOWS_VISTA_COMPAT"] = bool(
+            self.options.get_safe("windows_vista_compat", False)
+        )
+        toolchain.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "ThreadSchedule")
+
+        headers = self.cpp_info.components["headers"]
+        headers.set_property("cmake_target_name", "ThreadSchedule::ThreadSchedule")
+        headers.bindirs = []
+        headers.libdirs = []
+        if self.settings.os == "Linux":
+            headers.system_libs = ["pthread", "rt"]
+        if self.options.get_safe("windows_vista_compat", False):
+            headers.defines = ["THREADSCHEDULE_WINDOWS_VISTA_COMPAT=1"]
+
+        if self.options.shared:
+            runtime = self.cpp_info.components["runtime"]
+            runtime.set_property("cmake_target_name", "ThreadSchedule::Runtime")
+            runtime.libs = ["threadscheduled" if self.settings.build_type == "Debug" else "threadschedule"]
+            runtime.requires = ["headers"]
+            runtime.defines = ["THREADSCHEDULE_RUNTIME"]

--- a/recipes/threadschedule/all/test_package/CMakeLists.txt
+++ b/recipes/threadschedule/all/test_package/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(ThreadSchedule CONFIG REQUIRED)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+if(TEST_SHARED_RUNTIME)
+    target_link_libraries(${PROJECT_NAME} PRIVATE ThreadSchedule::Runtime)
+else()
+    target_link_libraries(${PROJECT_NAME} PRIVATE ThreadSchedule::ThreadSchedule)
+endif()

--- a/recipes/threadschedule/all/test_package/conanfile.py
+++ b/recipes/threadschedule/all/test_package/conanfile.py
@@ -1,0 +1,33 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+
+
+class ThreadScheduleTestPackage(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def generate(self):
+        CMakeDeps(self).generate()
+        toolchain = CMakeToolchain(self)
+        toolchain.cache_variables["TEST_SHARED_RUNTIME"] = bool(
+            self.dependencies["threadschedule"].options.shared
+        )
+        toolchain.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            self.run(os.path.join(self.cpp.build.bindir, "test_package"), env="conanrun")

--- a/recipes/threadschedule/all/test_package/test_package.cpp
+++ b/recipes/threadschedule/all/test_package/test_package.cpp
@@ -1,0 +1,8 @@
+#include <threadschedule/threadschedule.hpp>
+
+int main()
+{
+    threadschedule::thread_pool pool(threadschedule::worker_count{1});
+    auto result = pool.submit([] { return 42; });
+    return result && result->get() == 42 ? 0 : 1;
+}

--- a/recipes/threadschedule/config.yml
+++ b/recipes/threadschedule/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "3.0.0":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe: **threadschedule/3.0.0**

#### Motivation
This adds the first ConanCenter recipe for [ThreadSchedule](https://github.com/Katze719/ThreadSchedule), a C++17 library for creating, configuring, scheduling, and observing threads on Linux and Windows.

This is my first package submission to ConanCenter. I am also the upstream author, and I would appreciate any feedback or guidance from the maintainers.

#### Details
- Packages the default header-only ThreadSchedule target.
- Exposes the optional shared registry runtime when the shared option is enabled.
- Preserves the upstream CMake target names ThreadSchedule::ThreadSchedule and ThreadSchedule::Runtime.
- Uses the official 3.0.0 source release and verifies it with SHA-256.
- Supports the upstream Windows Vista compatibility option on Windows.

Locally tested with Conan 2.31.2, GCC 16, and C++17 in these configurations:
- Header-only, Release
- Shared runtime, Release
- Shared runtime, Debug

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan
