### PR TITLE
librats: add recipe (2.3.7)

### DIFF
--- a/recipes/librats/all/conandata.yml
+++ b/recipes/librats/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "2.3.7":
+    url: "https://github.com/librats/librats/archive/refs/tags/2.3.7.tar.gz"
+    sha256: "f576c0fb39a48553d52cfc111d9dfbc5e0340fcca2ed0d1d310d711228cd6aa0"

--- a/recipes/librats/all/conanfile.py
+++ b/recipes/librats/all/conanfile.py
@@ -1,0 +1,131 @@
+import os
+
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, get
+from conan.tools.scm import Version
+
+required_conan_version = ">=2.0"
+
+
+class LibratsConan(ConanFile):
+    name = "librats"
+    description = (
+        "C++17 peer-to-peer networking library: encrypted P2P (Noise XX), "
+        "DHT/mDNS discovery, NAT traversal (STUN/UPnP/NAT-PMP), GossipSub "
+        "pub/sub, file transfer, optional BitTorrent."
+    )
+    # librats itself is MIT. It embeds adapted single-primitive crypto sources
+    # and, for Android API < 24, a getifaddrs() shim, each keeping its own
+    # notice; see THIRD_PARTY_NOTICES.md upstream. For non-Android targets the
+    # BSD-2/1-Clause parts are not compiled and this reduces to MIT AND BSD-3-Clause.
+    license = "MIT AND BSD-3-Clause AND BSD-2-Clause AND BSD-1-Clause"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/librats/librats"
+    topics = ("p2p", "networking", "dht", "noise-protocol", "gossipsub", "bittorrent", "nat-traversal")
+
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "search_features": [True, False],   # BitTorrent subsystem
+        "storage": [True, False],           # distributed key/value store
+        "bindings": [True, False],          # C ABI (rats_*)
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "search_features": False,
+        "storage": False,
+        "bindings": True,
+    }
+    implements = ["auto_shared_fpic"]
+
+    @property
+    def _min_cppstd(self):
+        return 17
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "gcc": "8",
+            "clang": "7",
+            "apple-clang": "12",
+            "msvc": "192",
+        }
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def validate(self):
+        check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not fully support."
+            )
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        # Library kind is driven by Conan's `shared` option.
+        tc.cache_variables["RATS_SHARED_LIBRARY"] = bool(self.options.shared)
+        tc.cache_variables["RATS_STATIC_LIBRARY"] = not bool(self.options.shared)
+        tc.cache_variables["RATS_BUILD_TESTS"] = False
+        tc.cache_variables["RATS_BUILD_CLIENT"] = False
+        tc.cache_variables["RATS_BUILD_EXAMPLES"] = False
+        tc.cache_variables["RATS_BINDINGS"] = bool(self.options.bindings)
+        tc.cache_variables["RATS_SEARCH_FEATURES"] = bool(self.options.search_features)
+        tc.cache_variables["RATS_STORAGE"] = bool(self.options.storage)
+        tc.cache_variables["RATS_INSTALL"] = True
+        # The upstream CMakeLists derives the version from `git describe`;
+        # a source tarball has no .git, so feed it explicitly.
+        tc.cache_variables["RATS_VERSION_OVERRIDE"] = str(self.version)
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE",
+             src=self.source_folder,
+             dst=os.path.join(self.package_folder, "licenses"))
+        # Notices of the adapted third-party sources listed in THIRD_PARTY_NOTICES.md.
+        copy(self, "*.LICENSE",
+             src=os.path.join(self.source_folder, "licenses"),
+             dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "rats")
+        self.cpp_info.set_property("cmake_target_name", "rats::rats")
+        self.cpp_info.libs = ["rats"]
+        # One root: headers spell their own path in full ("librats/node/node.h"),
+        # so include/ alone is enough and nothing generic lands on the consumer's
+        # include path. Mirrors INSTALL_INTERFACE in the upstream CMakeLists.
+        self.cpp_info.includedirs = ["include"]
+
+        # No defines are repeated here on purpose. RATS_SEARCH_FEATURES,
+        # RATS_STORAGE and — for the Windows DLL — RATS_IMPORT_DLL are baked into
+        # the installed librats/util/features.h by the build itself, so the headers
+        # describe the package they came from and cannot disagree with it. That
+        # matters for Conan specifically: CMakeDeps generates its own config from
+        # this method and never reads the project's ratsConfig.cmake, so anything
+        # declared only in CMakeLists.txt would otherwise have to be mirrored here
+        # and kept in sync by hand.
+
+        if self.settings.os in ("Linux", "FreeBSD"):
+            self.cpp_info.system_libs = ["pthread"]
+        elif self.settings.os == "Windows":
+            self.cpp_info.system_libs = ["ws2_32", "iphlpapi", "bcrypt", "advapi32"]
+        elif self.settings.os == "Android":
+            # Android NDK provides log/dl; threading is in libc.
+            self.cpp_info.system_libs = ["log"]

