### PR TITLE
[xkbcommon] Configure default locale and config for Linux

### DIFF
--- a/recipes/xkbcommon/all/conanfile.py
+++ b/recipes/xkbcommon/all/conanfile.py
@@ -84,6 +84,9 @@ class XkbcommonConan(ConanFile):
         tc.project_options["build.pkg_config_path"] = self.generators_folder
         if self.settings.os == "Android":
             tc.project_options["enable-tools"] = False
+        elif self.settings.os == "Linux":
+            tc.project_options["x-locale-root"] = "/usr/share/X11/locale"
+            tc.project_options["xkb-config-root"] = "/usr/share/X11/xkb"
         tc.generate()
 
         pkg_config_deps = PkgConfigDeps(self)

--- a/recipes/xkbcommon/all/conanfile.py
+++ b/recipes/xkbcommon/all/conanfile.py
@@ -86,7 +86,8 @@ class XkbcommonConan(ConanFile):
             tc.project_options["enable-tools"] = False
         elif self.settings.os == "Linux":
             tc.project_options["x-locale-root"] = "/usr/share/X11/locale"
-            tc.project_options["xkb-config-unversioned-extensions-path"] = "/usr/share/xkeyboard-config.d"
+            if Version(self.version) >= "1.13.0":
+                tc.project_options["xkb-config-unversioned-extensions-path"] = "/usr/share/xkeyboard-config.d"
         tc.generate()
 
         pkg_config_deps = PkgConfigDeps(self)

--- a/recipes/xkbcommon/all/conanfile.py
+++ b/recipes/xkbcommon/all/conanfile.py
@@ -85,7 +85,8 @@ class XkbcommonConan(ConanFile):
         if self.settings.os == "Android":
             tc.project_options["enable-tools"] = False
         elif self.settings.os == "Linux":
-            tc.project_options["x-locale-root"] = "/usr/share/X11/locale"            
+            tc.project_options["x-locale-root"] = "/usr/share/X11/locale"
+            tc.project_options["xkb-config-unversioned-extensions-path"] = "/usr/share/xkeyboard-config.d"
         tc.generate()
 
         pkg_config_deps = PkgConfigDeps(self)

--- a/recipes/xkbcommon/all/conanfile.py
+++ b/recipes/xkbcommon/all/conanfile.py
@@ -84,7 +84,7 @@ class XkbcommonConan(ConanFile):
         tc.project_options["build.pkg_config_path"] = self.generators_folder
         if self.settings.os == "Android":
             tc.project_options["enable-tools"] = False
-        elif self.settings.os == "Linux":
+        elif self.settings.os in ["Linux", "FreeBSD"]:
             tc.project_options["x-locale-root"] = "/usr/share/X11/locale"
             if Version(self.version) >= "1.13.0":
                 tc.project_options["xkb-config-unversioned-extensions-path"] = "/usr/share/xkeyboard-config.d"

--- a/recipes/xkbcommon/all/conanfile.py
+++ b/recipes/xkbcommon/all/conanfile.py
@@ -85,8 +85,7 @@ class XkbcommonConan(ConanFile):
         if self.settings.os == "Android":
             tc.project_options["enable-tools"] = False
         elif self.settings.os == "Linux":
-            tc.project_options["x-locale-root"] = "/usr/share/X11/locale"
-            tc.project_options["xkb-config-root"] = "/usr/share/X11/xkb"
+            tc.project_options["x-locale-root"] = "/usr/share/X11/locale"            
         tc.generate()
 
         pkg_config_deps = PkgConfigDeps(self)


### PR DESCRIPTION
### Summary
Changes to recipe:  **xkbcommon/1.13.1**

#### Motivation

When building projects like xkbcommon from source on linux, it's usually expected to install all artifacts, like libraries, config and headers, under /usr. As commented in both #12883 #29066 cases, the configuration path is hardcoded in the library, making it incompatible by default when consuming from Conan Center.

This PR enforces the use of the most common path used on Linux for both path. Those places are not random; they are documented in xkbcommon documentation: https://xkbcommon.org/doc/current/group__include-path.html

fixes #12883
fixes #29066

#### Details

When building the current xkbcommon from Conan Center, and trying to build the code exposed in #29066, we have the following error in the test package:

```
xkbcommon/1.13.1 (test package): Running CMake.build()
xkbcommon/1.13.1 (test package): RUN: cmake --build "/home/conan/project/all/test_package/build/gcc-13-x86_64-gnu17-release" --verbose -- -j2
Change Dir: '/home/conan/project/all/test_package/build/gcc-13-x86_64-gnu17-release'

Run Build Command(s): /usr/bin/ninja -v -j2
[1/2] /usr/bin/g++  -isystem /home/conan/.conan2/p/b/xkbco5efcff19fccbf/p/include -m64 -O3 -DNDEBUG -std=gnu++17 -MD -MT CMakeFiles/test_package.dir/test_package.cpp.o -MF CMakeFiles/test_package.dir/test_package.cpp.o.d -o CMakeFiles/test_package.dir/test_package.cpp.o -c /home/conan/project/all/test_package/test_package.cpp
[2/2] : && /usr/bin/g++ -m64 -O3 -DNDEBUG -m64 CMakeFiles/test_package.dir/test_package.cpp.o -o test_package -L/home/conan/.conan2/p/b/xkbco5efcff19fccbf/p/lib -Wl,-rpath,/home/conan/.conan2/p/b/xkbco5efcff19fccbf/p/lib  /home/conan/.conan2/p/b/xkbco5efcff19fccbf/p/lib/libxkbcommon.a && :



======== Testing the package: Executing test ========
xkbcommon/1.13.1 (test package): Running test()
xkbcommon/1.13.1 (test package): RUN: ./test_package
Querying compose table for locale: en_US.UTF-8
xkbcommon: ERROR: [XKB-679] No Compose file for locale "en_US.UTF-8": failed to use fallback "en_US.UTF-8"
xkbcommon: ERROR: [XKB-679] couldn't find a Compose file for locale "en_US.UTF-8" (mapped to "en_US.UTF-8")
Failed to create compose table

ERROR: xkbcommon/1.13.1 (test package): Error in test() method, line 27
	self.run(cmd, env="conanrun")
	ConanException: Error 1 while executing
```

It's not possible to find the locale for "en_US.UTF-8", which is configured to look into the package folder.


After applying this current patch, it's possible to see the following setup on meson:


```
Directories
    prefix                                : /
    bindir                                : bin
    libdir                                : lib
    datadir                               : share
    xkb-config-root                       : /usr/share/X11/xkb
    xkb-legacy-root                       : /usr/share/X11/xkb
    xkb-config-unversioned-extensions-path: /share/xkeyboard-config.d
    xkb-config-versioned-extensions-path  : /usr/share/X11/xkb.d
    xkb-config-extra-path                 : /etc/xkb
    xlocaledir                            : /usr/share/X11/locale
```

The full build log, including the modified test package passing, can be checked here: [xkbcommon-1.13.1-linux-amd64-gcc13-release-static.log](https://github.com/user-attachments/files/31793236/xkbcommon-1.13.1-linux-amd64-gcc13-release-static.log)


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [ ] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
