### PR TITLE
(#new) tts/3.0: add recipe

### DIFF
--- a/recipes/tts/all/conandata.yml
+++ b/recipes/tts/all/conandata.yml
@@ -1,0 +1,8 @@
+sources:
+  "3.0":
+    url: "https://github.com/jfalcou/tts/archive/3.0.tar.gz"
+    sha256: "3954fb40a2d444bc935ecf2d439ed72d3c72eae9ec1b021fc99b469166bf57cd"
+  "cpm":
+    url: "https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.40.2/CPM.cmake"
+    sha256: "c8cdc32c03816538ce22781ed72964dc864b2a34a310d3b7104812a5ca2d835d"
+    filename: "CPM_0.40.2.cmake"

--- a/recipes/tts/all/conanfile.py
+++ b/recipes/tts/all/conanfile.py
@@ -2,66 +2,43 @@ import os
 
 from conan import ConanFile
 from conan.tools.build import check_min_cppstd
-from conan.tools.cmake import cmake_layout, CMake, CMakeToolchain
-from conan.tools.files import copy, download, get, rmdir
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
 
 required_conan_version = ">=2.1"
 
 
 class TTSConan(ConanFile):
     name = "tts"
-    description = "Tiny Test System, a C++20 unit test library for numerical code."
+    description = "Tiny Test System, a C++20 unit test framework"
     license = "BSL-1.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://jfalcou.github.io/tts/"
-    topics = ("tts", "unit-testing", "c++", "header-only")
+    topics = ("tts", "unit-test", "c++", "header-only")
     package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 
     def layout(self):
-        cmake_layout(self, src_folder="src")
+        basic_layout(self, src_folder="src")
 
     def package_id(self):
         self.info.clear()
-
-    def requirements(self):
-        self.tool_requires("copacabana/7.0")
 
     def validate(self):
         check_min_cppstd(self, 20)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
-        # This release downloads CPM at configure time; seeding the cache keeps the
-        # configure step off the network.
-        cpm = self.conan_data["sources"]["cpm"]
-        download(self, cpm["url"], os.path.join(self.source_folder, "cpm-cache", "cpm", cpm["filename"]),
-                 sha256=cpm["sha256"])
-
-    def generate(self):
-        tc = CMakeToolchain(self)
-        tc.cache_variables["CPM_SOURCE_CACHE"] = os.path.join(self.source_folder, "cpm-cache")
-        # The build is written with copacabana, which CPM fetches at configure time; the
-        # package installed here is handed to CPM instead.
-        tc.cache_variables["CPM_COPACABANA_SOURCE"] = os.path.join(
-            self.dependencies.build["copacabana"].package_folder, "res")
-        tc.cache_variables["CPM_LOCAL_PACKAGES_ONLY"] = True
-        tc.cache_variables["TTS_BUILD_TEST"] = False
-        tc.cache_variables["TTS_BUILD_DOCUMENTATION"] = False
-        tc.generate()
-
-    def build(self):
-        cmake = CMake(self)
-        cmake.configure()
 
     def package(self):
         copy(self, "LICENSE.md", self.source_folder, os.path.join(self.package_folder, "licenses"))
-        cmake = CMake(self)
-        cmake.install()
-        rmdir(self, os.path.join(self.package_folder, "lib"))
-        rmdir(self, os.path.join(self.package_folder, "share"))
+        copy(self, "*.hpp",
+             os.path.join(self.source_folder, "include"),
+             os.path.join(self.package_folder, "include"))
 
     def package_info(self):
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
+        self.cpp_info.set_property("cmake_file_name", "tts")
+        self.cpp_info.set_property("cmake_target_name", "tts::tts")

--- a/recipes/tts/all/conanfile.py
+++ b/recipes/tts/all/conanfile.py
@@ -1,0 +1,67 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import cmake_layout, CMake, CMakeToolchain
+from conan.tools.files import copy, download, get, rmdir
+
+required_conan_version = ">=2.1"
+
+
+class TTSConan(ConanFile):
+    name = "tts"
+    description = "Tiny Test System, a C++20 unit test library for numerical code."
+    license = "BSL-1.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://jfalcou.github.io/tts/"
+    topics = ("tts", "unit-testing", "c++", "header-only")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def requirements(self):
+        self.tool_requires("copacabana/7.0")
+
+    def validate(self):
+        check_min_cppstd(self, 20)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        # This release downloads CPM at configure time; seeding the cache keeps the
+        # configure step off the network.
+        cpm = self.conan_data["sources"]["cpm"]
+        download(self, cpm["url"], os.path.join(self.source_folder, "cpm-cache", "cpm", cpm["filename"]),
+                 sha256=cpm["sha256"])
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.cache_variables["CPM_SOURCE_CACHE"] = os.path.join(self.source_folder, "cpm-cache")
+        # The build is written with copacabana, which CPM fetches at configure time; the
+        # package installed here is handed to CPM instead.
+        tc.cache_variables["CPM_COPACABANA_SOURCE"] = os.path.join(
+            self.dependencies.build["copacabana"].package_folder, "res")
+        tc.cache_variables["CPM_LOCAL_PACKAGES_ONLY"] = True
+        tc.cache_variables["TTS_BUILD_TEST"] = False
+        tc.cache_variables["TTS_BUILD_DOCUMENTATION"] = False
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+
+    def package(self):
+        copy(self, "LICENSE.md", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/tts/all/test_package/CMakeLists.txt
+++ b/recipes/tts/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.22)
+project(test_package LANGUAGES CXX)
+
+find_package(tts REQUIRED CONFIG)
+
+add_executable(test_package test_package.cpp)
+target_link_libraries(test_package PRIVATE tts::tts)
+target_compile_features(test_package PRIVATE cxx_std_20)

--- a/recipes/tts/all/test_package/conanfile.py
+++ b/recipes/tts/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            self.run(os.path.join(self.cpp.build.bindir, "test_package"), env="conanrun")

--- a/recipes/tts/all/test_package/test_package.cpp
+++ b/recipes/tts/all/test_package/test_package.cpp
@@ -1,0 +1,4 @@
+#define TTS_MAIN
+#include <tts/tts.hpp>
+
+TTS_CASE("the package is usable") { TTS_EQUAL(1 + 1, 2); };

--- a/recipes/tts/config.yml
+++ b/recipes/tts/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "3.0":
+    folder: all


### PR DESCRIPTION
### Summary
Changes to recipe: **tts/3.0** (#new)

#### Motivation
TTS is the unit test framework the jfalcou libraries are written against, and it has no recipe in
the index. A recipe for `tts/0.1` was proposed in 2021 and closed; this is the current library.

#### Details
Header-only, so the recipe copies `include/` and declares the target, with no build step and no
dependency. C++20 is required, which `check_min_cppstd` states.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate
- [x] Tested locally with at least one configuration using a recent version of Conan
