### PR TITLE
g1fitting: add recipe

### DIFF
--- a/recipes/g1fitting/all/conandata.yml
+++ b/recipes/g1fitting/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.0.0.cci.20260324":
+    url: "https://github.com/ebertolazzi/G1fitting/archive/60fe94389a6d5ca6e858f1d267bdc385b5c70c55.tar.gz"
+    sha256: "2d36aa6560f46b48c1db1b07f7d817b3fe71ba140ffcf50780b608483c38301e"

--- a/recipes/g1fitting/all/conanfile.py
+++ b/recipes/g1fitting/all/conanfile.py
@@ -1,0 +1,55 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import collect_libs, copy, get
+import os
+
+required_conan_version = ">=2"
+
+class G1fittingConan(ConanFile):
+    name = "g1fitting"
+    description = "G1 fitting with clothoids"
+    license = "BSD-2-Clause"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/ebertolazzi/G1fitting"
+    topics = ("clothoids", "g1fitting")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+    }
+    implements = ["auto_shared_fpic"]
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version],
+            destination=self.source_folder, strip_root=True)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generate()
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "licence.txt", self.source_folder, os.path.join(self.package_folder, "licenses"))
+        copy(self, "*.hh", os.path.join(self.source_folder, "src"), os.path.join(self.package_folder, "include"), keep_path=False)
+        copy(self, "*.a", self.build_folder, os.path.join(self.package_folder, "lib"), keep_path=False)
+        copy(self, "*.lib", self.build_folder, os.path.join(self.package_folder, "lib"), keep_path=False)
+        copy(self, "*.so", self.build_folder, os.path.join(self.package_folder, "lib"), keep_path=False)
+        copy(self, "*.dylib", self.build_folder, os.path.join(self.package_folder, "lib"), keep_path=False)
+        copy(self, "*.dll", self.build_folder, os.path.join(self.package_folder, "bin"), keep_path=False)
+
+    def package_info(self):
+        # Conan automatically sets libdirs=["lib"] and includedirs=["include"] by default
+        # and infers other traits based on package_type
+        self.cpp_info.libs = collect_libs(self)    

--- a/recipes/g1fitting/all/test_package/CMakeLists.txt
+++ b/recipes/g1fitting/all/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.15)
+project(PackageTest CXX)
+
+# include(CMakePackageConfigHelpers)
+
+find_package(g1fitting CONFIG REQUIRED)
+
+add_executable(test_g1fitting main.cpp)
+target_link_libraries(test_g1fitting g1fitting::g1fitting)

--- a/recipes/g1fitting/all/test_package/conanfile.py
+++ b/recipes/g1fitting/all/test_package/conanfile.py
@@ -1,0 +1,26 @@
+import os
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import can_run
+
+
+class g1fittingTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def layout(self):
+        cmake_layout(self)
+
+    def test(self):
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindir, "test_g1fitting")
+            self.run(cmd, env="conanrun")

--- a/recipes/g1fitting/all/test_package/main.cpp
+++ b/recipes/g1fitting/all/test_package/main.cpp
@@ -1,0 +1,28 @@
+#include <iostream>
+#include <vector>
+
+#include "Clothoid.hh"
+
+Clothoid::valueType test_pi = 3.14159265358979323846264338328;
+
+int main() {
+    Clothoid::ClothoidCurve c1(0,0,test_pi*0.7,-0.1,0.05,20) ;
+    Clothoid::ClothoidCurve c2(-10,0,test_pi/4,0.1,-0.05,20) ;
+    std::vector<Clothoid::valueType> s1, s2 ;
+    Clothoid::indexType max_iter  = 10 ;
+    Clothoid::valueType tolerance = 1e-8 ;
+    try {
+        c1.intersect( 0, c2, 0, s1, s2, max_iter, tolerance ) ;
+        std::cout << "ok = TRUE" << std::endl ;
+    }
+    catch (...) {
+        std::cout  << "ok = FALSE\n" ;
+    }
+    for ( long unsigned int i = 0 ; i < s1.size() ; ++i ) {
+        std::cout << "S1[" << i << "] = " << s1[i] << std::endl ;
+    }
+    for ( long unsigned int i = 0 ; i < s2.size() ; ++i ) {
+        std::cout << "S2[" << i << "] = " << s2[i] << std::endl ;
+    }
+    return 0 ;
+}

--- a/recipes/g1fitting/config.yml
+++ b/recipes/g1fitting/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.0.0.cci.20260324":
+    folder: all


### PR DESCRIPTION
### Summary
Add recipe for **g1fitting/0.0.0.cci.20260324**

#### Motivation
I want to consume g1fitting using Conan. g1fitting does not have an existing recipe but has a publicly available GitHub repository. The publicly available GitHub repository does not have official releases or tags so I followed the guidelines for creating a CCI-only version number.

#### Details
Adds a recipe for g1fitting.


---
- [X] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [X] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [X] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
