### PR TITLE
torqus: add recipe for 0.1.0

### DIFF
--- a/recipes/torqus/all/conandata.yml
+++ b/recipes/torqus/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.1.0":
+    url: "https://github.com/rysolis/torqus/archive/refs/tags/v0.1.0.tar.gz"
+    sha256: "01af7a335e2ce874b755909a814186ea961498d4c86b07d06bc422bf9105111c"

--- a/recipes/torqus/all/conanfile.py
+++ b/recipes/torqus/all/conanfile.py
@@ -1,0 +1,84 @@
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get
+import os
+
+required_conan_version = ">=2"
+
+
+class TorqusConan(ConanFile):
+    name = "torqus"
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/rysolis/torqus"
+    description = "A C++20 TFHE library (leveled arithmetic, gate bootstrapping)"
+    topics = ("tfhe", "fhe", "homomorphic-encryption", "cryptography", "header-only")
+
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    options = {
+        "use_mimalloc": [True, False],
+        "enable_simd": [True, False],
+        "enable_noise": [True, False],
+    }
+    default_options = {
+        "use_mimalloc": True,
+        "enable_simd": True,
+        "enable_noise": True,
+    }
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        # Optional even in the CMakeLists.txt sense (falls back to the
+        # system allocator if not found) -- only actually required() here
+        # because Conan needs to resolve/build it up front when the option
+        # is on, unlike CMake's own find_package(... QUIET) probe.
+        if self.options.use_mimalloc:
+            self.requires("mimalloc/3.3.2")
+
+    def package_id(self):
+        # Header-only, so settings (os/arch/compiler/build_type) don't
+        # affect the package -- nothing here gets compiled. Options are a
+        # different story: use_mimalloc is baked into the installed
+        # torqusConfig.cmake's find guard, and enable_simd/enable_noise
+        # become INTERFACE compile definitions exported via
+        # torqusTargets.cmake, so different option values really do
+        # produce different installed package content and must stay part
+        # of the package_id.
+        self.info.settings.clear()
+
+    def validate(self):
+        check_min_cppstd(self, 20)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["BUILD_TESTING"] = False
+        tc.variables["TORQUS_USE_MIMALLOC"] = bool(self.options.use_mimalloc)
+        tc.variables["TORQUS_ENABLE_SIMD"] = bool(self.options.enable_simd)
+        tc.variables["TFHE_ENABLE_NOISE"] = bool(self.options.enable_noise)
+        tc.generate()
+        CMakeDeps(self).generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "torqus")
+        self.cpp_info.set_property("cmake_target_name", "torqus::torqus")
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/torqus/all/test_package/CMakeLists.txt
+++ b/recipes/torqus/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.22)
+project(test_package LANGUAGES CXX)
+
+find_package(torqus REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE torqus::torqus)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)

--- a/recipes/torqus/all/test_package/conanfile.py
+++ b/recipes/torqus/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/torqus/all/test_package/test_package.cpp
+++ b/recipes/torqus/all/test_package/test_package.cpp
@@ -1,0 +1,22 @@
+#define TFHE_DISABLE_NOISE
+
+#include <cstdlib>
+#include <random>
+
+#include "primitive.hpp"
+#include "tfhe/ciphertext.hpp"
+#include "tfhe/params.hpp"
+#include "tfhe/runtime.hpp"
+
+using Torus = ModTorus<32>;
+using Lwe = lwe_params<tlwe_core_params<Torus, 630>, noise_params<15>>;
+
+int main() {
+  std::mt19937 eng{0};
+  Runtime<Lwe> runtime(eng);
+
+  TLWE<Torus, Lwe::n> ct = runtime.encrypt(Torus(1u, 4u));
+  Torus plaintext = runtime.decrypt(ct);
+
+  return plaintext == Torus(1u, 4u) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/recipes/torqus/config.yml
+++ b/recipes/torqus/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.1.0":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  torqus/ v0.1.0

#### Motivation

New recipe. [torqus](https://github.com/rysolis/torqus) is a header-only C++20 TFHE (fully homomorphic encryption) library, Apache-2.0 licensed.

#### Details

Header-only package installed via the upstream project's own CMake install() rules. Optional mimalloc dependency behind a use_mimalloc option (default on).
Tested locally with Conan 2.31.2: conan create . --version 0.1.0 --build=missing -s compiler.cppstd=20 succeeds, including test_package.