### PR TITLE
[Coal] Add version 3.0.4

### DIFF
--- a/recipes/coal/all/conandata.yml
+++ b/recipes/coal/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "3.0.2":
-    url: "https://github.com/coal-library/coal/releases/download/v3.0.2/coal-3.0.2.tar.gz"
-    sha256: "899eb343ee7d86ae6312401bc969d1d2cb8103a5a67af5e1f06061a9c5fb0743"
+  "3.0.4":
+    url: "https://github.com/coal-library/coal/releases/download/v3.0.4/coal-3.0.4.tar.gz"
+    sha256: "0a9091aa281f51b9513f11aae39758a6188bca63010524f36b3bdc566381ca4a"

--- a/recipes/coal/all/conanfile.py
+++ b/recipes/coal/all/conanfile.py
@@ -28,9 +28,9 @@ class CoalConan(ConanFile):
         cmake_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("eigen/[>=3.4.0 <4]", transitive_headers=True)
-        self.requires("boost/1.88.0", transitive_headers=True)
-        self.requires("assimp/5.4.3")
+        self.requires("eigen/[>=5 <6]", transitive_headers=True)
+        self.requires("boost/1.91.0", transitive_headers=True)
+        self.requires("assimp/6.0.5")
         if self.options.with_octomap:
             self.requires("octomap/1.10.0", transitive_headers=True)
         if self.options.with_qhull:

--- a/recipes/coal/config.yml
+++ b/recipes/coal/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "3.0.2":
+  "3.0.4":
     folder: all


### PR DESCRIPTION
### Summary
Changes to recipe:  **coal/3.0.4**

#### Motivation
We would like to use coal but have some issues because the provided version ranges prevents us from using it with eigen 5.0.1 and boost 1.91.0. As there is also a newer version available, I thought this is a good chance to extend the ranges.

#### Details
Add new coal version and pin dependencies to newer versions.

I now excluded the old eigen versions - would it make sense to keep them in there?


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
