### PR TITLE
spirv-reflect: change max cmake version to <5 instead of <4

### DIFF
--- a/recipes/spirv-reflect/all/conanfile.py
+++ b/recipes/spirv-reflect/all/conanfile.py
@@ -45,7 +45,7 @@ class SpirvReflectConan(ConanFile):
         tc.generate()
 
     def build_requirements(self):
-        self.tool_requires("cmake/[>=3.24 <4]")
+        self.tool_requires("cmake/[>=3.24 <5]")
 
     def build(self):
         cmake = CMake(self)

--- a/recipes/spirv-reflect/all/conanfile.py
+++ b/recipes/spirv-reflect/all/conanfile.py
@@ -45,7 +45,7 @@ class SpirvReflectConan(ConanFile):
         tc.generate()
 
     def build_requirements(self):
-        self.tool_requires("cmake/[>=3.24 <5]")
+        self.tool_requires("cmake/[>=3.24]")
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
### Summary
changed max cmake version from 4-5

#### Motivation
It is a bug fix, wich was clamping the maximum cmake version to <4 in build_requirements

#### Details
- glslang is also affected #30928 
- spirv-tools is also affected #30929
---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!