### PR TITLE
miniaudio: add 0.11.25

### DIFF
--- a/recipes/miniaudio/all/conandata.yml
+++ b/recipes/miniaudio/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "0.11.25":
+    url: "https://github.com/mackron/miniaudio/archive/0.11.25.tar.gz"
+    sha256: "b900edcffe979816e2560a0580b9b1216d674b4f17fbadeca8f777a7f8ab0274"
   "0.11.22":
     url: "https://github.com/mackron/miniaudio/archive/0.11.22.tar.gz"
     sha256: "bcb07bfb27e6fa94d34da73ba2d5642d4940b208ec2a660dbf4e52e6b7cd492f"

--- a/recipes/miniaudio/config.yml
+++ b/recipes/miniaudio/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "0.11.25":
+    folder: all
   "0.11.22":
     folder: all
   "0.11.21":


### PR DESCRIPTION
### Summary
Changes to recipe: **miniaudio/0.11.25**

#### Motivation
Add the latest upstream release of miniaudio: https://github.com/mackron/miniaudio/releases/tag/0.11.25

#### Details
- Add version 0.11.25 to `config.yml` and `conandata.yml`.
- Build and run package test successfully on macOS (header-only and compiled).

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
