### PR TITLE
ironpress: add version 1.6.0

### DIFF
--- a/recipes/ironpress/all/conandata.yml
+++ b/recipes/ironpress/all/conandata.yml
@@ -1,0 +1,8 @@
+sources:
+  "1.6.0":
+    archive:
+      url: "https://github.com/gastongouron/ironpress/archive/refs/tags/v1.6.0.tar.gz"
+      sha256: "380f174720f813d16d69cfd14f5a2af7657b0c2b58c33ec42dad612d7dcb974b"
+    cargo_lock:
+      url: "https://raw.githubusercontent.com/gastongouron/ironpress/11256bdeed794c8721777d8c52d420dd6ec433e0/Cargo.lock"
+      sha256: "6322f2d67285c66de3f3062fa8eccbeb1bffbbe7e7bb55d50ff44ea7084a4e93"

--- a/recipes/ironpress/all/conanfile.py
+++ b/recipes/ironpress/all/conanfile.py
@@ -1,0 +1,155 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import cross_building
+from conan.tools.files import collect_libs, copy, download, get
+import os
+
+
+required_conan_version = ">=2.0.9"
+
+
+class IronpressConan(ConanFile):
+    name = "ironpress"
+    description = "In-process HTML, CSS, and Markdown to PDF renderer"
+    license = "MIT"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/gastongouron/ironpress"
+    topics = ("pdf", "html", "css", "markdown")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {"shared": [True, False], "fPIC": [True, False]}
+    default_options = {"shared": False, "fPIC": True}
+    implements = ["auto_shared_fpic"]
+    no_copy_source = True
+
+    def layout(self):
+        self.folders.source = "src"
+        self.folders.build = "build"
+
+    def source(self):
+        sources = self.conan_data["sources"][self.version]
+        get(self, **sources["archive"], strip_root=True)
+        download(
+            self,
+            **sources["cargo_lock"],
+            filename=os.path.join(self.source_folder, "Cargo.lock"),
+        )
+
+    def validate(self):
+        supported = {
+            "Linux": ("x86_64", "armv8"),
+            "Macos": ("x86_64", "armv8"),
+            "Windows": ("x86_64",),
+        }
+        os_name = str(self.settings.os)
+        architecture = str(self.settings.arch)
+        if os_name not in supported or architecture not in supported[os_name]:
+            raise ConanInvalidConfiguration(
+                f"Ironpress does not publish a native contract for {os_name}/{architecture}."
+            )
+        if cross_building(self):
+            raise ConanInvalidConfiguration(
+                "Ironpress requires a native Rust toolchain for the target platform."
+            )
+
+    @property
+    def _cargo_profile(self):
+        return "debug" if self.settings.build_type == "Debug" else "release"
+
+    @property
+    def _native_output(self):
+        return os.path.join(self.build_folder, "cargo", self._cargo_profile)
+
+    def build(self):
+        release = " --release" if self._cargo_profile == "release" else ""
+        target_dir = os.path.join(self.build_folder, "cargo")
+        manifest = os.path.join(self.source_folder, "Cargo.toml")
+        self.run(
+            f"cargo build --locked --manifest-path=\"{manifest}\""
+            " --package ironpress-ffi"
+            f" --target-dir=\"{target_dir}\"{release}"
+        )
+
+    def package(self):
+        copy(
+            self,
+            "LICENSE",
+            src=self.source_folder,
+            dst=os.path.join(self.package_folder, "licenses"),
+        )
+        include_dir = os.path.join(self.package_folder, "include")
+        copy(
+            self,
+            "ironpress.h",
+            src=os.path.join(self.source_folder, "bindings", "c", "include"),
+            dst=include_dir,
+        )
+        copy(
+            self,
+            "*.hpp",
+            src=os.path.join(self.source_folder, "bindings", "cpp", "include"),
+            dst=include_dir,
+        )
+
+        if self.options.shared:
+            self._package_shared_library()
+        else:
+            self._package_static_library()
+
+    def _package_shared_library(self):
+        if self.settings.os == "Windows":
+            copy(
+                self,
+                "ironpress_ffi.dll",
+                src=self._native_output,
+                dst=os.path.join(self.package_folder, "bin"),
+            )
+            copy(
+                self,
+                "ironpress_ffi.dll.lib",
+                src=self._native_output,
+                dst=os.path.join(self.package_folder, "lib"),
+            )
+            return
+
+        extension = "dylib" if self.settings.os == "Macos" else "so"
+        copy(
+            self,
+            f"libironpress_ffi.{extension}",
+            src=self._native_output,
+            dst=os.path.join(self.package_folder, "lib"),
+        )
+
+    def _package_static_library(self):
+        filename = (
+            "ironpress_ffi.lib"
+            if self.settings.os == "Windows"
+            else "libironpress_ffi.a"
+        )
+        copy(
+            self,
+            filename,
+            src=self._native_output,
+            dst=os.path.join(self.package_folder, "lib"),
+        )
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "Ironpress")
+
+        c_api = self.cpp_info.components["c"]
+        c_api.set_property("cmake_target_name", "Ironpress::C")
+        c_api.set_property("pkg_config_name", "ironpress")
+        c_api.libs = collect_libs(self)
+        if not self.options.shared:
+            c_api.system_libs = self._static_system_libraries()
+
+        cpp_api = self.cpp_info.components["cxx"]
+        cpp_api.set_property("cmake_target_name", "Ironpress::CXX")
+        cpp_api.requires = ["c"]
+
+    def _static_system_libraries(self):
+        if self.settings.os == "Windows":
+            return ["kernel32", "ntdll", "userenv", "ws2_32", "dbghelp"]
+        if self.settings.os == "Macos":
+            return ["iconv", "m"]
+        return ["dl", "pthread", "m"]

