### PR TITLE
gperf: do not remove compiler libcxx info from package id

### DIFF
--- a/recipes/gperf/all/conanfile.py
+++ b/recipes/gperf/all/conanfile.py
@@ -27,7 +27,10 @@ class GperfConan(ConanFile):
         self.folders.build = self.folders.source
 
     def package_id(self):
-        del self.info.settings.compiler
+        # only the compiler.libcxx setting is relevant,
+        # but we can't delete only the compiler name itself.
+        self.info.settings.rm_safe("compiler.version")
+        self.info.settings.rm_safe("compiler.cppstd")
 
     def build_requirements(self):
         if self.settings_build.os == "Windows":


### PR DESCRIPTION
### Summary
Changes to recipe:  **gperf/3.1**

#### Motivation

Fixes #30918 

#### Details

Do not remove `compiler.libcxx` info from the `package_id` as the executable will likely have a runtime dependency on the C++ library (unless it was statically linked, which would be untypical).

Note that, AFAIK, there is no way to just remove the compiler name (ie, `clang` or `gcc`) without removing all the compiler metadata. Ideally we would like to remove everything except the `compiler.libcxx` setting.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
