### PR TITLE
[ffmpeg] fix missing system libs for avformat on Windows

### DIFF
--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -870,7 +870,9 @@ class FFMpegConan(ConanFile):
                 avdevice.system_libs = ["ole32", "psapi", "strmiids", "uuid", "oleaut32", "shlwapi", "gdi32", "vfw32"]
             avutil.system_libs = ["user32", "bcrypt"]
             if self.options.avformat:
-                avformat.system_libs = ["secur32"]
+                avformat.system_libs = ["secur32", "ws2_32"]
+                if not self.options.with_ssl:
+                    avformat.system_libs.extend(["crypt32", "ncrypt"])
         elif is_apple_os(self):
             if self.options.avdevice:
                 avdevice.frameworks = ["CoreFoundation", "Foundation", "CoreGraphics"]

--- a/recipes/ffmpeg/all/conanfile.py
+++ b/recipes/ffmpeg/all/conanfile.py
@@ -870,9 +870,11 @@ class FFMpegConan(ConanFile):
                 avdevice.system_libs = ["ole32", "psapi", "strmiids", "uuid", "oleaut32", "shlwapi", "gdi32", "vfw32"]
             avutil.system_libs = ["user32", "bcrypt"]
             if self.options.avformat:
-                avformat.system_libs = ["secur32", "ws2_32"]
+                avformat.system_libs = ["ws2_32"]
                 if not self.options.with_ssl:
-                    avformat.system_libs.extend(["crypt32", "ncrypt"])
+                    avformat.system_libs.append("secur32")
+                    if Version(self.version) >= "8.0":
+                        avformat.system_libs.extend(["crypt32", "ncrypt"])
         elif is_apple_os(self):
             if self.options.avdevice:
                 avdevice.frameworks = ["CoreFoundation", "Foundation", "CoreGraphics"]


### PR DESCRIPTION
### Summary
Changes to recipe:  **ffmpeg/8.1.2**

#### Motivation

fixes #30648
/cc @hollykbuck

#### Details

When building ffmpeg on Windows with `avformat=True` (default is enabled) and `with_ssl=False` (default is openssl), the linking stage during the test package fails with:

```
avformat.lib(network.o) : error LNK2019: unresolved external symbol __imp_accept referenced in function ff_accept
avformat.lib(network.o) : error LNK2019: unresolved external symbol __imp_bind referenced in function ff_listen
avformat.lib(tcp.o) : error LNK2001: unresolved external symbol __imp_bind
avformat.lib(udp.o) : error LNK2001: unresolved external symbol __imp_bind
```

See the full build log: [ffmpeg-8.1.2-windows-amd64-msvc194-release-static.log](https://github.com/user-attachments/files/31825090/ffmpeg-8.1.2-windows-amd64-msvc194-release-static.log)

The Conan Center CI never hits this because it uses `with_ssl="openssl"`, and OpenSSL declares `ws2_32` and `crypt32` as system libs, so avformat gets a ride from those transitive libraries.

However, when using `with_ssl=False`, that free ride disappears, exposing that `ws2_32` was never actually declared for avformat/avutil in the recipe. As a result, test_package fails with the reported error.

Also, disabling `openssl` flips the ffmpeg [schannel](https://github.com/FFmpeg/FFmpeg/blob/n8.1.2/configure#L4047) fallback feature. Once enabled, [schannel needs secur32, ncrypt, and crypt32](https://github.com/FFmpeg/FFmpeg/blob/n8.1.2/configure#L7557), explaning those missing symbols.

After applying the current patch from commit f575128dfbb767bafb004ea2f88e24514249c562, I can build without ssl with success:

* [ffmpeg-8.1.2-windows-amd64-msvc194-release-static-patched.log](https://github.com/user-attachments/files/31825112/ffmpeg-8.1.2-windows-amd64-msvc194-release-static-patched.log)


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
