### PR TITLE
flatbush: add release v1.5.0

### DIFF
--- a/recipes/flatbush/all/conandata.yml
+++ b/recipes/flatbush/all/conandata.yml
@@ -1,4 +1,4 @@
 sources:
-  "1.4.1":
-    url: "https://github.com/chusitoo/flatbush/archive/refs/tags/v1.4.1.zip"
-    sha256: "1d531c49700d11bdc4941d6e8e997ce8e309f24abe849ae294e8aee563c25a47"
+  "1.5.0":
+    url: "https://github.com/chusitoo/flatbush/archive/refs/tags/v1.5.0.zip"
+    sha256: "14a047eae61e6bfd14c74dc9b23b529cf27f9fe1a9c4a16ad6ca44faa42e136a"

--- a/recipes/flatbush/config.yml
+++ b/recipes/flatbush/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.4.1":
+  "1.5.0":
     folder: "all"


### PR DESCRIPTION
### Summary
Changes to recipe:  **flatbush/1.5.0**

#### Motivation
Performance improvements, align with baseline codebase in JS

#### Details
- Added custom neighbor distance metrics.
- Added zero-copy index views with fromView().
- Added Point<T> insertion and JavaScript Uint8ClampedArray compatibility.
- Improved construction and query performance through packed builds, radix sorting, prefetching, and faster subtree traversal.
- One-million-item construction improved from 85 to 55 ms with Clang and 86 to 59 ms with GCC.
- Improved numerical robustness for extreme bounds and distance calculations.
- Hardened deserialization against malformed, oversized, and internally corrupt indexes.
- Fixed C++20 std::span, exception propagation, unbounded neighbor searches, and multi-translation-unit usage.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] If this is a bug fix, please link related issue or provide bug details
- [x] Tested locally with at least one configuration using a recent version of Conan

---
Add a :+1: reaction to pull requests you find [important](https://github.com/conan-io/conan-center-index/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc) to help the team prioritize, thanks!
