### PR TITLE
spy/3.0.0: add 3.0.0 and fix the declared license

### DIFF
--- a/recipes/spy/all/conandata.yml
+++ b/recipes/spy/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "3.0.0":
+    url: "https://github.com/jfalcou/spy/archive/3.0.0.tar.gz"
+    sha256: "2bdbb346515e1067b5215a412bfe9eb0babec2fb93ffd2d75f7a39a97c72e9ce"
   "1.1.0":
     url: "https://github.com/jfalcou/spy/archive/1.1.0.tar.gz"
     sha256: "35e15dfe7bebcb03fb28c249d2c2c4ed302dadafbfd5f81e71c31b95d1e3b2dd"

--- a/recipes/spy/all/conanfile.py
+++ b/recipes/spy/all/conanfile.py
@@ -3,6 +3,7 @@ from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.files import copy, get
 from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
 import os
 
 required_conan_version = ">=1.50.0"
@@ -10,8 +11,8 @@ required_conan_version = ">=1.50.0"
 
 class SpyConan(ConanFile):
     name = "spy"
-    description = "C++ 17 for constexpr-proof detection and classification of informations about OS, compiler, etc..."
-    license = "MIT"
+    description = "Constexpr-proof detection and classification of compilers, operating systems, architectures and SIMD extensions"
+    license = "BSL-1.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://jfalcou.github.io/spy/"
     topics = ("config", "metaprogramming", "header-only")
@@ -21,17 +22,26 @@ class SpyConan(ConanFile):
 
     @property
     def _min_cppstd(self):
-        return "17"
+        return "17" if Version(self.version) < "2.0.0" else "20"
 
     @property
     def _compilers_minimum_version(self):
         return {
-            "gcc": "7.4",
-            "Visual Studio": "15.7",
-            "msvc": "191",
-            "clang": "6",
-            "apple-clang": "10",
-        }
+            "17": {
+                "gcc": "7.4",
+                "Visual Studio": "15.7",
+                "msvc": "191",
+                "clang": "6",
+                "apple-clang": "10",
+            },
+            "20": {
+                "gcc": "11",
+                "Visual Studio": "16.11",
+                "msvc": "1929",
+                "clang": "13",
+                "apple-clang": "14",
+            },
+        }[self._min_cppstd]
 
     def package_id(self):
         self.info.clear()

--- a/recipes/spy/config.yml
+++ b/recipes/spy/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "3.0.0":
+    folder: all
   "1.1.0":
     folder: all
   "1.0.0":


### PR DESCRIPTION
### Summary
Changes to recipe: **spy/3.0.0**

#### Motivation
SPY 3.0.0 was released on 2026-09-06. It moved to C++20 with its 2.0.0, which the recipe has to
say, the versions it carries today asking for C++17.

#### Details
The version is added to `config.yml` and `conandata.yml`, and `_min_cppstd` becomes version
dependent, 17 below 2.0.0 and 20 from there on, with the minimum compiler table split accordingly.
The rest of the recipe is untouched: it already copied the headers without building anything.

The declared license goes from `MIT` to `BSL-1.0`, which is what upstream says in its `LICENSE.md`
and in the SPDX header of every source file, and the description no longer says C++17.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate
- [x] Tested locally with at least one configuration using a recent version of Conan
