### PR TITLE
[redis-plus-plus] Disable werror by default to avoid GCC-16 error

### DIFF
--- a/recipes/redis-plus-plus/all/conanfile.py
+++ b/recipes/redis-plus-plus/all/conanfile.py
@@ -2,7 +2,7 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir
+from conan.tools.files import apply_conandata_patches, copy, export_conandata_patches, get, rmdir, replace_in_file
 import os
 
 required_conan_version = ">=2.1"
@@ -52,6 +52,7 @@ class RedisPlusPlusConan(ConanFile):
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
         apply_conandata_patches(self)
+        replace_in_file(self, os.path.join(self.source_folder, "CMakeLists.txt"), "-Werror", "")
 
     def generate(self):
         tc = CMakeToolchain(self)


### PR DESCRIPTION
### Summary
Changes to recipe:  **redis-plus-plus/1.3.15**

#### Motivation

close #30798

#### Details

I can reproduce the reported scenario: When building redis-plus-plus/1.3.15 with GCC 16, I have the following error:

```
/home/conan/.conan2/p/b/redis6c5fffd311a1b/b/src/src/sw/redis++/reply.h: In constructor ‘sw::redis::ParseError::ParseError(const std::string&, const redisReply&)’:
/home/conan/.conan2/p/b/redis6c5fffd311a1b/b/src/src/sw/redis++/reply.h:54:60: error: ‘<unknown>’ may be used uninitialized [-Werror=maybe-uninitialized]
   54 |             const redisReply &reply) : ProtoError(_err_info(expect_type, reply)) {}
```

[redis-plus-plus-1.3.15-linux-amd64-gcc16-release-static.log](https://github.com/user-attachments/files/31748521/redis-plus-plus-1.3.15-linux-amd64-gcc16-release-static.log)


After applying this patch, by removing multiple declarations of Werror from CMakeLists, I can build without errors:


[redis-plus-plus-1.3.15-linux-amd64-gcc16-release-static-patched.log](https://github.com/user-attachments/files/31748520/redis-plus-plus-1.3.15-linux-amd64-gcc16-release-static-patched.log)


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
