### PR TITLE
quill: add version 13.0.0

### DIFF
--- a/recipes/quill/all/conandata.yml
+++ b/recipes/quill/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "13.0.0":
+    url: "https://github.com/odygrd/quill/releases/download/v13.0.0/quill-13.0.0.zip"
+    sha256: "efb6ac9eea48633b05ebffae1dfee00fb065199bdc7686ea3353f77de09bbfa9"
   "12.1.0":
     url: "https://github.com/odygrd/quill/releases/download/v12.1.0/quill-12.1.0.zip"
     sha256: "7981344e651f8b27116783f0968d10b6da7c282800b669d9c20fcdb907e21343"

--- a/recipes/quill/config.yml
+++ b/recipes/quill/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "13.0.0":
+    folder: "all"
   "12.1.0":
     folder: "all"
   "12.0.0":


### PR DESCRIPTION
Summary
Add [Quill ](https://github.com/odygrd/quill)version 13.0.0

Motivation
Version bump - maintenance and bug fixes

Details
config.yml and conandata.yml point to the latest version

Changelog
https://github.com/odygrd/quill/blob/master/CHANGELOG.md#v1300

https://github.com/odygrd/quill/releases

https://github.com/odygrd/quill/compare/v12.1.0...v13.0.0