### PR TITLE
cpp-sort: publish versions 1.17.3, 2.2.0

### DIFF
--- a/recipes/cpp-sort/all/conandata.yml
+++ b/recipes/cpp-sort/all/conandata.yml
@@ -1,7 +1,13 @@
 sources:
+  "2.2.0":
+    url: "https://github.com/Morwenn/cpp-sort/archive/refs/tags/v2.2.0.tar.gz"
+    sha256: "c097a17c895fa684b92f6af45e8464e7179f0d73145826942add09daa5ca0c22"
   "2.0.0":
     url: "https://github.com/Morwenn/cpp-sort/archive/refs/tags/v2.0.0.tar.gz"
     sha256: "050c32d397c095b76b6f6583d4a49266b9965db51064c00b8bb0e8c4c4437037"
+  "1.17.3":
+    url: "https://github.com/Morwenn/cpp-sort/archive/1.17.3.tar.gz"
+    sha256: "a47a194b79c2f330a8f8d43cdbc5f6957acf593f191521280e3fad596152cd92"
   "1.17.0":
     url: "https://github.com/Morwenn/cpp-sort/archive/1.17.0.tar.gz"
     sha256: "df6cbb805ff71e1b0a30fc1ed55696a2d8c70c3ab87447bee2b749e02415432e"

--- a/recipes/cpp-sort/config.yml
+++ b/recipes/cpp-sort/config.yml
@@ -1,5 +1,9 @@
 versions:
+  "2.2.0":
+    folder: all
   "2.0.0":
+    folder: all
+  "1.17.3":
     folder: all
   "1.17.0":
     folder: all


### PR DESCRIPTION
### Summary

Changes to recipe:  add versions **cpp-sort/1.17.3** and **cpp-sort/2.2.0**

#### Motivation

I realized that I hadn't uploaded new versions on Conan Center in a while. I doubt it's useful to update intermediary versions, so the two I provide here are:
* v2.2.0: the latest version available
* 1.17.3: the lastest patch version of the 1.x.y branch (now in maintenance mode, all active development is on 2.x.y)

New features, bug fixes, speed improvements, better tooling, etc.

#### Details

The only changes are the addition of two versions, with no modification to the recipe.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] ~~If this is a bug fix, please link related issue or provide bug details~~ not a bug fix
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
