### PR TITLE
Add Au 0.6.0 to conan

### DIFF
--- a/recipes/au/all/conandata.yml
+++ b/recipes/au/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "0.5.0":
-    url: "https://github.com/aurora-opensource/au/releases/download/0.5.0/au-0.5.0.tar.gz"
-    sha256: "69d3510df7880dc5a109d751b8afc38b2adbf4af2e829b569b19cbdd970fee5e"
+  "0.6.0":
+    url: "https://github.com/aurora-opensource/au/releases/download/0.6.0/au-0.6.0.tar.gz"
+    sha256: "e03aba27139b1e090b520945e62fc3ba2bf9128a096d68576eaf301970d5fb10"

--- a/recipes/au/config.yml
+++ b/recipes/au/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "0.5.0":
+  "0.6.0":
     folder: all


### PR DESCRIPTION
### Summary

Changes to recipe:  **au** (add 0.6.0)

#### Motivation

There is a significant new Au release!  See [release notes].  This brings CUDA support, vectors/matrices and Eigen support, unit literals, better `Constant` and `Magnitude` arithmetic, and more.

[release notes]: https://github.com/aurora-opensource/au/releases/tag/0.6.0

#### Details

Just a simple version bump for the library.

To test these changes:

```sh
cd recipes/au
conan create all/conanfile.py --version=0.6.0
```

This ran with no errors and prodcued the expected output.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!