### PR TITLE
melon: add 1.0.0, remove 1.0.0-alpha.1

### DIFF
--- a/recipes/melon/all/conandata.yml
+++ b/recipes/melon/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "1.0.0-alpha.1":
-    url: "https://github.com/fhamonic/melon/archive/refs/tags/v1.0.0-alpha.1.tar.gz"
-    sha256: "370f6bb1fddc68f1ab771c8b659fed6d9dc8da51290897ed72fd87589143220c"
+  "1.0.0":
+    url: "https://github.com/fhamonic/melon/archive/refs/tags/v1.0.0.tar.gz"
+    sha256: "6a5ddd6cb039d8166e72640a611cf33ae63cfdc0ccc37369f89db7f5edc45039"

--- a/recipes/melon/all/conanfile.py
+++ b/recipes/melon/all/conanfile.py
@@ -1,45 +1,46 @@
+import os
+
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.files import copy, get
 from conan.tools.layout import basic_layout
 from conan.tools.scm import Version
-import os
+
+required_conan_version = ">=2.0"
 
 
-required_conan_version = ">=1.52.0"
-
-class PackageConan(ConanFile):
+class MelonConan(ConanFile):
     name = "melon"
-    description = "A modern and efficient graph library using C++20 ranges and concepts."
+    description = "Modern and Efficient Library for Optimization in Networks."
     license = "BSL-1.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/fhamonic/melon"
-    topics = ("graph", "algorithm", "ranges", "c++20", "header-only")
+    topics = ("graph", "header-only", "cpp23", "algorithms")
     package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 
     @property
     def _min_cppstd(self):
-        return 20
+        return 23
 
     @property
     def _compilers_minimum_version(self):
+        # The real constraint is the standard library, not the compiler (see
+        # upstream's include/melon/detail/stdlib_check.hpp): gcc 14 is the
+        # first release shipping libstdc++ 14, apple-clang 21 (Xcode 26.4)
+        # the first shipping libc++ 20; clang 18 (paired with libstdc++ >= 14)
+        # and msvc 194 are the oldest versions upstream CI tests.
         return {
-            "apple-clang": "14",
-            "clang": "17",
-            "gcc": "12",
-            "msvc": "192",
-            "Visual Studio": "17",
+            "gcc": "14",
+            "clang": "18",
+            "apple-clang": "21",
+            "msvc": "194",
         }
 
     def layout(self):
         basic_layout(self, src_folder="src")
-
-    def requirements(self):
-        self.requires("range-v3/0.12.0")
-        self.requires("fmt/10.2.1")
 
     def package_id(self):
         self.info.clear()
@@ -56,9 +57,6 @@ class PackageConan(ConanFile):
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
-    def build(self):
-        pass
-
     def package(self):
         copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
         copy(
@@ -66,11 +64,19 @@ class PackageConan(ConanFile):
             "*.hpp",
             os.path.join(self.source_folder, "include"),
             os.path.join(self.package_folder, "include"),
+            # melon/experimental/ ships, but two headers are still unfinished
+            excludes=(
+                "melon/experimental/scapegoat_tree.hpp",
+                "melon/experimental/doubly_connected_digraph.hpp",
+            ),
         )
 
     def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "melon")
+        self.cpp_info.set_property("cmake_target_name", "melon::melon")
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
 
+        # the knapsack_bnb headers use std::jthread and std::async
         if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.system_libs.extend(["pthread"])
+            self.cpp_info.system_libs.append("pthread")

--- a/recipes/melon/all/conanfile.py
+++ b/recipes/melon/all/conanfile.py
@@ -28,6 +28,9 @@ class MelonConan(ConanFile):
     def validate(self):
         check_min_cppstd(self, 23)
 
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.24]")
+
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 

--- a/recipes/melon/all/conanfile.py
+++ b/recipes/melon/all/conanfile.py
@@ -1,13 +1,11 @@
 import os
 
 from conan import ConanFile
-from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
-from conan.tools.files import copy, get
-from conan.tools.layout import basic_layout
-from conan.tools.scm import Version
+from conan.tools.files import copy, get, rmdir
+from conan.tools.cmake import cmake_layout, CMakeToolchain, CMake
 
-required_conan_version = ">=2.0"
+required_conan_version = ">=2.1"
 
 
 class MelonConan(ConanFile):
@@ -21,62 +19,36 @@ class MelonConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 
-    @property
-    def _min_cppstd(self):
-        return 23
-
-    @property
-    def _compilers_minimum_version(self):
-        # The real constraint is the standard library, not the compiler (see
-        # upstream's include/melon/detail/stdlib_check.hpp): gcc 14 is the
-        # first release shipping libstdc++ 14, apple-clang 21 (Xcode 26.4)
-        # the first shipping libc++ 20; clang 18 (paired with libstdc++ >= 14)
-        # and msvc 194 are the oldest versions upstream CI tests.
-        return {
-            "gcc": "14",
-            "clang": "18",
-            "apple-clang": "21",
-            "msvc": "194",
-        }
-
     def layout(self):