--- a/recipes/ironpress/all/test_package/CMakeLists.txt
+++ b/recipes/ironpress/all/test_package/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(ironpress_conan_consumers LANGUAGES C CXX)
+
+find_package(Ironpress REQUIRED CONFIG)
+
+add_executable(ironpress_c_consumer src/c_consumer.c)
+target_compile_features(ironpress_c_consumer PRIVATE c_std_11)
+target_link_libraries(ironpress_c_consumer PRIVATE Ironpress::C)
+
+add_executable(ironpress_cpp_consumer src/cpp_consumer.cpp)
+target_compile_features(ironpress_cpp_consumer PRIVATE cxx_std_17)
+target_link_libraries(ironpress_cpp_consumer PRIVATE Ironpress::CXX)

--- a/recipes/ironpress/all/test_package/conanfile.py
+++ b/recipes/ironpress/all/test_package/conanfile.py
@@ -1,0 +1,28 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class IronpressTestPackage(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            for executable in ("ironpress_c_consumer", "ironpress_cpp_consumer"):
+                if self.settings.os == "Windows":
+                    executable += ".exe"
+                path = os.path.join(self.cpp.build.bindir, executable)
+                self.run(path, env="conanrun")

--- a/recipes/ironpress/all/test_package/src/c_consumer.c
+++ b/recipes/ironpress/all/test_package/src/c_consumer.c
@@ -1,0 +1,21 @@
+#include "ironpress.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main(void) {
+    static const char source[] = "<h1>Installed with Conan</h1>";
+    const IronpressBytes html = {(const uint8_t *)source, sizeof(source) - 1};
+    IronpressBuffer *pdf = NULL;
+    IronpressError *error = NULL;
+
+    if (ironpress_html_to_pdf(html, &pdf, &error) != IRONPRESS_STATUS_OK) {
+        ironpress_error_free(&error);
+        return EXIT_FAILURE;
+    }
+    const int valid = ironpress_buffer_len(pdf) >= 4 &&
+                      memcmp(ironpress_buffer_data(pdf), "%PDF", 4) == 0;
+    ironpress_buffer_free(&pdf);
+    return valid ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/recipes/ironpress/all/test_package/src/cpp_consumer.cpp
+++ b/recipes/ironpress/all/test_package/src/cpp_consumer.cpp
@@ -1,0 +1,14 @@
+#include "ironpress.hpp"
+
+#include <cstdlib>
+#include <string_view>
+
+int main() {
+    const auto pdf = ironpress::html_to_pdf("<h1>Installed with Conan</h1>");
+    if (pdf.size() < 4 || pdf.data() == nullptr) {
+        return EXIT_FAILURE;
+    }
+    const auto prefix =
+        std::string_view(reinterpret_cast<const char *>(pdf.data()), 4);
+    return prefix == "%PDF" ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/recipes/ironpress/config.yml
+++ b/recipes/ironpress/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.6.0":
+    folder: all


### PR DESCRIPTION
### Summary

Changes to recipe: **ironpress/1.6.0**

#### Motivation

Ironpress exposes a stable C ABI and a header-only C++17 wrapper for its
in-process HTML, CSS, and Markdown to PDF renderer.

This adds a source-built Conan recipe for the native interfaces tracked in
gastongouron/ironpress#242.

#### Details

- Builds `ironpress-ffi` from the v1.6.0 source tag.
- Uses the immutable upstream `Cargo.lock` from the v1.6.0 release merge.
- Supports static and shared C/C++ consumers.
- Supports Linux x86_64/armv8, macOS x86_64/armv8, and Windows x86_64.
- Tests both C and C++ consumers by rendering and validating a PDF.

Local verification completed with Conan 2.31.1 on macOS armv8:

```text
conan create recipes/ironpress/all --version=1.6.0 --build=missing
conan create recipes/ironpress/all --version=1.6.0 --build=missing \
  -o 'ironpress/*:shared=True'
```

Both configurations built from fresh Conan homes and passed their C and C++
runtime tests.

This is a draft because the build uses Cargo 1.88 and downloads the locked
crate graph. Maintainer guidance on Cargo availability, network policy, and
third-party license notices would be welcome before marking it ready.

---

- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---

Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
