### PR TITLE
(#new) kumi/4.0: add recipe

### DIFF
--- a/recipes/kumi/all/conandata.yml
+++ b/recipes/kumi/all/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "5.0":
+    url: "https://github.com/jfalcou/kumi/archive/v5.0.tar.gz"
+    sha256: "175569a39837988b6349f2bc7b7bab757c09d29e9503e20e188c9afa1c88e474"
   "4.0":
     url: "https://github.com/jfalcou/kumi/archive/v4.0.tar.gz"
     sha256: "f788ee60b814a07d2b2148dd86b5153261b582ac5a248905cbf3e19423a0f7cd"

--- a/recipes/kumi/all/conandata.yml
+++ b/recipes/kumi/all/conandata.yml
@@ -1,0 +1,8 @@
+sources:
+  "4.0":
+    url: "https://github.com/jfalcou/kumi/archive/v4.0.tar.gz"
+    sha256: "f788ee60b814a07d2b2148dd86b5153261b582ac5a248905cbf3e19423a0f7cd"
+  "cpm":
+    url: "https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.40.8/CPM.cmake"
+    sha256: "78ba32abdf798bc616bab7c73aac32a17bbd7b06ad9e26a6add69de8f3ae4791"
+    filename: "CPM_0.40.8.cmake"

--- a/recipes/kumi/all/conanfile.py
+++ b/recipes/kumi/all/conanfile.py
@@ -2,15 +2,15 @@ import os
 
 from conan import ConanFile
 from conan.tools.build import check_min_cppstd
-from conan.tools.cmake import cmake_layout, CMake, CMakeToolchain
-from conan.tools.files import copy, download, get, rmdir
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
 
 required_conan_version = ">=2.1"
 
 
-class KUMIConan(ConanFile):
+class KumiConan(ConanFile):
     name = "kumi"
-    description = "C++20 tuple and tuple-based algorithms library."
+    description = "A C++20 compact tuple implementation"
     license = "BSL-1.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://jfalcou.github.io/kumi/"
@@ -20,48 +20,25 @@ class KUMIConan(ConanFile):
     no_copy_source = True
 
     def layout(self):
-        cmake_layout(self, src_folder="src")
+        basic_layout(self, src_folder="src")
 
     def package_id(self):
         self.info.clear()
-
-    def requirements(self):
-        self.tool_requires("copacabana/7.0")
 
     def validate(self):
         check_min_cppstd(self, 20)
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
-        # This release downloads CPM at configure time; seeding the cache keeps the
-        # configure step off the network.
-        cpm = self.conan_data["sources"]["cpm"]
-        download(self, cpm["url"], os.path.join(self.source_folder, "cpm-cache", "cpm", cpm["filename"]),
-                 sha256=cpm["sha256"])
-
-    def generate(self):
-        tc = CMakeToolchain(self)
-        tc.cache_variables["CPM_SOURCE_CACHE"] = os.path.join(self.source_folder, "cpm-cache")
-        # The build is written with copacabana, which CPM fetches at configure time; the
-        # package installed here is handed to CPM instead.
-        tc.cache_variables["CPM_COPACABANA_SOURCE"] = os.path.join(
-            self.dependencies.build["copacabana"].package_folder, "res")
-        tc.cache_variables["CPM_LOCAL_PACKAGES_ONLY"] = True
-        tc.cache_variables["KUMI_BUILD_TEST"] = False
-        tc.cache_variables["KUMI_BUILD_DOCUMENTATION"] = False
-        tc.generate()
-
-    def build(self):
-        cmake = CMake(self)
-        cmake.configure()
 
     def package(self):
         copy(self, "LICENSE.md", self.source_folder, os.path.join(self.package_folder, "licenses"))
-        cmake = CMake(self)
-        cmake.install()
-        rmdir(self, os.path.join(self.package_folder, "lib"))
-        rmdir(self, os.path.join(self.package_folder, "share"))
+        copy(self, "*.hpp",
+             os.path.join(self.source_folder, "include"),
+             os.path.join(self.package_folder, "include"))
 
     def package_info(self):
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
+        self.cpp_info.set_property("cmake_file_name", "kumi")
+        self.cpp_info.set_property("cmake_target_name", "kumi::kumi")

--- a/recipes/kumi/all/conanfile.py
+++ b/recipes/kumi/all/conanfile.py
@@ -1,0 +1,67 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import cmake_layout, CMake, CMakeToolchain
+from conan.tools.files import copy, download, get, rmdir
+
+required_conan_version = ">=2.1"
+
+
+class KUMIConan(ConanFile):
+    name = "kumi"
+    description = "C++20 tuple and tuple-based algorithms library."
+    license = "BSL-1.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://jfalcou.github.io/kumi/"
+    topics = ("kumi", "tuple", "c++", "header-only")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
+    def package_id(self):
+        self.info.clear()
+
+    def requirements(self):
+        self.tool_requires("copacabana/7.0")
+
+    def validate(self):
+        check_min_cppstd(self, 20)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+        # This release downloads CPM at configure time; seeding the cache keeps the
+        # configure step off the network.
+        cpm = self.conan_data["sources"]["cpm"]
+        download(self, cpm["url"], os.path.join(self.source_folder, "cpm-cache", "cpm", cpm["filename"]),
+                 sha256=cpm["sha256"])
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.cache_variables["CPM_SOURCE_CACHE"] = os.path.join(self.source_folder, "cpm-cache")
+        # The build is written with copacabana, which CPM fetches at configure time; the
+        # package installed here is handed to CPM instead.
+        tc.cache_variables["CPM_COPACABANA_SOURCE"] = os.path.join(
+            self.dependencies.build["copacabana"].package_folder, "res")
+        tc.cache_variables["CPM_LOCAL_PACKAGES_ONLY"] = True
+        tc.cache_variables["KUMI_BUILD_TEST"] = False
+        tc.cache_variables["KUMI_BUILD_DOCUMENTATION"] = False
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+
+    def package(self):
+        copy(self, "LICENSE.md", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib"))
+        rmdir(self, os.path.join(self.package_folder, "share"))
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/recipes/kumi/all/test_package/CMakeLists.txt
+++ b/recipes/kumi/all/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.22)
+project(test_package LANGUAGES CXX)
+
+find_package(kumi REQUIRED CONFIG)
+
+add_executable(test_package test_package.cpp)
+target_link_libraries(test_package PRIVATE kumi::kumi)
+target_compile_features(test_package PRIVATE cxx_std_20)

--- a/recipes/kumi/all/test_package/conanfile.py
+++ b/recipes/kumi/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            self.run(os.path.join(self.cpp.build.bindir, "test_package"), env="conanrun")

--- a/recipes/kumi/all/test_package/test_package.cpp
+++ b/recipes/kumi/all/test_package/test_package.cpp
@@ -1,0 +1,10 @@
+#include <kumi/tuple.hpp>
+
+#include <cassert>
+
+int main()
+{
+  auto t = kumi::make_tuple(1, 2.5, 'x');
+  assert(kumi::size_v<decltype(t)> == 3);
+  return 0;
+}

--- a/recipes/kumi/config.yml
+++ b/recipes/kumi/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "4.0":
+    folder: all

--- a/recipes/kumi/config.yml
+++ b/recipes/kumi/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "5.0":
+    folder: all
   "4.0":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe: **kumi/4.0** (#new)

#### Motivation
KUMI is a compact tuple implementation with an algorithm set over tuples, used by several C++20
libraries, and it has no recipe in the index.

#### Details
Header-only, so the recipe copies `include/` and declares the target, with no build step and no
dependency. C++20 is required, which `check_min_cppstd` states.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate
- [x] Tested locally with at least one configuration using a recent version of Conan
