### PR TITLE
immer: add version 0.9.1

### DIFF
--- a/recipes/immer/all/conandata.yml
+++ b/recipes/immer/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.9.1":
+    url: "https://github.com/arximboldi/immer/archive/v0.9.1.tar.gz"
+    sha256: "b18b92ba60ec3186dc36ef671d3c2ae542cbb63eb6dc0e258476c6111a67c971"
   "0.8.1":
     url: "https://github.com/arximboldi/immer/archive/v0.8.1.tar.gz"
     sha256: "de8411c84830864604bb685dc8f2e3c0dbdc40b95b2f6726092f7dcc85e75209"

--- a/recipes/immer/config.yml
+++ b/recipes/immer/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.9.1":
+    folder: all
   "0.8.1":
     folder: all
   "0.8.0":


### PR DESCRIPTION
### Specify library name and version: immer/0.9.1

Adds the latest immer release (0.9.1) to the recipe. No changes to `conanfile.py` were needed — immer's core library is still header-only and C++14 (the new experimental `immer/extra/persist` module added in 0.9.0 requires C++17, but it's gated behind the `immer_BUILD_PERSIST_TESTS` CMake option, off by default, and out of scope for this header-only package recipe).

---

- [x] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [x] I've used a [recent](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md#recipe-source-code) version of Conan.
- [x] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.

Local verification:
```
conan create . --version 0.9.1 --build=missing
```
Package built (134 `.hpp` files + LICENSE) and `test_package` compiled and ran successfully.