### PR TITLE
nanoarrow: link the vendored flatcc runtime with nanoarrow_ipc

### DIFF
--- a/recipes/nanoarrow/all/conanfile.py
+++ b/recipes/nanoarrow/all/conanfile.py
@@ -97,6 +97,10 @@ class NanoarrowConan(ConanFile):
         
         if self.options.with_ipc:
             self.cpp_info.components["nanoarrow_ipc"].libs = [f"nanoarrow_ipc{suffix}"]
+            if not self.options.shared:
+                # The static IPC library depends on the vendored flatcc runtime, which nanoarrow
+                # installs as a separate archive (libflatccrt.a) that consumers must link as well.
+                self.cpp_info.components["nanoarrow_ipc"].libs.append("flatccrt")
             self.cpp_info.components["nanoarrow_ipc"].requires = ["nanoarrow_core"]
             self.cpp_info.components["nanoarrow_ipc"].set_property("cmake_target_name", "nanoarrow::nanoarrow_ipc")
             if self.options.get_safe("with_zstd"):

--- a/recipes/nanoarrow/all/test_package/CMakeLists.txt
+++ b/recipes/nanoarrow/all/test_package/CMakeLists.txt
@@ -5,3 +5,7 @@ find_package(nanoarrow REQUIRED)
 
 add_executable(test_package test_package.c)
 target_link_libraries(test_package PRIVATE nanoarrow::nanoarrow)
+if(NANOARROW_TEST_WITH_IPC)
+  target_link_libraries(test_package PRIVATE nanoarrow::nanoarrow_ipc)
+  target_compile_definitions(test_package PRIVATE NANOARROW_TEST_WITH_IPC)
+endif()

--- a/recipes/nanoarrow/all/test_package/conanfile.py
+++ b/recipes/nanoarrow/all/test_package/conanfile.py
@@ -1,11 +1,11 @@
 from conan import ConanFile
 from conan.tools.build import can_run
-from conan.tools.cmake import cmake_layout, CMake
+from conan.tools.cmake import cmake_layout, CMake, CMakeToolchain
 import os
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    generators = "CMakeDeps", "VirtualRunEnv"
     test_type = "explicit"
 
     def requirements(self):
@@ -13,6 +13,11 @@ class TestPackageConan(ConanFile):
 
     def layout(self):
         cmake_layout(self)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["NANOARROW_TEST_WITH_IPC"] = bool(self.dependencies["nanoarrow"].options.with_ipc)
+        tc.generate()
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/nanoarrow/all/test_package/test_package.c
+++ b/recipes/nanoarrow/all/test_package/test_package.c
@@ -1,6 +1,10 @@
 #include <nanoarrow/nanoarrow.h>
 #include <stdio.h>
 
+#ifdef NANOARROW_TEST_WITH_IPC
+#include <nanoarrow/nanoarrow_ipc.h>
+#endif
+
 int main() {
     struct ArrowSchema schema;
     ArrowSchemaInit(&schema);
@@ -10,7 +14,25 @@ int main() {
         return 1;
     }
     ArrowSchemaRelease(&schema);
+
+#ifdef NANOARROW_TEST_WITH_IPC
+    /* Verifying a (bogus) header goes through the vendored flatcc runtime, so this
+     * only links when nanoarrow::nanoarrow_ipc carries libflatccrt. */
+    struct ArrowIpcDecoder decoder;
+    if (ArrowIpcDecoderInit(&decoder) != NANOARROW_OK) {
+        fprintf(stderr, "ArrowIpcDecoderInit failed\n");
+        return 1;
+    }
+    unsigned char bogus[8] = {0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00};
+    struct ArrowBufferView view;
+    view.data.as_uint8 = bogus;
+    view.size_bytes = (int64_t)sizeof(bogus);
+    struct ArrowError error;
+    (void)ArrowIpcDecoderVerifyHeader(&decoder, view, &error);
+    ArrowIpcDecoderReset(&decoder);
+    printf("nanoarrow ipc test passed\n");
+#endif
+
     printf("nanoarrow test passed\n");
     return 0;
 }
-


### PR DESCRIPTION
### Summary
Changes to recipe:  **nanoarrow/0.7.0**

#### Motivation
With `with_ipc=True` (static, the default), consumers that actually call the IPC decoder fail to link: nanoarrow vendors the flatcc runtime and installs it as a separate archive (`libflatccrt.a`, present in the package's `lib/`), but `package_info()` does not list it on the `nanoarrow_ipc` component. The recipe's `test_package` only links `nanoarrow::nanoarrow`, so CI never exercised the IPC component and the omission went unnoticed. Hit while packaging PlotJuggler's Arrow IPC parser (https://github.com/PlotJuggler/pj-official-plugins/pull/279), which currently works around it with a `find_library(flatccrt)`.

#### Details
- `package_info()`: append `flatccrt` to `nanoarrow_ipc.libs` for static builds (the shared `nanoarrow_ipc` already links it privately, and `package()` removes `*.a` for shared builds).
- `test_package`: link `nanoarrow::nanoarrow_ipc` and call `ArrowIpcDecoderInit`/`ArrowIpcDecoderVerifyHeader` when the tested package has `with_ipc=True` (passed through as a CMake variable). `ArrowIpcDecoderVerifyHeader` goes through the flatcc verifier, so this only links when the runtime is on the link line.

Tested locally with Conan 2 on Linux/gcc for `nanoarrow/0.7.0`:
- `-o with_ipc=True -o with_zstd=True` (static): builds, test_package links and runs the IPC path
- `-o with_ipc=True -o shared=True`: builds and runs
- default options: unchanged

Independent of #30738 (0.9.0 bump); the same fix applies to that version.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan
