### PR TITLE
glslang: change max cmake version to <5 instead of <4

### DIFF
--- a/recipes/glslang/all/conanfile.py
+++ b/recipes/glslang/all/conanfile.py
@@ -79,7 +79,7 @@ class GlslangConan(ConanFile):
 
     def build_requirements(self):
         if Version(self.version) >= "1.3.261":
-            self.tool_requires("cmake/[>=3.17.2 <4]")
+            self.tool_requires("cmake/[>=3.17.2 <5]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)

--- a/recipes/glslang/all/conanfile.py
+++ b/recipes/glslang/all/conanfile.py
@@ -79,7 +79,7 @@ class GlslangConan(ConanFile):
 
     def build_requirements(self):
         if Version(self.version) >= "1.3.261":
-            self.tool_requires("cmake/[>=3.17.2 <5]")
+            self.tool_requires("cmake/[>=3.17.2]")
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)


### PR DESCRIPTION
### Summary
changed max cmake version from 4-5

#### Motivation
It is a bug fix, wich was clamping the maximum cmake version to <4 in build_requirements

#### Details
- spirv-reflect is also affected #30930 
- spirv-tools is also affected #30929 
---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
