### PR TITLE
unicode-ranges: add recipe for 0.1.0

### DIFF
--- a/recipes/unicode-ranges/all/conandata.yml
+++ b/recipes/unicode-ranges/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.1.0":
+    url: "https://github.com/cristi1990an/unicode_ranges/archive/refs/tags/v0.1.0.tar.gz"
+    sha256: "0d18fbf45080644d4418f152ac02eda879aaa768f2c33a1787a1f337a68abcbe"

--- a/recipes/unicode-ranges/all/conanfile.py
+++ b/recipes/unicode-ranges/all/conanfile.py
@@ -1,0 +1,119 @@
+import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get, rmdir
+from conan.tools.scm import Version
+
+
+required_conan_version = ">=2.20"
+
+
+class UnicodeRangesConan(ConanFile):
+    name = "unicode-ranges"
+    description = "C++23 validated UTF-8, UTF-16, and UTF-32 text types and algorithms"
+    license = "MIT OR Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/cristi1990an/unicode_ranges"
+    topics = ("unicode", "utf-8", "utf-16", "utf-32", "text")
+    package_type = "static-library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "fPIC": [True, False],
+        "with_icu": [True, False],
+    }
+    default_options = {
+        "fPIC": True,
+        "with_icu": False,
+    }
+    options_description = {
+        "with_icu": "Enable ICU-backed locale-aware casing",
+    }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def requirements(self):
+        if self.options.with_icu:
+            self.requires("icu/78.2")
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.24 <5]")
+
+    def validate(self):
+        check_min_cppstd(self, 23)
+
+        minimum_versions = {
+            "gcc": "14",
+            "clang": "22",
+            "msvc": "195",
+        }
+        compiler = str(self.settings.compiler)
+        minimum = minimum_versions.get(compiler)
+        if minimum and Version(self.settings.compiler.version) < minimum:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires {compiler} {minimum} or newer"
+            )
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        dependencies = CMakeDeps(self)
+        dependencies.generate()
+
+        toolchain = CMakeToolchain(self)
+        toolchain.cache_variables["UTF8_RANGES_BUILD_TESTS"] = False
+        toolchain.cache_variables["UTF8_RANGES_BUILD_BENCHMARKS"] = False
+        toolchain.cache_variables["UTF8_RANGES_ENABLE_ICU"] = bool(
+            self.options.with_icu
+        )
+        toolchain.cache_variables["CMAKE_FIND_PACKAGE_PREFER_CONFIG"] = True
+        if self.options.get_safe("fPIC") is not None:
+            toolchain.cache_variables["CMAKE_POSITION_INDEPENDENT_CODE"] = bool(
+                self.options.fPIC
+            )
+        toolchain.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(
+            self,
+            "LICENSE*",
+            src=self.source_folder,
+            dst=os.path.join(self.package_folder, "licenses"),
+        )
+        copy(
+            self,
+            "THIRD_PARTY_NOTICES.md",
+            src=self.source_folder,
+            dst=os.path.join(self.package_folder, "licenses"),
+        )
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "share"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "unicode_ranges")
+        self.cpp_info.set_property(
+            "cmake_target_name", "unicode_ranges::unicode_ranges"
+        )
+        self.cpp_info.libs = ["unicode_ranges"]
+        self.cpp_info.bindirs = []
+
+        if self.settings.os in ("Linux", "FreeBSD"):
+            self.cpp_info.system_libs.append("pthread")
+
+        if self.options.with_icu:
+            self.cpp_info.defines.append("UTF8_RANGES_ENABLE_ICU=1")
+            self.cpp_info.requires.extend(("icu::icu-uc", "icu::icu-i18n"))

--- a/recipes/unicode-ranges/all/test_package/CMakeLists.txt
+++ b/recipes/unicode-ranges/all/test_package/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.24)
+
+project(test_package LANGUAGES CXX)
+
+find_package(unicode_ranges REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_23)
+target_link_libraries(${PROJECT_NAME} PRIVATE unicode_ranges::unicode_ranges)
+
+if(MSVC)
+    target_compile_options(${PROJECT_NAME} PRIVATE /utf-8 /bigobj)
+endif()

--- a/recipes/unicode-ranges/all/test_package/conanfile.py
+++ b/recipes/unicode-ranges/all/test_package/conanfile.py
@@ -1,0 +1,30 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.24 <5]")
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            executable = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(executable, env="conanrun")

--- a/recipes/unicode-ranges/all/test_package/test_package.cpp
+++ b/recipes/unicode-ranges/all/test_package/test_package.cpp
@@ -1,0 +1,13 @@
+#include "unicode_ranges_all.hpp"
+
+#include <string_view>
+
+using namespace unicode_ranges;
+
+int main()
+{
+    auto text = utf8_string::from_bytes(std::string_view{ "Gr\xC3\xBC\xC3\x9F" });
+    if (!text)
+        return 1;
+    return text->to_utf16().char_count() == text->char_count() ? 0 : 2;
+}

--- a/recipes/unicode-ranges/config.yml
+++ b/recipes/unicode-ranges/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.1.0":
+    folder: all


### PR DESCRIPTION
## Summary

Adds the first Conan Center recipe for `unicode-ranges/0.1.0`.

- Packages the upstream `v0.1.0` release archive as a static C++23 library.
- Exposes `unicode_ranges::unicode_ranges` through CMakeDeps.
- Provides opt-in ICU integration through `with_icu`.
- Includes an independent test package that compiles, links, and runs against the packaged target.

## Local validation

```text
conan create recipes/unicode-ranges/all --version=0.1.0 \
  --build=missing -s build_type=Release -s compiler.cppstd=23 \
  -o "&:with_icu=False"
```

Validated successfully with Conan 2.31.1 and MSVC 19.51. The upstream repository also tests GCC 14 and both ICU configurations in its dedicated Conan workflow.
