### PR TITLE
opentelemetry-cpp: Fix validation without protobuf exporters

### DIFF
--- a/recipes/opentelemetry-cpp/all/conanfile.py
+++ b/recipes/opentelemetry-cpp/all/conanfile.py
@@ -127,7 +127,7 @@ class OpenTelemetryCppConan(ConanFile):
             if not self.dependencies["grpc"].options.cpp_plugin:
                 raise ConanInvalidConfiguration(f"{self.ref} requires grpc with cpp_plugin=True")
 
-        if self.dependencies["protobuf"].package_type == "static-library" and self.package_type != "static-library":
+        if self._needs_proto and self.dependencies["protobuf"].package_type == "static-library" and self.package_type != "static-library":
             # https://github.com/open-telemetry/opentelemetry-cpp/blame/2d80af1b1d26e300d9c0f7f51fa360f22c773523/cmake/opentelemetry-proto.cmake#L189-L193
             raise ConanInvalidConfiguration(f"opentelemetry-cpp should be built as a static library when using static protobuf")
 


### PR DESCRIPTION
### Summary
Changes to recipe:  **opentelemetry-cpp/1.26.0**, **opentelemetry-cpp/1.24.0**,, **opentelemetry-cpp/1.22.0**, **opentelemetry-cpp/1.21.0**

#### Motivation
When adding the opentelemetry-cpp using the following combination of options in combination with the settings below:
        self.options["opentelemetry-cpp"].shared = False
        self.options["opentelemetry-cpp"].with_otlp_grpc = False
        self.options["opentelemetry-cpp"].with_otlp_http = False
        self.options["opentelemetry-cpp"].with_zipkin = False
        self.options["opentelemetry-cpp"].with_elasticsearch = False
        self.options["opentelemetry-cpp"].with_prometheus = True
        self.options["opentelemetry-cpp"].with_stl = True

[settings]
[cmake] arch=x86_64
[cmake] build_type=Release
[cmake] compiler=gcc
[cmake] compiler.cppstd=23
[cmake] compiler.libcxx=libstdc++11
[cmake] compiler.version=15
[cmake] os=Linux

Conan will fail to validate the recipe.


#### Details
- Protobuf is omitted when gRPC, HTTP, and file OTLP exporters are disabled.
- validate() nevertheless accessed the missing protobuf dependency.
- Guarding the static-protobuf check with _needs_proto aligns validation with requirements().

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
