### PR TITLE
mpdecimal: support Windows ARM64 with MSVC

### DIFF
--- a/recipes/mpdecimal/all/conanfile.py
+++ b/recipes/mpdecimal/all/conanfile.py
@@ -50,7 +50,7 @@ class MpdecimalConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def validate(self):
-        if is_msvc(self) and self.settings.arch not in ("x86", "x86_64"):
+        if is_msvc(self) and self.settings.arch not in ("x86", "x86_64", "armv8"):
             raise ConanInvalidConfiguration(
                 f"{self.ref} currently does not supported {self.settings.arch}. Contributions are welcomed")
         if self.options.cxx and Version(self.version) < "2.5.1":
@@ -122,8 +122,7 @@ class MpdecimalConan(ConanFile):
             with chdir(self, build_dir):
                 self.run("""nmake -f Makefile.vc {target} MACHINE={machine} DEBUG={debug} DLL={dll}""".format(
                     target=target,
-                    machine={"x86": "ppro", "x86_64": "x64"}[str(self.settings.arch)],
-                    # FIXME: else, use ansi32 and ansi64
+                    machine={"x86": "ppro", "x86_64": "x64", "armv8": "ansi64"}[str(self.settings.arch)],
                     debug="1" if self.settings.build_type == "Debug" else "0",
                     dll="1" if self.options.shared else "0",
                 ))


### PR DESCRIPTION
## Summary
Enable the mpdecimal Conan recipe for Windows ARM64 with MSVC by allowing `armv8` and mapping it to upstream's portable `MACHINE=ansi64` configuration.

## Scope
One commit changing only `recipes/mpdecimal/all/conanfile.py`.

## Evidence
- Native Cura Windows ARM64 proof consumed this exact recipe fix
- mpdecimal's ARM architecture gate cleared
- Final package proof completed successfully: https://github.com/yeelam-gordon/Cura/actions/runs/33557522209

This is a dependency prerequisite for Ultimaker/Cura#21773 and Ultimaker/cura-workflows#64.
