### PR TITLE
mimalloc: add 3.5.1

### DIFF
--- a/recipes/mimalloc/all/conandata.yml
+++ b/recipes/mimalloc/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.5.1":
+    url: "https://github.com/microsoft/mimalloc/archive/v3.5.1.tar.gz"
+    sha256: "2602daad9b64b213a8835dee6fadda96d2081c0171bfcd3fb2db39bdc669d6b3"
   "3.3.2":
     url: "https://github.com/microsoft/mimalloc/archive/v3.3.2.tar.gz"
     sha256: "ca02384e007f46950598500dfaebde5ff9948c1d231f5a81b058799afa64bbbb"

--- a/recipes/mimalloc/config.yml
+++ b/recipes/mimalloc/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.5.1":
+    folder: all
   "3.3.2":
     folder: all
   "2.2.4":


### PR DESCRIPTION
### Summary
Changes to recipe: **mimalloc/3.5.1**

#### Motivation
Add the latest upstream release of mimalloc: https://github.com/microsoft/mimalloc/releases/tag/v3.5.1

#### Details
- Add version 3.5.1 to `config.yml` and `conandata.yml`.
- Build and run package test successfully on macOS.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
