### PR TITLE
[xz_utils] Stop redirecting xz download from tukaani page

### DIFF
--- a/recipes/xz_utils/all/conandata.yml
+++ b/recipes/xz_utils/all/conandata.yml
@@ -1,10 +1,12 @@
 sources:
   "5.8.3":
     url:
-      - "https://tukaani.org/xz/xz-5.8.3.tar.xz"
+      - "https://github.com/tukaani-project/xz/releases/download/v5.8.3/xz-5.8.3.tar.xz"
+      - "https://codeberg.org/tukaani/xz/releases/download/v5.8.3/xz-5.8.3.tar.xz"
+      - "https://sourceforge.net/projects/lzmautils/files/xz-5.8.3.tar.xz"
     sha256: "fff1ffcf2b0da84d308a14de513a1aa23d4e9aa3464d17e64b9714bfdd0bbfb6"
   "5.4.5":
     url:
-      - "https://tukaani.org/xz/xz-5.4.5.tar.xz"
-      - "https://c3i.jfrog.io/artifactory/conan-center-backup-sources/da9dec6c12cf2ecf269c31ab65b5de18e8e52b96f35d5bcd08c12b43e6878803"
+      - "https://github.com/tukaani-project/xz/releases/download/v5.4.5/xz-5.4.5.tar.xz"
+      - "https://sourceforge.net/projects/lzmautils/files/xz-5.4.5.tar.xz"
     sha256: "da9dec6c12cf2ecf269c31ab65b5de18e8e52b96f35d5bcd08c12b43e6878803"


### PR DESCRIPTION
### Summary
Changes to recipe:  **xz_utils/5.8.3**

#### Motivation

close #30848
/cc @@dbartsevich 


#### Details

As explained by xz's author, https://github.com/conan-io/conan-center-index/issues/30848#issuecomment-5469461845, the official page does a redirect to Github and maybe the provider is blocking Github CI from downloading the source. 

This PR replaces to use Github as adds official mirrors as well. 

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