-        basic_layout(self, src_folder="src")
+        cmake_layout(self, src_folder="src")
 
     def package_id(self):
         self.info.clear()
 
     def validate(self):
-        if self.settings.compiler.get_safe("cppstd"):
-            check_min_cppstd(self, self._min_cppstd)
-        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
-        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
-            raise ConanInvalidConfiguration(
-                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
-            )
+        check_min_cppstd(self, 23)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.cache_variables["MELON_BUILD_TESTS"] = False
+        tc.generate()
+
+    def build(self):
+        pass
+
     def package(self):
         copy(self, "LICENSE", self.source_folder, os.path.join(self.package_folder, "licenses"))
-        copy(
-            self,
-            "*.hpp",
-            os.path.join(self.source_folder, "include"),
-            os.path.join(self.package_folder, "include"),
-            # melon/experimental/ ships, but two headers are still unfinished
-            excludes=(
-                "melon/experimental/scapegoat_tree.hpp",
-                "melon/experimental/doubly_connected_digraph.hpp",
-            ),
-        )
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
-        self.cpp_info.set_property("cmake_file_name", "melon")
-        self.cpp_info.set_property("cmake_target_name", "melon::melon")
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
 
-        # the knapsack_bnb headers use std::jthread and std::async
         if self.settings.os in ["Linux", "FreeBSD"]:
-            self.cpp_info.system_libs.append("pthread")
+            self.cpp_info.system_libs = ["pthread"]

--- a/recipes/melon/all/test_package/CMakeLists.txt
+++ b/recipes/melon/all/test_package/CMakeLists.txt
@@ -5,4 +5,4 @@ find_package(melon REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE melon::melon)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_23)

--- a/recipes/melon/all/test_package/CMakeLists.txt
+++ b/recipes/melon/all/test_package/CMakeLists.txt
@@ -5,4 +5,3 @@ find_package(melon REQUIRED CONFIG)
 
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE melon::melon)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_23)

--- a/recipes/melon/all/test_package/conanfile.py
+++ b/recipes/melon/all/test_package/conanfile.py
@@ -4,6 +4,7 @@ from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
+# It will become the standard on Conan 2.x
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"

--- a/recipes/melon/all/test_package/conanfile.py
+++ b/recipes/melon/all/test_package/conanfile.py
@@ -4,7 +4,6 @@ from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
-# It will become the standard on Conan 2.x
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"

--- a/recipes/melon/all/test_package/test_package.cpp
+++ b/recipes/melon/all/test_package/test_package.cpp
@@ -1,49 +1,13 @@
-#include <algorithm>
 #include <cstdlib>
-#include <ranges>
+#include <iostream>
 
-#include "melon/algorithm/bidirectional_dijkstra.hpp"
 #include "melon/container/static_digraph.hpp"
 #include "melon/utility/static_digraph_builder.hpp"
+#include "melon/version.hpp"
 
-using namespace melon;
 