--- a/recipes/librats/all/test_package/CMakeLists.txt
+++ b/recipes/librats/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package LANGUAGES CXX)
+
+find_package(rats REQUIRED CONFIG)
+
+add_executable(test_package test_package.cpp)
+target_link_libraries(test_package PRIVATE rats::rats)
+target_compile_features(test_package PRIVATE cxx_std_17)

--- a/recipes/librats/all/test_package/conanfile.py
+++ b/recipes/librats/all/test_package/conanfile.py
@@ -1,0 +1,27 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import CMake, cmake_layout
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/librats/all/test_package/test_package.cpp
+++ b/recipes/librats/all/test_package/test_package.cpp
@@ -1,0 +1,61 @@
+/**
+ * Smoke test for the packaged library: compiles against the installed headers and
+ * links against the installed binary.
+ *
+ * Its real job is to be the canary for the shared build. On MSVC a public class
+ * that was never marked RATS_API (src/util/rats_export.h) is simply absent from
+ * the DLL — it links fine in the static build and fails only at a downstream
+ * consumer. So this touches one out-of-line member of each exported type rather
+ * than just constructing a Node.
+ *
+ * Nothing here opens a socket: subsystems are attached but the node is never
+ * started, which is enough to force the linker to resolve their symbols.
+ */
+
+#include <librats/node/node.h>
+#include <librats/subsystems/dht_discovery.h>
+#include <librats/subsystems/file_transfer.h>
+#include <librats/subsystems/mdns_discovery.h>
+#include <librats/subsystems/message_json.h>
+#include <librats/subsystems/peer_exchange.h>
+#include <librats/subsystems/ping_service.h>
+#include <librats/subsystems/port_mapping_service.h>
+#include <librats/subsystems/pubsub.h>
+#include <librats/subsystems/reconnection.h>
+#include <librats/util/json.h>
+
+#include <cstdio>
+#include <memory>
+
+int main() {
+    librats::NodeConfig config;
+    config.listen_port = 0;  // ephemeral
+    librats::Node node(config);
+
+    // Every opt-in subsystem, so a missing export on any of them breaks the build.
+    node.add_subsystem(std::make_unique<librats::DhtDiscovery>(librats::DhtDiscovery::Config{}));
+    node.add_subsystem(std::make_unique<librats::MdnsDiscovery>());
+    node.add_subsystem(std::make_unique<librats::PubSub>());
+    node.add_subsystem(std::make_unique<librats::FileTransfer>("."));
+    node.add_subsystem(std::make_unique<librats::MessageJson>());
+    node.add_subsystem(std::make_unique<librats::PingService>());
+    node.add_subsystem(std::make_unique<librats::PeerExchange>());
+    node.add_subsystem(std::make_unique<librats::PortMappingService>());
+    node.add_subsystem(std::make_unique<librats::ReconnectionService>());
+
+    // Value types that cross the boundary by value.
+    const auto address = librats::Address::parse("127.0.0.1:4242");
+    if (!address || !address->is_valid()) {
+        std::fputs("librats: Address::parse failed\n", stderr);
+        return 1;
+    }
+
+    const librats::Json doc = librats::Json::parse(R"({"ok":true})");
+
+    std::printf("librats peer id: %s  peers: %zu  addr: %s  json: %s\n",
+                node.local_id().short_hex().c_str(),
+                node.peer_count(),
+                address->to_string().c_str(),
+                doc.dump().c_str());
+    return 0;
+}

--- a/recipes/librats/config.yml
+++ b/recipes/librats/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "2.3.7":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe: **librats/2.3.7**

#### Motivation
Adds a new recipe for [librats](https://github.com/librats/librats), a C++ peer-to-peer networking library: encrypted transport (Noise_XX over TCP or reliable UDP), peer discovery (DHT/BEP 5, mDNS), NAT traversal (STUN, UPnP, NAT-PMP, hole punching, circuit relay), GossipSub pub/sub, file transfer and an optional BitTorrent client.

The library is not yet available in ConanCenter, so consumers currently have to vendor it or install it from source or vcpkg. It is MIT-licensed, actively maintained, and builds with plain CMake, which makes it a good fit for a ConanCenter recipe.

#### Details
New recipe `recipes/librats/all` (`conanfile.py`, `conandata.yml`, `config.yml`)
plus `test_package`.

Tested locally with Conan 2.x on Linux/GCC (`gcc 15`, `libstdc++11`, `cppstd 17`)
for `shared=True/False` and for the default and all-features-on option sets.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a 👍 reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!