### PR TITLE
[luajit] Add 2.1.1787165859

### DIFF
--- a/recipes/luajit/all/conandata.yml
+++ b/recipes/luajit/all/conandata.yml
@@ -1,8 +1,7 @@
-# INFO: Upstream moved to rolling releases and removed all tarballs.
-#       The Github mirror (https://github.com/LuaJIT/LuaJIT) does not match the checksums and have missing header files.
-#       Conan will consume the backup sources from the Conan Center Artifactory instead, which are the original tarballs (same checksums).
-#       Read the issue https://github.com/conan-io/conan-center-index/issues/25032 for more information.
 sources:
+  "2.1.1787165859":
+    url: "https://luajit.org/git/luajit.git"
+    commit: "1ee778a4e37122d8ca7d5733c590a47dafd6b15c"
   "2.1.0-beta3":
     url: "https://c3i.jfrog.io/artifactory/conan-center-backup-sources/1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3"
     sha256: "1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3"

--- a/recipes/luajit/all/conanfile.py
+++ b/recipes/luajit/all/conanfile.py
@@ -1,5 +1,5 @@
 from conan import ConanFile
-from conan.tools.scm import Version
+from conan.tools.scm import Git, Version
 from conan.tools.files import get, chdir, replace_in_file, copy, rmdir, export_conandata_patches, apply_conandata_patches
 from conan.tools.microsoft import is_msvc, MSBuildToolchain, VCVars, unix_path
 from conan.tools.layout import basic_layout
@@ -48,8 +48,14 @@ class LuajitConan(ConanFile):
             raise ConanInvalidConfiguration(f"{self.ref} is not supported by Mac M1. Please, try any version >=2.1")
 
     def source(self):
-        filename = f"LuaJIT-{self.version}.tar.gz"
-        get(self, **self.conan_data["sources"][self.version], destination=self.source_folder, filename=filename, strip_root=True)
+        source = self.conan_data["sources"][self.version]
+        if "commit" in source:
+            git = Git(self)
+            git.clone(url=source["url"], target=".")
+            git.checkout(source["commit"])
+        else:
+            filename = f"LuaJIT-{self.version}.tar.gz"
+            get(self, **source, destination=self.source_folder, filename=filename, strip_root=True)
 
     def generate(self):
         if is_msvc(self):

--- a/recipes/luajit/config.yml
+++ b/recipes/luajit/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "2.1.1787165859":
+    folder: "all"
   "2.1.0-beta3":
     folder: "all"


### PR DESCRIPTION
### Summary
Changes to recipe: **luajit/2.1.1787165859**

#### Motivation
LuaJIT uses rolling releases and recommends the `v2.1` branch for production use. The current Conan Center version is `2.1.0-beta3` from 2017.

The Conan Center version is 890 commits behind the current `v2.1` branch. This count uses `git rev-list --count 8271c643c21d1b2f344e339f559f2de6f3663191..1ee778a4e37122d8ca7d5733c590a47dafd6b15c`.

- Current Conan Center source: https://github.com/LuaJIT/LuaJIT/commit/8271c643c21d1b2f344e339f559f2de6f3663191
- Current `v2.1` source: https://github.com/LuaJIT/LuaJIT/commit/1ee778a4e37122d8ca7d5733c590a47dafd6b15c
- Rolling release policy: https://luajit.org/status.html

Fixes https://github.com/conan-io/conan-center-index/issues/30024

#### Details
- Adds `luajit/2.1.1787165859` from the immutable upstream commit.
- Uses the official LuaJIT Git repository because upstream does not publish release archives.
- Preserves `luajit/2.1.0-beta3` and its backup source.
- Passes `conan create` for static and shared builds on macOS 27 with Apple Clang 21 and Conan 2.31.2.
- Passes the existing `luajit/2.1.0-beta3` static and shared package tests.
- Improves the median time of a repeated JIT workload from 0.393376 s to 0.024020 s for the static package. This is 16.38 times faster.
- Improves the median time of the same workload from 0.406866 s to 0.025812 s for the shared package. This is 15.76 times faster.
- Uses Xcode Instruments Time Profiler for both measurements. All result values were identical.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Linked the related issue
- [x] Tested locally with a recent version of Conan
