### PR TITLE
libheif: add version 1.23.3

### DIFF
--- a/recipes/libheif/all/conandata.yml
+++ b/recipes/libheif/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
-  "1.23.2":
-    url: "https://github.com/strukturag/libheif/releases/download/v1.23.2/libheif-1.23.2.tar.gz"
-    sha256: "8bd5d41d19dc84536d118b04774709f244df6104ef66d623dad5fa4650143405"
+  "1.23.3":
+    url: "https://github.com/strukturag/libheif/releases/download/v1.23.3/libheif-1.23.3.tar.gz"
+    sha256: "11c1179e0e4bec33624b87f22ec42c1e993a40d946d44d26f9c431cf1456a863"
   "1.16.2":
     # keeping this version while it is still referenced by other recipes
     url: "https://github.com/strukturag/libheif/releases/download/v1.16.2/libheif-1.16.2.tar.gz"

--- a/recipes/libheif/config.yml
+++ b/recipes/libheif/config.yml
@@ -1,5 +1,5 @@
 versions:
-  "1.23.2":
+  "1.23.3":
     folder: all
   "1.16.2":
     folder: all


### PR DESCRIPTION
fixes #30894

Summary
Changes to recipe: **libheif/1.23.3**

Motivation
Even more security-related fixes introduced in the latest release of libheif
Quoting Dirk Farin:
> One of the fixed issues is rated critical, so all users are strongly advised to upgrade.

Details
Added latest (1.23.3) version of libheif available from the official release source

 Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
 Checked that this PR is not a duplicate: https://github.com/conan-io/conan-center-index/discussions/24240
 If this is a bug fix, please link related issue or provide bug details
 Tested locally with at least one configuration using a recent version of Conan
Add a 👍 reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!