### PR TITLE
(#new) copacabana/7.0: add recipe

### DIFF
--- a/recipes/copacabana/all/conandata.yml
+++ b/recipes/copacabana/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "7.0":
+    url: "https://github.com/jfalcou/copacabana/archive/v7.tar.gz"
+    sha256: "c24436ebcdda92b87d02b28d4c6f9d5c20a58ac254725280d142e8d72e8c6412"

--- a/recipes/copacabana/all/conanfile.py
+++ b/recipes/copacabana/all/conanfile.py
@@ -1,0 +1,38 @@
+import os
+
+from conan import ConanFile
+from conan.tools.files import copy, get
+
+required_conan_version = ">=2.1"
+
+
+class CopacabanaConan(ConanFile):
+    name = "copacabana"
+    description = "CMake package tools for building, testing, documenting and packaging C++ libraries."
+    license = "BSL-1.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/jfalcou/copacabana"
+    topics = ("cmake", "build-system", "header-only")
+    package_type = "build-scripts"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    def package_id(self):
+        self.info.clear()
+
+    def source(self):
+        # Upstream tags this v7; conan needs at least two characters in a version.
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def package(self):
+        copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        copy(self, "*", os.path.join(self.source_folder, "copacabana"),
+             os.path.join(self.package_folder, "res", "copacabana"))
+
+    def package_info(self):
+        self.cpp_info.includedirs = []
+        self.cpp_info.libdirs = []
+        self.cpp_info.bindirs = []
+        # The tree is included by path at configure time, not found by find_package.
+        self.conf_info.define("user.copacabana:source",
+                              os.path.join(self.package_folder, "res"))

--- a/recipes/copacabana/all/test_package/CMakeLists.txt
+++ b/recipes/copacabana/all/test_package/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.22)
+project(test_package LANGUAGES CXX)
+
+# The package ships CMake scripts. CPM sets COPACABANA_SOURCE_DIR when it adds the package;
+# the test does the same by hand, then checks the tree defines what consumers call.
+set(COPACABANA_SOURCE_DIR "${COPACABANA_SOURCE}/res")
+include("${COPACABANA_SOURCE_DIR}/copacabana/cmake/copacabana.cmake")
+
+if(NOT COMMAND copa_setup_install)
+  message(FATAL_ERROR "copacabana.cmake did not define copa_setup_install")
+endif()
+
+add_executable(test_package test_package.cpp)

--- a/recipes/copacabana/all/test_package/conanfile.py
+++ b/recipes/copacabana/all/test_package/conanfile.py
@@ -1,0 +1,23 @@
+import os
+
+from conan import ConanFile
+from conan.tools.cmake import cmake_layout, CMake
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain"
+
+    def build_requirements(self):
+        self.tool_requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure(variables={"COPACABANA_SOURCE": self.dependencies.build["copacabana"].package_folder})
+        cmake.build()
+
+    def test(self):
+        pass

--- a/recipes/copacabana/all/test_package/test_package.cpp
+++ b/recipes/copacabana/all/test_package/test_package.cpp
@@ -1,0 +1,1 @@
+int main() { return 0; }

--- a/recipes/copacabana/config.yml
+++ b/recipes/copacabana/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "7.0":
+    folder: all


### PR DESCRIPTION
### Summary

Changes to recipe: **copacabana/7.0**

#### Motivation

copacabana is the set of CMake modules a family of C++ libraries share to build, test, document and package themselves (tts, kumi, spy, raberu, jfalcou-eve, kyosu). Packaging it lets those libraries be built from Conan without fetching it through CPM at configure time.

#### Details

A `build-scripts` package on the model of `extra-cmake-modules`: no headers, no libraries, the `copacabana/cmake` tree copied under `res/`, `package_id` cleared. It is meant as a `tool_requires`; the recipe exposes the path through `user.copacabana:source`, which a consumer hands to `COPACABANA_SOURCE_DIR`, and the `test_package` does exactly that. The upstream tag is `v7`; Conan versions need two characters, hence `7.0`.

---

- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with Conan 2 on Linux (`conan create` and the test package)