### PR TITLE
[diligent-core] Bump dependencies to keep using maintained versions

### DIFF
--- a/recipes/diligent-core/all/conan_deps.cmake
+++ b/recipes/diligent-core/all/conan_deps.cmake
@@ -11,5 +11,7 @@ if (NOT ${DILIGENT_NO_GLSLANG})
     add_library(SPIRV ALIAS glslang::SPIRV)
 endif()
 
-add_library(SPIRV-Headers ALIAS SPIRV-Headers::SPIRV-Headers)
+if(TARGET SPIRV-Headers::SPIRV-Headers AND NOT TARGET SPIRV-Headers)
+    add_library(SPIRV-Headers ALIAS SPIRV-Headers::SPIRV-Headers)
+endif()
 add_library(spirv-tools-core   ALIAS spirv-tools::spirv-tools)

--- a/recipes/diligent-core/all/conanfile.py
+++ b/recipes/diligent-core/all/conanfile.py
@@ -113,22 +113,23 @@ class DiligentCoreConan(ConanFile):
 
     def requirements(self):
         self.requires("opengl/system")
-        if self.settings.os == "Linux":
-            self.requires("wayland/1.22.0")
 
-        self.requires("spirv-cross/1.3.224.0")
-        self.requires("spirv-tools/1.3.224.0")
+        spirv_version = "1.4.350.0"
+        self.requires(f"spirv-cross/{spirv_version}")
+        self.requires(f"spirv-tools/{spirv_version}")
         if self.options.with_glslang:
-            self.requires("glslang/1.3.224.0")
-        self.requires("vulkan-headers/1.3.224.0")
-        self.requires("vulkan-validationlayers/1.3.224.1")
-        self.requires("volk/1.3.224.0")
-        self.requires("xxhash/0.8.1")
+            self.requires(f"glslang/{spirv_version}")
+        self.requires(f"vulkan-headers/{spirv_version}")
+        self.requires(f"vulkan-validationlayers/{spirv_version}")
+        self.requires(f"volk/{spirv_version}")
+        self.requires("xxhash/0.8.3")
+        if self.settings.os == "Linux":
+            self.requires("wayland/[>=1.22.0 <2]")
 
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.requires("xorg/system")
             if not cross_building(self, skip_x64_x86=True):
-                self.requires("xkbcommon/1.4.1")
+                self.requires("xkbcommon/1.13.1")
 
     def _diligent_platform(self):
         if self.settings.os == "Windows":


### PR DESCRIPTION
### Summary
Changes to recipe:  **diligent-core/api.252009**

#### Motivation

Recent changes regarding `glslang` and `spirv` resulted in a scenario where non-maintained versions are consumed by diligent-core.

This PR updates its dependencies to keep them all aligned and to consume those versions that are maintained. 


#### Details

Version `1.4.350.0` is the latest and supported/maintained by all these dependencies. Previous version `1.3.224.0` is no longer maintained (e.g. https://github.com/conan-io/conan-center-index/blob/master/recipes/spirv-cross/all/conandata.yml).

I also moved Wayland to be solved later, so avoid having conflicts due vulkan-validationlayers asking an older wayland version (1.22.0)


---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
