### PR TITLE
libvpx: unset ASFLAGS from environment for Intel platforms

### DIFF
--- a/recipes/libvpx/all/conanfile.py
+++ b/recipes/libvpx/all/conanfile.py
@@ -188,6 +188,10 @@ class LibVPXConan(ConanFile):
             env.define("CC", "")
         else:
             env = tc.environment()
+
+        if is_apple_os(self) and self.settings.arch in ['x86', 'x86_64']:
+            env.define("ASFLAGS", "")
+
         tc.generate(env)
 
     def _patch_sources(self):


### PR DESCRIPTION
### Summary
Changes to recipe:  **libvpx/***

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->
Close: https://github.com/conan-io/conan-center-index/issues/30865

#### Details

Related to the changes introduces by the Conan client: https://github.com/conan-io/conan/pull/20078/changes


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