-int main(int argc, char *argv[])
-{
-    static_digraph_builder<static_digraph, int> builder(6);
-
-    builder.add_arc({0u, 1u}, 7);  // 0
-    builder.add_arc({0u, 2u}, 9);  // 1
-    builder.add_arc({0u, 5u}, 14); // 2
-    builder.add_arc({1u, 0u}, 7);  // 3
-    builder.add_arc({1u, 2u}, 10); // 4
-    builder.add_arc({1u, 3u}, 15); // 5
-    builder.add_arc({2u, 0u}, 9);  // 6
-    builder.add_arc({2u, 1u}, 10); // 7
-    builder.add_arc({2u, 3u}, 12); // 8
-    builder.add_arc({2u, 5u}, 2);  // 9
-    builder.add_arc({3u, 1u}, 15); // 10
-    builder.add_arc({3u, 2u}, 12); // 11
-    builder.add_arc({3u, 4u}, 6);  // 12
-    builder.add_arc({4u, 3u}, 6);  // 13
-    builder.add_arc({4u, 5u}, 9);  // 14
-    builder.add_arc({5u, 0u}, 14); // 15
-    builder.add_arc({5u, 2u}, 2);  // 16
-    builder.add_arc({5u, 4u}, 9);  // 17
-
-    auto [graph, length_map] = builder.build();
-
-    bidirectional_dijkstra alg(graph, length_map, 0u, 3u);
-
-    // since v1.0.0, run() returns *this; the distance is queried with dist()
-    int dist = alg.run().dist();
-    if (dist != 21) return EXIT_FAILURE;
-
-    if (!alg.path_found()) return EXIT_FAILURE;
-    auto path = alg.path();
-    if (std::ranges::distance(path) != 2) return EXIT_FAILURE;
-    if (std::ranges::find(path, 1u) == path.end()) return EXIT_FAILURE;
-    if (std::ranges::find(path, 8u) == path.end()) return EXIT_FAILURE;
-
+int main(void) {
+    melon::static_digraph_builder<melon::static_digraph, int> builder(6);
+    std::cout << "Melon version: " << MELON_VERSION << std::endl;
     return EXIT_SUCCESS;
 }

--- a/recipes/melon/all/test_package/test_package.cpp
+++ b/recipes/melon/all/test_package/test_package.cpp
@@ -1,40 +1,42 @@
+#include <algorithm>
+#include <cstdlib>
+#include <ranges>
+
 #include "melon/algorithm/bidirectional_dijkstra.hpp"
-#include "melon/utility/static_digraph_builder.hpp"
 #include "melon/container/static_digraph.hpp"
+#include "melon/utility/static_digraph_builder.hpp"
 
-using namespace fhamonic::melon;
-
-// test_package with bidirectional dijkstra because it condenses range-v3 uses
-// shown to overwhelm some compilers
+using namespace melon;
 
 int main(int argc, char *argv[])
 {
     static_digraph_builder<static_digraph, int> builder(6);
 
-    builder.add_arc(0u, 1u, 7);  // 0
-    builder.add_arc(0u, 2u, 9);  // 1
-    builder.add_arc(0u, 5u, 14); // 2
-    builder.add_arc(1u, 0u, 7);  // 3
-    builder.add_arc(1u, 2u, 10); // 4
-    builder.add_arc(1u, 3u, 15); // 5
-    builder.add_arc(2u, 0u, 9);  // 6
-    builder.add_arc(2u, 1u, 10); // 7
-    builder.add_arc(2u, 3u, 12); // 8
-    builder.add_arc(2u, 5u, 2);  // 9
-    builder.add_arc(3u, 1u, 15); // 10
-    builder.add_arc(3u, 2u, 12); // 11
-    builder.add_arc(3u, 4u, 6);  // 12
-    builder.add_arc(4u, 3u, 6);  // 13
-    builder.add_arc(4u, 5u, 9);  // 14
-    builder.add_arc(5u, 0u, 14); // 15
-    builder.add_arc(5u, 2u, 2);  // 16
-    builder.add_arc(5u, 4u, 9);  // 17
+    builder.add_arc({0u, 1u}, 7);  // 0
+    builder.add_arc({0u, 2u}, 9);  // 1
+    builder.add_arc({0u, 5u}, 14); // 2
+    builder.add_arc({1u, 0u}, 7);  // 3
+    builder.add_arc({1u, 2u}, 10); // 4
+    builder.add_arc({1u, 3u}, 15); // 5
+    builder.add_arc({2u, 0u}, 9);  // 6
+    builder.add_arc({2u, 1u}, 10); // 7
+    builder.add_arc({2u, 3u}, 12); // 8
+    builder.add_arc({2u, 5u}, 2);  // 9
+    builder.add_arc({3u, 1u}, 15); // 10
+    builder.add_arc({3u, 2u}, 12); // 11
+    builder.add_arc({3u, 4u}, 6);  // 12
+    builder.add_arc({4u, 3u}, 6);  // 13
+    builder.add_arc({4u, 5u}, 9);  // 14
+    builder.add_arc({5u, 0u}, 14); // 15
+    builder.add_arc({5u, 2u}, 2);  // 16
+    builder.add_arc({5u, 4u}, 9);  // 17
 
     auto [graph, length_map] = builder.build();
 
     bidirectional_dijkstra alg(graph, length_map, 0u, 3u);
 
-    int dist = alg.run();
+    // since v1.0.0, run() returns *this; the distance is queried with dist()
+    int dist = alg.run().dist();
     if (dist != 21) return EXIT_FAILURE;
 
     if (!alg.path_found()) return EXIT_FAILURE;

--- a/recipes/melon/config.yml
+++ b/recipes/melon/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.0.0-alpha.1":
+  "1.0.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **melon/[1.0.0]**

#### Motivation
melon 1.0.0 is the first stable release of the library, superseding the two-year-old prerelease `1.0.0-alpha.1` (added in #25189). The prerelease is API-incompatible with the stable release and unmaintained upstream, so this PR adds `1.0.0` and removes `1.0.0-alpha.1`. As upstream author, I'm not aware of remaining consumers of the prerelease.

#### Details
- Adds `1.0.0`, removes `1.0.0-alpha.1` from `config.yml`/`conandata.yml`.
- 1.0.0 is dependency-free (previously required `range-v3` and `fmt`) and requires C++23: `validate()` checks cppstd 23 with compiler floors gcc 14, clang 18, apple-clang 21, msvc 194, all matching upstream CI.
- `pthread` added to `system_libs` on Linux/FreeBSD (the `knapsack_bnb` headers use `std::jthread`/`std::async`).
- Packaging matches upstream's own conanfile: two unfinished `melon/experimental/` headers excluded, CMake properties set to `melon`/`melon::melon` as installed by `melonConfig.cmake`.
- test_package updated for the 1.0.0 API (umbrella namespace removed, `add_arc({u, v}, w)`, `run().dist()`) and bumped to `cxx_std_23`.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
